### PR TITLE
Bump version to 1.2.3

### DIFF
--- a/packages/ui-common/package.json
+++ b/packages/ui-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cognizant-ai-lab/ui-common",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "type": "module",
     "scripts": {
         "build": "yarn clean && yarn generate && tsc --project tsconfig.build.json && fix-esm-import-path dist > /dev/null",


### PR DESCRIPTION
Prepare for release 1.2.3, mainly to provide fix for UN-3545, which we need before releasing latest neuro-ai.