### PR TITLE
Bump ui-common to 1.2.4

### DIFF
--- a/packages/ui-common/package.json
+++ b/packages/ui-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cognizant-ai-lab/ui-common",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "type": "module",
     "scripts": {
         "build": "yarn clean && yarn generate && tsc --project tsconfig.build.json && fix-esm-import-path dist > /dev/null",


### PR DESCRIPTION
The 1.2.3 release process did not work as expected. This PR just bumps the version number again for a release-redo.