### PR TITLE
Remove defaults for some ECR vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ on:
 env:
     # AWS info needed to push the image to ECR
     AWS_REGION: ${{ vars.AWS_REGION || 'us-west-2' }}
-    ECR_REGISTRY: ${{ vars.ECR_REGISTRY || '123456789012.dkr.ecr.us-east-1.amazonaws.com' }}
-    ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY || 'neuro-san/neuro-san-ui' }}
+    ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+    ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
     # and the Node.js version which is a repo-level variable
     NODEJS_VERSION: ${{ vars.NODEJS_VERSION }}
 


### PR DESCRIPTION
This is just a little papercut PR, more than anything I need a quick win to get something done. As we know, there's copy/pasta so there's a duplicate PR in neuro-ui repo as well. 

I think it's better to rely on the repo's set values for this ECR info and just not provide defaults. 