### PR TITLE
Adding Opensource information files.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -47,18 +47,22 @@ All community leaders are obligated to respect the privacy and security of the r
 Community leaders will follow these guidelines in determining the consequences for any action they deem to violate this Code of Conduct:
 
 ### 1. Correction
+
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome.  
 **Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
+
 **Community Impact**: A violation through a single incident or series of actions.  
 **Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time.
 
 ### 3. Temporary Ban
+
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.  
 **Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time.
 
 ### 4. Permanent Ban
+
 **Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.  
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Thank you for your interest in contributing to this project!
 ## Reporting Bugs
 
 Open an issue with:
+
 - Clear description of the bug
 - Steps to reproduce
 - Expected vs actual behavior
@@ -30,6 +31,7 @@ Open an issue with:
 ## Suggesting Features
 
 Open an issue describing:
+
 - The problem you're trying to solve
 - Your proposed solution
 - Any alternatives you've considered

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,10 +21,10 @@ If you discover a security vulnerability, please report it by emailing labgithub
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| Latest  | :white_check_mark: |
-| < Latest| :x:                |
+| Version  | Supported          |
+| -------- | ------------------ |
+| Latest   | :white_check_mark: |
+| < Latest | :x:                |
 
 We recommend always using the latest version of this project.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,6 +15,7 @@ Search [existing issues](../../issues) to see if your question has already been 
 ### Ask a Question
 
 If you can't find an answer, open a new issue with:
+
 - A clear description of your problem
 - What you've already tried
 - Relevant code snippets or error messages
@@ -35,4 +36,3 @@ Commercial support is not currently available for this project.
 ---
 
 Thank you for using this project!
-


### PR DESCRIPTION
Before we can make the repository public, the GitHub admins require us to add these four information files to it.