### PR TITLE
#90 Implement sample queries in MAUI

### DIFF
--- a/jest_unit.config.ts
+++ b/jest_unit.config.ts
@@ -28,7 +28,7 @@ const config: Config.InitialOptions = {
     coverageThreshold: {
         global: {
             statements: -75,
-            branches: -125,
+            branches: -124,
             functions: -19,
             lines: -58,
         },


### PR DESCRIPTION
Uses the `sample_queries` metadata to offer the user clickable chips with sample queries, to aid new users and speed up demos.

Truncates excessively long queries with ellipsis; hover tip shows full query.

Displays on the first 5 sample queries to avoid using too much space.

<img width="1573" height="775" alt="image" src="https://github.com/user-attachments/assets/84b3d59a-f3ac-419d-b22b-da1ff9118f17" />

<img width="1580" height="711" alt="image" src="https://github.com/user-attachments/assets/99149ac1-9b67-4642-8fef-8e75b9e72ad8" />

