### PR TITLE
#671 Fix heatmap display

### DIFF
--- a/jest_unit.config.ts
+++ b/jest_unit.config.ts
@@ -27,10 +27,10 @@ const config: Config.InitialOptions = {
     // For details on these settings: https://jestjs.io/docs/configuration
     coverageThreshold: {
         global: {
-            statements: -74,
+            statements: -73,
             branches: -123,
             functions: -19,
-            lines: -57,
+            lines: -56,
         },
     },
 }

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
@@ -83,7 +83,10 @@ export const AgentNode: FC<NodeProps<AgentNodeProps>> = (props: NodeProps<AgentN
 
     // Determine background color based on active status, heatmap, or depth
     let backgroundColor: string
-    const isHeatmap = agentCounts?.size > 0 && maxAgentCount > 0
+
+    // HACK: parent passes in agentCounts as undefined when not using heatmap mode. We distinguish between
+    // "undefined" (no heatmap) and "defined but empty" (heatmap with zero counts).
+    const isHeatmap = agentCounts !== undefined
     if (isActiveAgent) {
         // Highlight active agents with a distinct color
         backgroundColor = agentNodeColor

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -190,6 +190,9 @@ export const MultiAgentAccelerator = ({
     }, [])
 
     const onStreamingStarted = useCallback((): void => {
+        // Reset agent counts
+        agentCountsRef.current = new Map()
+
         // Show info popup only once per session
         if (!haveShownPopup) {
             sendNotification(NotificationType.info, "Agents working", "Click the stop button or hit Escape to exit.")
@@ -203,7 +206,6 @@ export const MultiAgentAccelerator = ({
     const onStreamingComplete = useCallback((): void => {
         // When streaming is complete, clean up any refs and state
         conversationsRef.current = null
-        agentCountsRef.current = new Map<string, number>()
         setCurrentConversations(null)
         resetState()
     }, [])
@@ -232,7 +234,10 @@ export const MultiAgentAccelerator = ({
                         id="multi-agent-accelerator-sidebar"
                         isAwaitingLlm={isAwaitingLlm}
                         networks={networks}
-                        setSelectedNetwork={setSelectedNetwork}
+                        setSelectedNetwork={(newNetwork) => {
+                            agentCountsRef.current = new Map()
+                            setSelectedNetwork(newNetwork)
+                        }}
                     />
                 </Grid>
             </Slide>


### PR DESCRIPTION
Fixes a couple of bugs in heatmap display:

1) After a run, agent counts were getting reset always so was reverting to "depth" display and not showing heatmap
2) When selecting a new network, even if "heatmap" option selected, it was showing the depth coloring since internally the code was getting confused by lack of availability of run data for new network.

Fixed:

<img width="1813" height="793" alt="image" src="https://github.com/user-attachments/assets/80ffa3e4-6722-456f-8a8c-85ef3b2f0ad5" />
