### PR TITLE
Derive base version from git tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,6 @@ jobs:
                     "${{ github.event_name }}" \
                     "${{ github.sha }}" \
                     "${{ github.run_number }}" \
-                    "packages/ui-common/package.json" \
                     "${{ github.event.release.tag_name }}" \
                     "${{ inputs.dist_tag }}"
 

--- a/build_scripts/compute_publish_version.sh
+++ b/build_scripts/compute_publish_version.sh
@@ -17,13 +17,12 @@
 #
 # Computes the npm package version and dist-tag for publishing @cognizant-ai-lab/ui-common.
 #
-# Usage: compute_publish_version.sh <event_name> <sha> <run_number> <package_json_path> [release_tag] [dist_tag_input]
+# Usage: compute_publish_version.sh <event_name> <sha> <run_number> [release_tag] [dist_tag_input]
 #
 # Arguments:
 #   event_name:       The GitHub event name (push, release, workflow_dispatch)
 #   sha:              The full Git SHA
 #   run_number:       The GitHub Actions run number
-#   package_json_path: Path to the package.json file to read base version from
 #   release_tag:      (Optional) The release tag name (required if event_name is "release")
 #   dist_tag_input:   (Optional) User-selected dist-tag for workflow_dispatch
 #
@@ -33,10 +32,13 @@
 #   - sha:       The full Git SHA (passed through)
 #   - short_sha: The short (7-char) Git SHA
 #
+# The base version for pre-release builds (push, workflow_dispatch) is derived
+# from the latest git tag so that it automatically tracks the most recent release.
+#
 # Version formats by trigger:
-#   - push to main:      <base>-main.<short_sha>.<run_number>  with dist-tag "main"
-#   - release:           <release_tag> (without v prefix)      with dist-tag "latest"
-#   - workflow_dispatch: <base>-pr.<short_sha>.<run_number>    with dist-tag from input
+#   - push to main:      <latest_tag>-main.<short_sha>.<run_number>  with dist-tag "main"
+#   - release:           <release_tag> (without v prefix)            with dist-tag "latest"
+#   - workflow_dispatch: <latest_tag>-pr.<short_sha>.<run_number>    with dist-tag from input
 #
 
 set -o errtrace
@@ -47,29 +49,27 @@ set -o pipefail
 EVENT_NAME="${1:-}"
 SHA="${2:-}"
 RUN_NUMBER="${3:-}"
-PACKAGE_JSON_PATH="${4:-}"
-RELEASE_TAG="${5:-}"
-DIST_TAG_INPUT="${6:-prerelease}"
+RELEASE_TAG="${4:-}"
+DIST_TAG_INPUT="${5:-prerelease}"
 
 # Validate required arguments
-if [[ -z "$EVENT_NAME" || -z "$SHA" || -z "$RUN_NUMBER" || -z "$PACKAGE_JSON_PATH" ]]; then
-    echo "Error: event_name, sha, run_number, and package_json_path are required" >&2
-    echo "Usage: $0 <event_name> <sha> <run_number> <package_json_path> [release_tag] [dist_tag_input]" >&2
-    exit 1
-fi
-
-# Validate package.json exists
-if [[ ! -f "$PACKAGE_JSON_PATH" ]]; then
-    echo "Error: package.json not found at $PACKAGE_JSON_PATH" >&2
+if [[ -z "$EVENT_NAME" || -z "$SHA" || -z "$RUN_NUMBER" ]]; then
+    echo "Error: event_name, sha, and run_number are required" >&2
+    echo "Usage: $0 <event_name> <sha> <run_number> [release_tag] [dist_tag_input]" >&2
     exit 1
 fi
 
 # Compute short SHA (first 7 characters)
 SHORT_SHA="${SHA:0:7}"
 
-# Read base version from package.json and strip any prerelease suffix
-BASE_VERSION=$(node --eval "console.log(require('./$PACKAGE_JSON_PATH').version)")
-BASE_VERSION="${BASE_VERSION%%-*}"
+# Derive base version from the latest git tag so pre-release versions
+# automatically stay in sync with the most recent release.
+if ! BASE_VERSION=$(git describe --tags --abbrev=0 2>/dev/null); then
+    echo "Error: no git tags found. Create an initial release tag first." >&2
+    exit 1
+fi
+# Strip 'v' prefix if present
+BASE_VERSION="${BASE_VERSION#v}"
 
 # Compute version and dist-tag based on event type
 if [[ "$EVENT_NAME" == "push" ]]; then


### PR DESCRIPTION
## Summary

Pre-release npm versions published from main were stuck at `1.2.4-main.<sha>.<run>` because `compute_publish_version.sh` read its base version from `packages/ui-common/package.json`, which was never bumped after releases. The latest release tag is `1.3.3`, but main builds still used `1.2.4`. This replaces the `package.json` lookup with `git describe --tags --abbrev=0` so the base version automatically tracks the most recent release tag. The `package_json_path` positional argument is removed from the script and the `publish.yml` invocation.

## Review & Testing Checklist for Human

- [ ] **Tag selection correctness**: `git describe --tags --abbrev=0` picks the nearest tag by commit ancestry, not by semver sort. Verify this behaves correctly in the repo's tag topology — e.g., the existing `1.0.0-known-good` tag shouldn't get picked up unexpectedly on any reachable path.
- [ ] **No other callers of the script**: The positional arguments shifted (arg 4 was `package_json_path`, now it's `release_tag`). Confirm nothing else invokes `compute_publish_version.sh` — search the repo and any external repos that might call it.
- [ ] **Tags available in CI**: `publish.yml` already uses `fetch-depth: 0` and the `checkout` action fetches tags by default with full depth. Confirm a test run on main produces the expected version string (e.g., `1.3.3-main.<sha>.<run>`).
- [ ] **Consider bumping `packages/ui-common/package.json`** from `1.2.4` to `1.3.3` for cosmetic consistency, even though it's no longer used for version computation.

Recommended test plan: trigger the publish workflow manually via `workflow_dispatch` on this branch and confirm the computed version in the job summary shows the latest tag as the base.

### Notes

Requested by: @donn-leaf
[Link to Devin run](https://app.devin.ai/sessions/44e82b9b8eba43869307ad1096fe0c74)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
