### PR TITLE
Restore jest/expect-expect rule.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -402,6 +402,8 @@ const config = [
             "func-style": "off",
             "id-length": "off",
             "init-declarations": "off",
+            // Indicate that the findBy and getBy calls are implicit assertions
+            "jest/expect-expect": ["error", {assertFunctionNames: ["expect", "screen.findBy*", "screen.getBy*"]}],
             "line-comment-position": "off",
             "lines-around-comment": "off",
             "max-lines": "off",


### PR DESCRIPTION
# Description

Restore jest/expect-expect rule.

This was on my radar with the lint rules. I thought it was OK, but once I brought the lint rules over to LMX (https://github.com/cognizant-ai-lab/idea-brainstorm-demo/pull/115), I decided we should bring it back.

FWIW, there were no other rules that I was on the fence about, it was only this one.
