### PR TITLE
Show failed intermediate steps with red circles in CI

### DIFF
--- a/packages/ui-common/components/Common/CustomerLogo.tsx
+++ b/packages/ui-common/components/Common/CustomerLogo.tsx
@@ -5,7 +5,7 @@ import {FC, ReactElement} from "react"
 
 import {useSettingsStore} from "../../state/Settings"
 
-export interface CustomerLogoProps {
+interface CustomerLogoProps {
     readonly fallbackElement?: ReactElement | string
     readonly logoServiceToken?: string
 }


### PR DESCRIPTION
Small quality of life improvement to CI. Shows red circles for failed steps, where previously all were just gray and you had to click into each one to see what failed. See before and after screenshot below.

Future: somehow get _successful_ steps to show as green circles. Requires moving mountains apparently to make this happen. The best the LLMs could come up with is "switch to a Matrix build" which is...kinda ugly as it means launching a VM for every step. Though, it would probably execute faster overall due to parallelism... 🤔 

<img width="1583" height="1055" alt="image" src="https://github.com/user-attachments/assets/e97de0aa-7f74-45d4-a643-dbe9683c5c7c" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
