### PR TITLE
#268 Use dark logos from logo service to contrast with background

### DIFF
--- a/packages/ui-common/components/Common/CustomerLogo.tsx
+++ b/packages/ui-common/components/Common/CustomerLogo.tsx
@@ -70,7 +70,7 @@ export const CustomerLogo: FC<CustomerLogoProps> = ({fallbackElement, logoServic
     // "auto": use logo.dev service
     const logoUrl =
         logoServiceToken && customer?.trim().length > 0
-            ? `https://img.logo.dev/name/${encodeURIComponent(customer)}?token=${logoServiceToken}&theme=light&format=png&size=75`
+            ? `https://img.logo.dev/name/${encodeURIComponent(customer)}?token=${logoServiceToken}&theme=dark&format=png&size=75`
             : null
 
     return logoUrl ? (


### PR DESCRIPTION
We always want the "dark mode" option from the logo service since our navbar background is hard-coded to `--bs-primary`, which is dark blue, whatever the user's preference or custom branding.

Before:
<img width="718" height="445" alt="image" src="https://github.com/user-attachments/assets/8871545a-c309-473c-a2f1-f989d3d15718" />

After:
<img width="709" height="439" alt="image" src="https://github.com/user-attachments/assets/0cb96cda-dc7f-4b8c-9a2f-de4f98f1e1c5" />
