### PR TITLE
Fix: Resolve MUI hydration mismatch caused by server/client theme inconsistency

### DIFF
--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -127,7 +127,7 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
     const background = useSettingsStore((state) => state.settings.branding.background)
 
     const [theme, setTheme] = useState(createTheme)
-    // generating the branded themes only in client-side to avoid hydration issues.
+    // Generate the branded theme only on the client to avoid hydration issues.
     useEffect(() => {
         setTheme(createAppTheme(primary, secondary, background))
     }, [primary, secondary, background])

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -126,7 +126,7 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
     const secondary = useSettingsStore((state) => state.settings.branding.secondary)
     const background = useSettingsStore((state) => state.settings.branding.background)
 
-    const [theme, setTheme] = useState(createTheme)
+    const [theme, setTheme] = useState(() => createTheme())
     // Generate the branded theme only on the client to avoid hydration issues.
     useEffect(() => {
         setTheme(createAppTheme(primary, secondary, background))

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -21,7 +21,7 @@ import "../styles/globals.css"
 import type {EnvironmentResponse} from "./api/environment/Types"
 import Container from "@mui/material/Container"
 import CssBaseline from "@mui/material/CssBaseline"
-import {createTheme, ThemeProvider} from "@mui/material/styles"
+import {createTheme, Theme, ThemeProvider} from "@mui/material/styles"
 import startCase from "lodash-es/startCase.js"
 import {AppProps} from "next/app"
 import Head from "next/head"
@@ -126,7 +126,7 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
     const secondary = useSettingsStore((state) => state.settings.branding.secondary)
     const background = useSettingsStore((state) => state.settings.branding.background)
 
-    const [theme, setTheme] = useState(() => createTheme())
+    const [theme, setTheme] = useState<Theme>(() => createTheme())
     // Generate the branded theme only on the client to avoid hydration issues.
     useEffect(() => {
         setTheme(createAppTheme(primary, secondary, background))

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -21,14 +21,14 @@ import "../styles/globals.css"
 import type {EnvironmentResponse} from "./api/environment/Types"
 import Container from "@mui/material/Container"
 import CssBaseline from "@mui/material/CssBaseline"
-import {ThemeProvider} from "@mui/material/styles"
+import {createTheme, ThemeProvider} from "@mui/material/styles"
 import startCase from "lodash-es/startCase.js"
 import {AppProps} from "next/app"
 import Head from "next/head"
 import {useRouter} from "next/router"
 import {SessionProvider} from "next-auth/react"
 import {SnackbarProvider} from "notistack"
-import {ReactElement, JSX as ReactJSX, ReactNode, useEffect, useMemo, useState} from "react"
+import {ReactElement, JSX as ReactJSX, ReactNode, useEffect, useState} from "react"
 
 import {
     Auth,
@@ -126,7 +126,11 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
     const secondary = useSettingsStore((state) => state.settings.branding.secondary)
     const background = useSettingsStore((state) => state.settings.branding.background)
 
-    const theme = useMemo(() => createAppTheme(primary, secondary, background), [primary, secondary, background])
+    const [theme, setTheme] = useState(createTheme)
+    // generating the branded themes only in client-side to avoid hydration issues.
+    useEffect(() => {
+        setTheme(createAppTheme(primary, secondary, background))
+    }, [primary, secondary, background])
 
     useEffect(() => {
         const urlPaths: string[] = pathname?.split("/").filter((path) => path !== "")


### PR DESCRIPTION
Root Cause

`createAppTheme` internally calls `cssVar()`, which reads CSS custom properties (like --bs-primary) from the browser's computed styles via` getComputedStyle(document.documentElement)`. These variables are defined in `globals.css` but the server (Node.js) has no browser, no CSS engine, and never parses that file. As a result, `cssVar()` returns a hardcoded fallback value on the server but the real CSS variable values on the client.

Due to this, the server and client produce different CSS strings, different class name hashes, and throws a hydration mismatch error.

Fix

Replaced `useMemo` with `useState + useEffect` in `_app.tsx`:

`useState(createTheme)` initializes with MUI's default theme using no arguments . Both server and client produce identical output during the initial render, so hydration succeeds.
`useEffect `runs exclusively on the client after hydration completes. At that point the browser has parsed `globals.css`, `cssVar()` returns correct values, and `createAppTheme` is called with the real branding values. This triggers a normal client-side re-render with no hydration involvement.
