### PR TITLE
#773 Refactor documentation, clean up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+**/.env*
 **/.next
 **/__tests__
 **/coverage/
@@ -6,8 +7,6 @@
 **/node_modules
 **/tsconfig.tsbuildinfo
 *.code-workspace
-.env*
-.env.local
 .idea
 .swc
 .vscode

--- a/README.md
+++ b/README.md
@@ -14,102 +14,32 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-# UI Developer Start Guide
+# Overview
 
-This README is intended to help a new UI developer get up to speed toward making changes to the Neuro SAN UI code.
-By following these instructions, you will be able to run the UI locally on your development machine and make changes
-to the code locally, without deploying anything to the hosted services.
+This is the repository for the Neuro SAN UI, which is the user interface for the Neuro SAN product. It contains
+various packages including the UI implementation itself, a shared component library, and a shared configuration
+library for developers.
 
-You will configure your local environment to connect to the Neuro️ SAN backend services.
+Depending on your role and your objective, you will want to refer to one of the other README files listed below.
 
-Note: Previous names for this project were UniLEAF and NeuroAI, and those names are still used in some places.
+# Role-Based Guides
 
-## Set Up Prerequisites
+## DevOps/Deployment
 
-- Install [NodeJS](https://nodejs.org/) on your development machine. At time of writing Node 22 is the current LTS version.
-    - Example on mac: `brew install node@22`
-    - For Ubuntu, see this link: https://joshtronic.com/2024/05/26/ubuntu-nodejs-22-install/
-    - Make sure that the node executable is in your path. You can do this by typing `node --version`.
-    - Make sure you have the exact Node.js version specified in `.nvmrc` or you will encounter errors.
-- Install `yarn` on your development host. Instructions for all platforms are [here](https://classic.yarnpkg.com/lang/en/docs)
-    - Example using current version on mac: `brew install yarn`
-    - For Ubuntu, see this link: https://classic.yarnpkg.com/lang/en/docs/cli/self-update/
-    - Make sure that the yarn executable is in your path. You can do this by typing `yarn --version`.
-- Clone the repository:
-    - `git clone git@github.com:leaf-ai/neuro-san-ui.git`
-- Install all dependencies including dev dependencies
-    - `yarn install`
-- Generate the Neuro-san OpenAPI types for the UI. This is done by running the following commands in the project root
-  directory:
-    - `yarn generate`
-        - `yarn generate` will generate the necessary files in the `generated` directory.
-    - To verify, check to make sure that `generated/neuro-san/NeuroSanClient.ts` was generated.
-- In your project root directory, create a file named `.env` which contains the following keys.  
-  Ask a current UI developer for the your_value values or get them self-serve from the leaf-team-vault server (see below).
+You are a DevOps engineer who wants to deploy a cloud instance of the UI.
 
-```bash
-# Determines which backend neuro-san server to access. This one is for the Dev environment -- change as necessary.
-NEURO_SAN_SERVER_URL=https://neuro-san-dev.decisionai.ml
+Refer to [DEPLOYMENT.md](apps/main/DEPLOYMENT.md) for instructions on how to deploy the UI to a production environment.
 
-# Determines which backend Opportunity Finder Pipeline uses. This one is for the Dev environment -- change as necessary.
-UNILEAF_AGENT_SERVER_URL=https://unileaf-agent-dev.evolution.ml
+## Internal Developer
 
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=<your_value>
+You are a developer who wants to contribute to the UI codebase.
 
-GITHUB_ID=<your_value>
-GITHUB_SECRET=<your_value>
+Refer to [DEVELOPMENT.md](apps/main/DEVELOPMENT.md) for instructions on how to set up your development environment and
+run the UI locally.
 
-AUTH0_CLIENT_ID=<your_value>
-AUTH0_CLIENT_SECRET=<your_value>
-AUTH0_ISSUER=https://cognizant-ai.auth0.com/authorize
-AUTH0_DOMAIN=cognizant-ai.auth0.com
+## External Developer
 
-# Can be anything
-SUPPORT_EMAIL_ADDRESS=test@example.com
+You are a developer who wants to use the shared component library in your own project.
 
-# Token from logo.dev if you want to use their service for logo generation. Can be omitted if you don't need logo
-# generation.
-LOGO_SERVICE_TOKEN=<your_token>
-```
-
-- Instructions for generating NEXTAUTH_SECRET are [here](https://next-auth.js.org/configuration/options#secret).
-- Instructions on generating OPENAI_API_KEY are [here](https://platform.openai.com/account/api-keys).  
-  You will need an active account with OpenAI to generate this key. This is only needed if you are working on the  
-  LLM features of the UI.
-- Be sure to chmod 600 this .env file to keep secret values secret
-
-## Run the development server:
-
-```bash
-# By setting the NEURO_SAN_UI_VERSION value, the ui will display your current branch in the header after Build:
-export NEURO_SAN_UI_VERSION=$(git branch --show-current) && yarn run dev
-```
-
-To run with verbose debugging:
-
-```bash
-DEBUG='*,-send,-compression,-babel,-next:*' NEURO_SAN_UI_VERSION=$(git branch --show-current) && yarn run dev
-```
-
-You can also set the `DEBUG` variable to a list of modules to only see output for those modules, for example:
-
-```bash
-export DEBUG="app,flow"
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-## Try making a simple change to the UI
-
-Now you've made it this far, try a simple change within the UI. Here's an example:
-
-1. Navigate to the MAUI page `http://localhost:3000/multiAgentAccelerator`
-1. Open `./pages/multiAgentAccelerator/index.tsx`
-1. Add a message, such as `Hello world!`, at the appropriate place in the tsx file (somewhere within the `<Grid>` in the last `return` statement).
-1. Your change appears immediately in the UI for MAUI, without relaunching any services or recompiling,
-   thanks to [Hot Module Replacement](https://webpack.js.org/guides/hot-module-replacement/) in Webpack which is used
-   by NextJS. If you don't see your change, try holding down `Shift` and clicking the browser refresh button --
-   this bypasses the browser cache.
-
-### Congratulations, you are now a UI developer!
+Refer to [README.md](packages/ui-common/README.md) for instructions on how to use the shared component library in your
+own project.

--- a/README.md
+++ b/README.md
@@ -43,5 +43,4 @@ run the UI locally.
 
 You are a developer who wants to use the shared component library in your own project.
 
-Refer to [README.md](packages/ui-common/README.md) for instructions on how to use the shared component library in your
-own project.
+Refer to [README.md](packages/ui-common/README.md) for instructions on how to do this.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Depending on your role and your objective, you will want to refer to one of the 
 
 # Role-Based Guides
 
+Select the guide that best matches your role and what you want to accomplish:
+
 ## DevOps/Deployment
 
 You are a DevOps engineer who wants to deploy a cloud instance of the UI.

--- a/apps/main/.env.sample
+++ b/apps/main/.env.sample
@@ -1,4 +1,5 @@
-# Determines which backend neuro-san server to access. This one is for the Dev environment -- change as necessary.
+# Determines which backend neuro-san server to access. This can be a server running locally or a remote server that
+# you have access to. Make sure to include the port number if it's not running on the default HTTP port (80).
 NEURO_SAN_SERVER_URL=<URL for your neuro-san server including port number>
 
 # Set this to false for testing or authentication via load balancer (recommended)

--- a/apps/main/DEPLOYMENT.md
+++ b/apps/main/DEPLOYMENT.md
@@ -1,0 +1,1 @@
+(Placeholder)

--- a/apps/main/DEPLOYMENT.md
+++ b/apps/main/DEPLOYMENT.md
@@ -1,1 +1,58 @@
-(Placeholder)
+## Copyright
+
+Copyright 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Overview
+
+This document provides an overview of how to deploy the Multi-Agent Accelerator UI ("MAUI") to a production
+environment. It is aimed at DevOps engineers or anyone responsible for deploying and maintaining the UI in a cloud
+environment.
+
+## Supported Environments
+
+MAUI is designed to be deployed in a cloud environment such as Kubernetes, AWS EKS or similar.
+Examples of supported environments include Amazon Web Services (AWS) and Microsoft Azure, but any environment that
+supports Docker containers should be compatible.
+
+## Prerequisites
+
+- A cloud environment with Kubernetes or similar container orchestration capabilities.
+- Access to the Docker image for MAUI (available in Amazon ECR or build your own).
+- Appropriate permissions to deploy and manage resources in the target environment, including opening ports and
+  configuring networking.
+- A domain name and SSL certificate if you want to serve the UI over HTTPS (optional but recommended).
+- A backend instance of the Neuro SAN services that the UI can connect to.
+- A key for OpenAI API access
+
+## Deployment Instructions
+
+MAUI is deployed as a Docker container. The Docker image is built and pushed to Amazon ECR as part of
+the CI/CD pipeline but you can also build your own Docker image.
+
+### Building the Docker Image
+
+Skip this step if you have access to a pre-built Docker image for MAUI.
+
+To build the Docker image yourself, follow these steps:
+
+...
+
+### Deploying to Kubernetes
+
+...
+
+## Authentication
+
+...

--- a/apps/main/DEPLOYMENT.md
+++ b/apps/main/DEPLOYMENT.md
@@ -1,19 +1,3 @@
-## Copyright
-
-Copyright 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
 ## Overview
 
 This document provides an overview of how to deploy the Multi-Agent Accelerator UI ("MAUI") to a production
@@ -45,14 +29,26 @@ the CI/CD pipeline but you can also build your own Docker image.
 
 Skip this step if you have access to a pre-built Docker image for MAUI.
 
-To build the Docker image yourself, follow these steps:
+To build the Docker image yourself, run the following command from the root of the repository. Inspect the script for
+the various options available.
 
-...
+```bash
+./apps/main/deploy/build.sh
+```
 
-### Deploying to Kubernetes
+To run the resulting Docker image locally for testing, you can use the following command. Note that some
+environment variables must be supplied as described in the script. See `.env.sample` for reference.
 
-...
+```bash
+./apps/main/deploy/run.sh
+```
+
+Deploying image to a cloud service provider is outside the scope of this document.
 
 ## Authentication
 
-...
+The process described above results in a deployment of the UI that is not protected by any authentication mechanism.
+For production deployments, it is strongly advised that you set up authentication to prevent unauthorized access to the
+application. This can be done using a variety of methods such as an AWS ALB with authentication via OIDC.
+Further details on how to set this up are outside the scope of this document. Please contact the Cognizant AI Lab team
+for more information.

--- a/apps/main/DEVELOPMENT.md
+++ b/apps/main/DEVELOPMENT.md
@@ -1,0 +1,96 @@
+# Copyright
+
+Copyright 2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+# UI Developer Start Guide
+
+This README is intended to help a new UI developer get up to speed toward making changes to the Neuro SAN UI code.
+By following these instructions, you will be able to run the UI locally on your development machine and make changes
+to the code locally, without deploying anything to the hosted services.
+
+You will configure your local environment to connect to the Neuro️ SAN backend services.
+
+Note: Previous names for this project were UniLEAF and NeuroAI, and those names are still used in some places.
+
+## Set Up Prerequisites
+
+- Install [NodeJS](https://nodejs.org/) on your development machine. At time of writing Node 22 is the current LTS version.
+    - Example on mac: `brew install node@22`
+    - For Ubuntu, see this link: https://joshtronic.com/2024/05/26/ubuntu-nodejs-22-install/
+    - Make sure that the node executable is in your path. You can do this by typing `node --version`.
+    - Make sure you have the exact Node.js version specified in `.nvmrc` or you will encounter errors.
+- Install `yarn` on your development host. Instructions for all platforms are [here](https://classic.yarnpkg.com/lang/en/docs)
+    - Example using current version on mac: `brew install yarn`
+    - For Ubuntu, see this link: https://classic.yarnpkg.com/lang/en/docs/cli/self-update/
+    - Make sure that the yarn executable is in your path. You can do this by typing `yarn --version`.
+- Clone the repository:
+    - `git clone git@github.com:leaf-ai/neuro-san-ui.git`
+- Install all dependencies including dev dependencies
+    - `yarn install`
+- Generate the Neuro-san OpenAPI types for the UI. This is done by running the following commands in the project root
+  directory:
+    - `yarn generate`
+        - `yarn generate` will generate the necessary files in the `generated` directory.
+    - To verify, check to make sure that `generated/neuro-san/NeuroSanClient.ts` was generated.
+- In your project root directory, create a file named `.env` which contains the following keys.  
+  Ask a current UI developer for the your_value values or get them self-serve from the leaf-team-vault server (see below).
+
+```dotenv
+# Determines which backend neuro-san server to access. This one is for the Dev environment -- change as necessary.
+NEURO_SAN_SERVER_URL=https://neuro-san-dev.decisionai.ml
+
+# Disable authentication for local development.
+NEXT_PUBLIC_ENABLE_AUTHENTICATION=false
+
+# Can be an arbitrary value, since authentication is disabled.
+AUTH0_CLIENT_SECRET=<your_value_here>
+
+# Generate this key using your OpenAI account.
+OPENAI_API_KEY=<your_value_here>
+
+# Can be anything; only use for "Contact Us" feature.
+SUPPORT_EMAIL_ADDRESS=test@example.com
+
+# Obtain a token from Logo.dev. Optional. If you omit this, automatic logo generation will not be available in the UI.
+LOGO_SERVICE_TOKEN=<your_value_here>
+```
+
+- Instructions for generating NEXTAUTH_SECRET are [here](https://next-auth.js.org/configuration/options#secret).
+- Instructions on generating OPENAI_API_KEY are [here](https://platform.openai.com/account/api-keys).  
+  You will need an active account with OpenAI to generate this key. This is only needed if you are working on the  
+  LLM features of the UI.
+- Be sure to chmod 600 this .env file to keep secret values secret
+
+## Run the development server:
+
+```bash
+# By setting the NEURO_SAN_UI_VERSION value, the ui will display your current branch in the header after Build:
+export NEURO_SAN_UI_VERSION=$(git branch --show-current) && yarn run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+You should see the Neuro SAN UI splash page.
+
+## Try making a simple change to the UI
+
+Now you've made it this far, try a simple change within the UI. Here's an example:
+
+1. Navigate to the home page `http://localhost:3000/multiAgentAccelerator`
+1. Open `./pages/multiAgentAccelerator/index.tsx` in your editor.
+1. Add a message, such as `Hello world!`, at the appropriate place in the tsx file (somewhere within the `<Grid>`
+   in the last `return` statement).
+1. Your change appears immediately in the UI for MAUI, without relaunching any services or recompiling,
+   thanks to auto-reloading by NextJS. If you don't see your change, try holding down `Shift` and clicking
+   the browser refresh button -- this bypasses the browser cache.

--- a/apps/main/DEVELOPMENT.md
+++ b/apps/main/DEVELOPMENT.md
@@ -44,53 +44,35 @@ Note: Previous names for this project were UniLEAF and NeuroAI, and those names 
     - `yarn generate`
         - `yarn generate` will generate the necessary files in the `generated` directory.
     - To verify, check to make sure that `generated/neuro-san/NeuroSanClient.ts` was generated.
-- In your project root directory, create a file named `.env` which contains the following keys.  
-  Ask a current UI developer for the your_value values or get them self-serve from the leaf-team-vault server (see below).
 
-```dotenv
-# Determines which backend neuro-san server to access. This one is for the Dev environment -- change as necessary.
-NEURO_SAN_SERVER_URL=https://neuro-san-dev.decisionai.ml
+## Set up environment variables
 
-# Disable authentication for local development.
-NEXT_PUBLIC_ENABLE_AUTHENTICATION=false
-
-# Can be an arbitrary value, since authentication is disabled.
-AUTH0_CLIENT_SECRET=<your_value_here>
-
-# Generate this key using your OpenAI account.
-OPENAI_API_KEY=<your_value_here>
-
-# Can be anything; only use for "Contact Us" feature.
-SUPPORT_EMAIL_ADDRESS=test@example.com
-
-# Obtain a token from Logo.dev. Optional. If you omit this, automatic logo generation will not be available in the UI.
-LOGO_SERVICE_TOKEN=<your_value_here>
-```
-
-- Instructions for generating NEXTAUTH_SECRET are [here](https://next-auth.js.org/configuration/options#secret).
-- Instructions on generating OPENAI_API_KEY are [here](https://platform.openai.com/account/api-keys).  
-  You will need an active account with OpenAI to generate this key. This is only needed if you are working on the  
-  LLM features of the UI.
+- In your project root directory, copy the file `.env.sample` to `.env` and fill in the appropriate values
+  for the keys in the file. Instructions on generating OPENAI_API_KEY are
+  [here](https://platform.openai.com/account/api-keys).  
+  You will need an active account with OpenAI to generate this key.
 - Be sure to chmod 600 this .env file to keep secret values secret
 
 ## Run the development server:
 
 ```bash
-# By setting the NEURO_SAN_UI_VERSION value, the ui will display your current branch in the header after Build:
-export NEURO_SAN_UI_VERSION=$(git branch --show-current) && yarn run dev
+# By setting the NEXT_PUBLIC_NEURO_SAN_UI_VERSION value, the ui will display your current branch in the header
+# after Build:
+export NEXT_PUBLIC_NEURO_SAN_UI_VERSION=$(git branch --show-current) && yarn run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-You should see the Neuro SAN UI splash page.
+You should see the Neuro SAN UI splash page. Click on "Explore agent networks". This should bring you to the
+agent networks screen.
 
 ## Try making a simple change to the UI
 
 Now you've made it this far, try a simple change within the UI. Here's an example:
 
 1. Navigate to the home page `http://localhost:3000/multiAgentAccelerator`
-1. Open `./pages/multiAgentAccelerator/index.tsx` in your editor.
-1. Add a message, such as `Hello world!`, at the appropriate place in the tsx file (somewhere within the `<Grid>`
-   in the last `return` statement).
+1. Open the file `./packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx` in your code editor.
+1. Add a message, such as `Hello world!`, at the appropriate place in the tsx file (somewhere within the last `return`
+   statement).
 1. Your change appears immediately in the UI for MAUI, without relaunching any services or recompiling,
-   thanks to auto-reloading by NextJS. If you don't see your change, try holding down `Shift` and clicking
+   thanks to auto-reloading by Next.js. If you don't see your change, try holding down `Shift` and clicking
    the browser refresh button -- this bypasses the browser cache.

--- a/apps/main/deploy/build.sh
+++ b/apps/main/deploy/build.sh
@@ -33,7 +33,7 @@ function build_main() {
     fi
 
     # Determine platform, defaulting to linux/amd64
-    if [ -z "${TARGET_PLATFORM}" ]
+    if [ -z "${TARGET_PLATFORM:-}" ]
     then
         TARGET_PLATFORM="linux/amd64"
     fi
@@ -41,7 +41,7 @@ function build_main() {
 
     # Locate repo root and Dockerfile
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
     DOCKERFILE="${REPO_ROOT}/apps/main/Dockerfile"
 
     echo "DOCKERFILE is ${DOCKERFILE}"

--- a/apps/main/deploy/build.sh
+++ b/apps/main/deploy/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 # Copyright © 2025 Cognizant Technology Solutions Corp
 #
@@ -8,7 +8,12 @@
 # Usage:
 #   build.sh [--no-cache]
 #
-# The script must be run from the neuro-san-ui/apps/main directory.
+# The script must be run from the root of the repo
+
+# See https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html for what these do
+set -o errtrace
+set -o nounset
+set -o pipefail
 
 export SERVICE_TAG=${SERVICE_TAG:-neuro-san-ui}
 export SERVICE_VERSION=${SERVICE_VERSION:-0.0.1}
@@ -22,7 +27,7 @@ function build_main() {
 
     # Parse for a specific arg when debugging
     CACHE_OR_NO_CACHE="--rm"
-    if [ "$1" == "--no-cache" ]
+    if [ "${1:-}" == "--no-cache" ]
     then
         CACHE_OR_NO_CACHE="--no-cache --progress=plain"
     fi
@@ -44,7 +49,7 @@ function build_main() {
     # Build the docker image
     # DOCKER_BUILDKIT needed for secrets / caching
     # shellcheck disable=SC2086
-    DOCKER_BUILDKIT=1 docker build \
+    docker buildx build \
         -t ${SERVICE_TAG}/${SERVICE_TAG}:${SERVICE_VERSION} \
         --platform ${TARGET_PLATFORM} \
         --build-arg NODEJS_VERSION="${NODEJS_VERSION}" \

--- a/apps/main/deploy/run.sh
+++ b/apps/main/deploy/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright © 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
 #
@@ -7,6 +7,11 @@
 # Script that runs the neuro-san-ui docker container locally
 # Usage: run.sh
 #
+
+# See https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html for what these do
+set -o errtrace
+set -o nounset
+set -o pipefail
 
 function check_directory() {
     working_dir=$(pwd)
@@ -46,8 +51,12 @@ function run() {
     docker_cmd="docker run --rm -it \
         --name=$SERVICE_NAME \
         --network=$network \
-        -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
-            neuro-san-ui/neuro-san-ui:$CONTAINER_VERSION"
+        --publish $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
+        --env LOGO_SERVICE_TOKEN \
+        --env NEURO_SAN_SERVER_URL \
+        --env OPENAI_API_KEY \
+        --env SUPPORT_EMAIL_ADDRESS \
+        neuro-san-ui/neuro-san-ui:$CONTAINER_VERSION"
 
     if [ "${OS}" == "Darwin" ];then
         # Host networking does not work for non-Linux operating systems


### PR DESCRIPTION
Reference: https://github.com/cognizant-ai-lab/neuro-san-studio/issues/773

Implements a more "role-based" structure for the doc. Also add a "set-up guide" for cloud (production-like) deployments.

Cleans up the "developer" instructions and moves them to `apps/main/DEVELOPMENT.md`. (The closest I could find to a naming standard for such docs.)

Moves the Docker build & run scripts under `apps/main/deploy` to at least approximate the way things are done in Neuro SAN proper.