### PR TITLE
#254 Various fixes/enhancements adjacent to main PR

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -73,10 +73,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -100,
+            statements: -102,
             branches: -157,
-            functions: -25,
-            lines: -77,
+            functions: -26,
+            lines: -79,
         },
     },
 

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow.test.tsx
@@ -1109,11 +1109,12 @@ describe("AgentFlow", () => {
         expect(agent1Node).toBeInTheDocument()
         fireEvent.click(agent1Node)
 
-        // The popup should now be open — find the Save button
-        const saveButton = await screen.findByRole("button", {name: "Save"})
+        // The popup should now be open — make the form dirty then save
+        const instructionsField = await screen.findByRole("textbox", {name: /^instructions$/iu})
+        fireEvent.change(instructionsField, {target: {value: "Updated instructions."}})
+        const saveButton = screen.getByRole("button", {name: "Save"})
         expect(saveButton).toBeInTheDocument()
 
-        // Click save (uses the initial instructions, no edits needed to exercise the code path)
         fireEvent.click(saveButton)
 
         // Popup should close
@@ -1599,12 +1600,14 @@ describe("AgentFlow", () => {
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
 
-            const saveButton = await screen.findByRole("button", {name: "Save"})
+            const instructionsField = await screen.findByRole("textbox", {name: /^instructions$/iu})
+            fireEvent.change(instructionsField, {target: {value: "Updated instructions"}})
+            const saveButton = screen.getByRole("button", {name: "Save"})
             fireEvent.click(saveButton)
 
-            // While in-flight the popup should stay open and show "Saving…"
+            // While in-flight the popup should stay open and show "Applying changes…"
             await waitFor(() => {
-                expect(screen.getByRole("button", {name: /saving/iu})).toBeInTheDocument()
+                expect(screen.getByRole("button", {name: /applying changes/iu})).toBeInTheDocument()
             })
             expect(screen.queryByRole("button", {name: /^save$/iu})).not.toBeInTheDocument()
 
@@ -1613,7 +1616,7 @@ describe("AgentFlow", () => {
 
             // After resolving, the popup should close
             await waitFor(() => {
-                expect(screen.queryByRole("button", {name: /saving/iu})).not.toBeInTheDocument()
+                expect(screen.queryByRole("button", {name: /applying changes/iu})).not.toBeInTheDocument()
             })
 
             expect(sendChatQuery).toHaveBeenCalledTimes(1)
@@ -1641,11 +1644,12 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            const saveButton = await screen.findByRole("button", {name: "Save"})
-            fireEvent.click(saveButton)
+            const instructionsField = await screen.findByRole("textbox", {name: /^instructions$/iu})
+            fireEvent.change(instructionsField, {target: {value: "Updated instructions"}})
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             await waitFor(() => {
-                expect(screen.queryByRole("button", {name: /saving/iu})).not.toBeInTheDocument()
+                expect(screen.queryByRole("button", {name: /applying changes/iu})).not.toBeInTheDocument()
             })
 
             const stored = useTempNetworksStore.getState().tempNetworks
@@ -1701,10 +1705,13 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            fireEvent.click(await screen.findByRole("button", {name: "Save"}))
+            fireEvent.change(await screen.findByRole("textbox", {name: /^instructions$/iu}), {
+                target: {value: "Updated instructions"},
+            })
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             await waitFor(() => {
-                expect(screen.queryByRole("button", {name: /saving/iu})).not.toBeInTheDocument()
+                expect(screen.queryByRole("button", {name: /applying changes/iu})).not.toBeInTheDocument()
             })
 
             const stored = useTempNetworksStore.getState().tempNetworks
@@ -1759,10 +1766,13 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            fireEvent.click(await screen.findByRole("button", {name: "Save"}))
+            fireEvent.change(await screen.findByRole("textbox", {name: /^instructions$/iu}), {
+                target: {value: "Updated instructions"},
+            })
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             await waitFor(() => {
-                expect(screen.queryByRole("button", {name: /saving/iu})).not.toBeInTheDocument()
+                expect(screen.queryByRole("button", {name: /applying changes/iu})).not.toBeInTheDocument()
             })
 
             const stored = useTempNetworksStore.getState().tempNetworks
@@ -1839,8 +1849,9 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            const saveButton = await screen.findByRole("button", {name: "Save"})
-            fireEvent.click(saveButton)
+            const instructionsField = await screen.findByRole("textbox", {name: /^instructions$/iu})
+            fireEvent.change(instructionsField, {target: {value: "Updated instructions"}})
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             await waitFor(() => {
                 expect(onNetworkReplaced).toHaveBeenCalledWith(OLD_NETWORK_ID, NEW_NETWORK_ID)
@@ -1900,10 +1911,13 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            fireEvent.click(await screen.findByRole("button", {name: "Save"}))
+            fireEvent.change(await screen.findByRole("textbox", {name: /^instructions$/iu}), {
+                target: {value: "Updated instructions"},
+            })
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             await waitFor(() => {
-                expect(screen.queryByRole("button", {name: /saving/iu})).not.toBeInTheDocument()
+                expect(screen.queryByRole("button", {name: /applying changes/iu})).not.toBeInTheDocument()
             })
 
             // enqueueSnackbar receives a React <span> element as the first arg (from sendNotification);
@@ -1937,12 +1951,13 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            const saveButton = await screen.findByRole("button", {name: "Save"})
-            fireEvent.click(saveButton)
+            const instructionsField = await screen.findByRole("textbox", {name: /^instructions$/iu})
+            fireEvent.change(instructionsField, {target: {value: "Updated instructions"}})
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             // Popup should close even on error (finally block)
             await waitFor(() => {
-                expect(screen.queryByRole("button", {name: /saving/iu})).not.toBeInTheDocument()
+                expect(screen.queryByRole("button", {name: /applying changes/iu})).not.toBeInTheDocument()
             })
 
             expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to submit"), expect.any(Error))
@@ -1964,8 +1979,9 @@ describe("AgentFlow", () => {
             })
 
             fireEvent.click(container.querySelector('[data-id="agent1"]'))
-            const saveButton = await screen.findByRole("button", {name: "Save"})
-            fireEvent.click(saveButton)
+            const instructionsField = await screen.findByRole("textbox", {name: /^instructions$/iu})
+            fireEvent.change(instructionsField, {target: {value: "Updated instructions"}})
+            fireEvent.click(screen.getByRole("button", {name: "Save"}))
 
             await waitFor(() => {
                 expect(screen.queryByRole("button", {name: "Save"})).not.toBeInTheDocument()

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentNodePopup.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentNodePopup.test.tsx
@@ -99,7 +99,9 @@ describe("AgentNodePopup", () => {
         await user.clear(instructionsField)
         await user.type(instructionsField, "Temporary edit")
 
+        // Clicking Cancel when dirty shows the ConfirmationModal; "Discard changes" confirms close
         await user.click(screen.getByRole("button", {name: /cancel/iu}))
+        await user.click(screen.getByRole("button", {name: /discard changes/iu}))
 
         expect(onClose).toHaveBeenCalled()
     })
@@ -271,41 +273,34 @@ describe("AgentNodePopup", () => {
         it("disables both Save and Cancel buttons while isSaving is true", () => {
             renderPopup({isSaving: true})
 
-            expect(screen.getByRole("button", {name: /saving/iu})).toBeDisabled()
+            expect(screen.getByRole("button", {name: /applying changes/iu})).toBeDisabled()
             expect(screen.getByRole("button", {name: /cancel/iu})).toBeDisabled()
         })
 
-        it("shows 'Saving…' label on the Save button while isSaving is true", () => {
+        it("shows 'Applying changes\u2026' label on the Save button while isSaving is true", () => {
             renderPopup({isSaving: true})
 
-            expect(screen.getByRole("button", {name: /saving/iu})).toBeInTheDocument()
+            expect(screen.getByRole("button", {name: /applying changes/iu})).toBeInTheDocument()
             expect(screen.queryByRole("button", {name: /^save$/iu})).not.toBeInTheDocument()
         })
 
         it("shows 'Save' label and enables buttons when isSaving is false", () => {
             renderPopup({isSaving: false})
 
+            // Save is also gated on isDirty; make the form dirty so it is not disabled by !isDirty
+            fireEvent.change(screen.getByRole("textbox", {name: /^instructions$/iu}), {
+                target: {value: "Changed"},
+            })
+
             expect(screen.getByRole("button", {name: /^save$/iu})).not.toBeDisabled()
             expect(screen.getByRole("button", {name: /cancel/iu})).not.toBeDisabled()
-        })
-
-        it("shows the 'few minutes' note while isSaving is true", () => {
-            renderPopup({isSaving: true})
-
-            expect(screen.getByText(/creating a new network/iu)).toBeInTheDocument()
-        })
-
-        it("hides the 'few minutes' note when isSaving is false", () => {
-            renderPopup({isSaving: false})
-
-            expect(screen.queryByText(/creating a new network/iu)).not.toBeInTheDocument()
         })
 
         it("does not call onSave when the Save button is disabled (isSaving true)", () => {
             const {onSave} = renderPopup({isSaving: true})
 
             // The button is disabled so clicking it should not trigger onSave
-            const saveBtn = screen.getByRole("button", {name: /saving/iu})
+            const saveBtn = screen.getByRole("button", {name: /applying changes/iu})
             fireEvent.click(saveBtn)
 
             expect(onSave).not.toHaveBeenCalled()
@@ -346,14 +341,14 @@ describe("AgentNodePopup", () => {
             textareas.forEach((ta) => expect(ta).toBeDisabled())
         })
 
-        it("calls onClose when backdrop is clicked while isSaving is true", () => {
+        it("does not call onClose when backdrop is clicked while isSaving is true", () => {
             const {onClose} = renderPopup({isSaving: true})
 
-            // Clicking outside always dismisses — lets the user abort a stuck in-flight request.
+            // Clicking outside is blocked while saving to prevent accidental dismissal.
             const backdrop = document.querySelector(".MuiBackdrop-root")
             if (backdrop) fireEvent.click(backdrop)
 
-            expect(onClose).toHaveBeenCalledTimes(1)
+            expect(onClose).not.toHaveBeenCalled()
         })
 
         it("calls onClose when backdrop is clicked while isSaving is false", () => {

--- a/packages/ui-common/components/Common/MUIDialog.tsx
+++ b/packages/ui-common/components/Common/MUIDialog.tsx
@@ -40,6 +40,7 @@ interface MUIDialogProps {
     className?: string
     closeable?: boolean
     contentSx?: SxProps
+    dialogSx?: SxProps
     footer?: ReactJSX.Element
     id: string
     isOpen: boolean
@@ -54,6 +55,7 @@ export const MUIDialog: FC<MUIDialogProps> = ({
     className,
     closeable = true,
     contentSx,
+    dialogSx,
     footer,
     id,
     isOpen,
@@ -70,6 +72,7 @@ export const MUIDialog: FC<MUIDialogProps> = ({
         slotProps={{
             paper: {sx: paperProps},
         }}
+        sx={dialogSx}
     >
         <StyledDialogTitle id={`${id}-title`}>{title}</StyledDialogTitle>
         {closeable && (

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
@@ -108,7 +108,7 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
                     color="text.secondary"
                     sx={{fontStyle: "italic", lineHeight: 1.35, marginLeft: "0.75rem"}}
                 >
-                    Creating a new network with those changes.
+                    Applying your changes...
                 </Typography>
             ) : (
                 <Box />

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
@@ -19,7 +19,6 @@ import Button from "@mui/material/Button"
 import CircularProgress from "@mui/material/CircularProgress"
 import LinearProgress from "@mui/material/LinearProgress"
 import TextField from "@mui/material/TextField"
-import Typography from "@mui/material/Typography"
 import {FC, useEffect, useState} from "react"
 
 import {MUIDialog} from "../Common/MUIDialog"
@@ -97,22 +96,11 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
             sx={{
                 display: "flex",
                 alignItems: "flex-start",
-                justifyContent: "space-between",
+                justifyContent: "flex-end",
                 width: "100%",
                 gap: 1,
             }}
         >
-            {isSaving ? (
-                <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{fontStyle: "italic", lineHeight: 1.35, marginLeft: "0.75rem"}}
-                >
-                    Applying your changes...
-                </Typography>
-            ) : (
-                <Box />
-            )}
             <Box sx={{display: "flex", gap: 1}}>
                 <Button
                     id="agent-node-popup-cancel-btn"
@@ -138,7 +126,7 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
                         ) : undefined
                     }
                 >
-                    {isSaving ? "Saving…" : "Save"}
+                    {isSaving ? "Applying changes…" : "Save"}
                 </Button>
             </Box>
         </Box>
@@ -146,12 +134,13 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
 
     return (
         <MUIDialog
+            dialogSx={isSaving ? {"& *, & *::before, & *::after": {cursor: "wait !important"}} : undefined}
+            footer={footer}
             id="agent-node-popup"
             isOpen={isOpen}
             onClose={handleClose}
-            title={agentName}
-            footer={footer}
             paperProps={{minWidth: "480px", maxWidth: "600px", width: "100%"}}
+            title={agentName}
         >
             {/* Progress bar shown while saving — makes it clear the dialog is busy */}
             {isSaving && (

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
@@ -71,6 +71,8 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
     const [instructionsText, setInstructionsText] = useState<string>(initialInstructions)
     const [descriptionText, setDescriptionText] = useState<string>(initialDescription)
 
+    const isDirty = instructionsText !== initialInstructions || descriptionText !== initialDescription
+
     // Keep local fields in sync when the dialog opens or if initial values change while open.
     // Guarding on isOpen prevents resetting the text during the close animation, which would cause a visible flash.
     useEffect(() => {
@@ -116,7 +118,7 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
                     onClick={handleSave}
                     variant="contained"
                     size="small"
-                    disabled={isSaving}
+                    disabled={isSaving || !isDirty}
                     startIcon={
                         isSaving ? (
                             <CircularProgress

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNodePopup.tsx
@@ -21,6 +21,7 @@ import LinearProgress from "@mui/material/LinearProgress"
 import TextField from "@mui/material/TextField"
 import {FC, useEffect, useState} from "react"
 
+import {ConfirmationModal} from "../Common/ConfirmationModal"
 import {MUIDialog} from "../Common/MUIDialog"
 
 // #region: Types
@@ -73,6 +74,8 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
 
     const isDirty = instructionsText !== initialInstructions || descriptionText !== initialDescription
 
+    const [displayConfirmationModal, setDisplayConfirmationModal] = useState<boolean>(false)
+
     // Keep local fields in sync when the dialog opens or if initial values change while open.
     // Guarding on isOpen prevents resetting the text during the close animation, which would cause a visible flash.
     useEffect(() => {
@@ -87,7 +90,15 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
     }
 
     const handleClose = () => {
-        // Discard local edits and reset to the initial values on cancel
+        if (isSaving) {
+            return
+        }
+
+        if (isDirty) {
+            setDisplayConfirmationModal(true)
+            return
+        }
+
         setInstructionsText(initialInstructions)
         setDescriptionText(initialDescription)
         onClose()
@@ -134,53 +145,75 @@ export const AgentNodePopup: FC<AgentNodePopupProps> = ({
         </Box>
     )
 
+    const getConfirmationModal = () => (
+        <ConfirmationModal
+            id="agent-node-popup-unsaved-changes-modal"
+            cancelBtnLabel="Discard changes"
+            closeable={false}
+            content={<p>You have unsaved edits. Are you sure you want to discard your changes and close the dialog?</p>}
+            handleCancel={() => {
+                setDisplayConfirmationModal(false)
+                setInstructionsText(initialInstructions)
+                setDescriptionText(initialDescription)
+                onClose()
+            }}
+            handleOk={handleSave}
+            maskCloseable={false}
+            okBtnLabel="Save changes"
+            title="Unsaved Changes"
+        />
+    )
+
     return (
-        <MUIDialog
-            dialogSx={isSaving ? {"& *, & *::before, & *::after": {cursor: "wait !important"}} : undefined}
-            footer={footer}
-            id="agent-node-popup"
-            isOpen={isOpen}
-            onClose={handleClose}
-            paperProps={{minWidth: "480px", maxWidth: "600px", width: "100%"}}
-            title={agentName}
-        >
-            {/* Progress bar shown while saving — makes it clear the dialog is busy */}
-            {isSaving && (
-                <LinearProgress
-                    aria-label="Saving agent"
-                    sx={{mb: 2, borderRadius: 1}}
+        <>
+            {displayConfirmationModal && getConfirmationModal()}
+            <MUIDialog
+                dialogSx={isSaving ? {"& *, & *::before, & *::after": {cursor: "wait !important"}} : undefined}
+                footer={footer}
+                id="agent-node-popup"
+                isOpen={isOpen}
+                onClose={handleClose}
+                paperProps={{minWidth: "480px", maxWidth: "600px", width: "100%"}}
+                title={agentName}
+            >
+                {/* Progress bar shown while saving — makes it clear the dialog is busy */}
+                {isSaving && (
+                    <LinearProgress
+                        aria-label="Saving agent"
+                        sx={{mb: 2, borderRadius: 1}}
+                    />
+                )}
+                {/* Description — editable */}
+                <TextField
+                    id="agent-node-popup-description-field"
+                    label="Description"
+                    value={descriptionText}
+                    onChange={(e) => setDescriptionText(e.target.value)}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    multiline
+                    rows={6}
+                    fullWidth
+                    size="small"
+                    disabled={isSaving}
+                    placeholder="Enter a short description of this agent…"
                 />
-            )}
-            {/* Description — editable */}
-            <TextField
-                id="agent-node-popup-description-field"
-                label="Description"
-                value={descriptionText}
-                onChange={(e) => setDescriptionText(e.target.value)}
-                onKeyDown={(e) => e.stopPropagation()}
-                multiline
-                rows={6}
-                fullWidth
-                size="small"
-                disabled={isSaving}
-                placeholder="Enter a short description of this agent…"
-            />
-            {/* Instructions — editable */}
-            <TextField
-                sx={{marginTop: 2}}
-                id="agent-node-popup-instructions-field"
-                label="Instructions"
-                value={instructionsText}
-                onChange={(e) => setInstructionsText(e.target.value)}
-                onKeyDown={(e) => e.stopPropagation()}
-                multiline
-                rows={6}
-                fullWidth
-                size="small"
-                autoFocus
-                disabled={isSaving}
-                placeholder="Enter instructions for this agent…"
-            />
-        </MUIDialog>
+                {/* Instructions — editable */}
+                <TextField
+                    sx={{marginTop: 2}}
+                    id="agent-node-popup-instructions-field"
+                    label="Instructions"
+                    value={instructionsText}
+                    onChange={(e) => setInstructionsText(e.target.value)}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    multiline
+                    rows={6}
+                    fullWidth
+                    size="small"
+                    autoFocus
+                    disabled={isSaving}
+                    placeholder="Enter instructions for this agent…"
+                />
+            </MUIDialog>
+        </>
     )
 }

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -550,6 +550,10 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                         onStreamingComplete={onStreamingComplete}
                         onStreamingStarted={onStreamingStarted}
                         extraSlyData={extraSlyData}
+                        agentPlaceholders={{
+                            [AGENT_NETWORK_DESIGNER_ID]:
+                                "Describe in plain language the network you would like to build",
+                        }}
                     />
                 </Grid>
             </Slide>

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -537,23 +537,23 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                     }}
                 >
                     <ChatCommon
-                        key={selectedNetwork ?? "no-network"}
-                        ref={chatRef}
-                        neuroSanURL={neuroSanURL}
-                        id="agent-network-ui"
-                        currentUser={userInfo.userName}
-                        userImage={userInfo.userImage}
-                        setIsAwaitingLlm={setIsAwaitingLlm}
-                        isAwaitingLlm={isAwaitingLlm}
-                        targetAgent={selectedNetwork}
-                        onChunkReceived={onChunkReceived}
-                        onStreamingComplete={onStreamingComplete}
-                        onStreamingStarted={onStreamingStarted}
-                        extraSlyData={extraSlyData}
                         agentPlaceholders={{
                             [AGENT_NETWORK_DESIGNER_ID]:
                                 "Describe in plain language the network you would like to build",
                         }}
+                        currentUser={userInfo.userName}
+                        extraSlyData={extraSlyData}
+                        id="agent-network-ui"
+                        isAwaitingLlm={isAwaitingLlm}
+                        key={selectedNetwork ?? "no-network"}
+                        neuroSanURL={neuroSanURL}
+                        onChunkReceived={onChunkReceived}
+                        onStreamingComplete={onStreamingComplete}
+                        onStreamingStarted={onStreamingStarted}
+                        ref={chatRef}
+                        setIsAwaitingLlm={setIsAwaitingLlm}
+                        targetAgent={selectedNetwork}
+                        userImage={userInfo.userImage}
                     />
                 </Grid>
             </Slide>

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import AddBoxRounded from "@mui/icons-material/AddBoxRounded"
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline"
 import ClearIcon from "@mui/icons-material/Clear"
 import HighlightOff from "@mui/icons-material/HighlightOff"
@@ -44,7 +45,7 @@ import {AgentInfo} from "../../../generated/neuro-san/NeuroSanClient"
 import {useEnvironmentStore} from "../../../state/Environment"
 import {TemporaryNetwork} from "../../../state/TemporaryNetworks"
 import {getZIndex} from "../../../utils/zIndexLayers"
-import {TEMPORARY_NETWORK_FOLDER} from "../const"
+import {AGENT_NETWORK_DESIGNER_ID, TEMPORARY_NETWORK_FOLDER} from "../const"
 
 // Animation for the sparkle effect when a new temporary network is added.
 const sparkle = keyframes`
@@ -113,11 +114,14 @@ const SidebarAside = styled("aside")({
 
 // Styled component for the sidebar heading, which is sticky at the top of the sidebar.
 const SidebarHeading = styled("h2")(({theme}) => ({
+    alignItems: "center",
     backgroundColor: theme.palette.background.default,
     borderBottomStyle: "solid",
     borderBottomWidth: "1px",
+    display: "flex",
     fontSize: "1.125rem",
     fontWeight: "bold",
+    justifyContent: "space-between",
     marginBottom: "0.25rem",
     paddingBottom: "0.75rem",
     position: "sticky",
@@ -330,28 +334,50 @@ export const Sidebar: FC<SidebarProps> = ({
             <SidebarAside id={`${id}-sidebar`}>
                 <SidebarHeading id={`${id}-heading`}>
                     Agent Networks
-                    <Button
-                        aria-label="Agent Network Settings"
-                        disabled={isAwaitingLlm}
-                        id="agent-network-settings-btn"
-                        onClick={handleSettingsClick}
-                        sx={{display: "inline-block", minWidth: "40px"}}
-                    >
-                        <Tooltip
-                            id="agent-network-settings-tooltip"
-                            placement="top"
-                            title={`${customURLLocalStorage || backendNeuroSanApiUrl}\nversion: ${
-                                testConnectionResult?.version || "unknown"
-                            }`}
+                    <Box sx={{display: "flex"}}>
+                        <Button
+                            aria-label="Add New Network"
+                            disabled={isAwaitingLlm}
+                            id="add-network-btn"
+                            onClick={() => {
+                                setSelectedItem(AGENT_NETWORK_DESIGNER_ID)
+                                setSelectedNetwork(AGENT_NETWORK_DESIGNER_ID)
+                            }}
+                            sx={{display: "inline-block", minWidth: "40px"}}
                         >
-                            <SettingsIcon
-                                id="agent-network-settings-icon"
-                                sx={{
-                                    color: isAwaitingLlm ? "rgba(0, 0, 0, 0.12)" : "var(--bs-secondary)",
-                                }}
-                            />
-                        </Tooltip>
-                    </Button>
+                            <Tooltip
+                                title="Create your own agent network"
+                                placement="top"
+                            >
+                                <AddBoxRounded
+                                    id="add-network-icon"
+                                    sx={{color: isAwaitingLlm ? "rgba(0, 0, 0, 0.12)" : "var(--bs-secondary)"}}
+                                />
+                            </Tooltip>
+                        </Button>
+                        <Button
+                            aria-label="Agent Network Settings"
+                            disabled={isAwaitingLlm}
+                            id="agent-network-settings-btn"
+                            onClick={handleSettingsClick}
+                            sx={{display: "inline-block", minWidth: "40px"}}
+                        >
+                            <Tooltip
+                                id="agent-network-settings-tooltip"
+                                placement="top"
+                                title={`${customURLLocalStorage || backendNeuroSanApiUrl}\nversion: ${
+                                    testConnectionResult?.version || "unknown"
+                                }`}
+                            >
+                                <SettingsIcon
+                                    id="agent-network-settings-icon"
+                                    sx={{
+                                        color: isAwaitingLlm ? "rgba(0, 0, 0, 0.12)" : "var(--bs-secondary)",
+                                    }}
+                                />
+                            </Tooltip>
+                        </Button>
+                    </Box>
                 </SidebarHeading>
                 <RichTreeView
                     key={Object.keys(networkIconSuggestions || {}).length} // Force remount when suggestions change


### PR DESCRIPTION
# Description

- Busy cursor when saving, everywhere in the dialog
- Confirms cancel if it will lose edits
- Get rid of extra "creating new network" text (abstraction leak + we already have two other "busy" indicators), instead, change "Save" button to "Applying changes..." when we're updating
- Prevent using bailing from dialog via escape, clicking "X", etc. when saving since that leaves us in an unstable state