### PR TITLE
Fix Docker build

### DIFF
--- a/apps/main/Dockerfile
+++ b/apps/main/Dockerfile
@@ -36,6 +36,7 @@ COPY .yarnrc.yml ./
 COPY package.json ./
 COPY yarn.lock ./
 COPY tsconfig.json ./
+COPY packages/dev-common/package.json ./packages/dev-common/
 COPY packages/ui-common ./packages/ui-common
 COPY apps/main/package.json ./apps/main/package.json
 
@@ -60,6 +61,7 @@ WORKDIR /app
 COPY .yarnrc.yml ./
 COPY package.json ./
 COPY packages/ui-common/package.json ./packages/ui-common/package.json
+COPY packages/dev-common/package.json ./packages/dev-common/package.json
 COPY apps/main/package.json ./apps/main/package.json
 COPY yarn.lock ./
 


### PR DESCRIPTION
#276 broke the [Docker build](https://github.com/cognizant-ai-lab/neuro-san-ui/actions/runs/25608845987/job/75175559701) due to introducing a new package -- `dev-common`.

Here's what was going wrong:
1) During the build, since the Dockerfile was not copying this package into the Docker build files (because I didn't think to add it -- maybe there's a way to prevent future oversights like this automatically?)...
2) ...when `yarn install` was invoked, yarn was noticing that `dev-common` was referenced in the root `package.json`, but not present. Therefore, yarn was attempting to update the lockfile to remove references to what it saw as a deleted package, `dev-common`.
3) However, we run with `--immutable` to avoid exactly this kind of situation.
4) Result: 💥 Can't modify the lockfile due to `--immutable` and the Docker build failed.

This PR remedies that.

Note: since we are using Next.js output tracing, and in the `runner` build stage we only copy the `Next.js` standalone assets (basically what Next.js deems necessary to run the app) + assets and public files, we're not copying `dev-common` to the resulting Docker image, which is how it should be; it doesn't contain production code, only shared configs etc. so shouldn't be part of the Docker image, which is meant to be a "lean and mean" production build (~225mb).