### PR TITLE
Shared knip config

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -38,7 +38,6 @@
         "@testing-library/user-event": "14.6.1",
         "@types/lodash-es": "4.17.12",
         "@types/react": "19.2.14",
-        "eslint": "10.2.1",
         "node-mocks-http": "1.17.2",
         "typescript": "5.9.3"
     }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,7 +31,6 @@ const esmPackagesToTransform = [
     "mdast.*",
     "parse-.*",
     "property-.*",
-    "react-syntax-highlighter",
     "refractor",
     "space-.*",
 ]

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,13 +23,10 @@ import type {KnipConfig} from "knip"
 
 import {config as baseConfig} from "./packages/dev-common/Configs/knip.config"
 
-const resolvedBase = typeof baseConfig === "function" ? null : baseConfig
-
 const config: KnipConfig = {
-    // eslint-disable-next-line @typescript-eslint/no-misused-spread -- we know the baseConfig is not a function
     ...baseConfig,
     ignore: [
-        ...(resolvedBase.ignore as string[]),
+        ...(baseConfig.ignore as string[]),
 
         // Temporarily exclude for transition to monorepo (legit issue)
         "packages/ui-common/components/AgentChat/Common/Types.ts",
@@ -38,7 +35,8 @@ const config: KnipConfig = {
         "jest_quiet.config.ts",
     ],
     ignoreDependencies: [
-        ...resolvedBase.ignoreDependencies,
+        ...baseConfig.ignoreDependencies,
+
         // Used for Speech Recognition API types
         "@types/dom-speech-recognition",
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -28,6 +28,9 @@ const config: KnipConfig = {
     ignore: [
         ...(baseConfig.ignore as string[]),
 
+        // Used in a sneaky way by jest
+        "babel.jest.config.cjs",
+
         // Temporarily exclude for transition to monorepo (legit issue)
         "packages/ui-common/components/AgentChat/Common/Types.ts",
 
@@ -37,8 +40,19 @@ const config: KnipConfig = {
     ignoreDependencies: [
         ...baseConfig.ignoreDependencies,
 
+        // Used internally by eslint
+        "globals",
+
+        // Used by jest
+        "@babel/core",
+        "@babel/preset-env",
+        "babel-jest",
+
         // Used for Speech Recognition API types
         "@types/dom-speech-recognition",
+
+        // Used internally by eslint
+        "globals",
 
         // Used by do_openapi_generate.sh
         "openapi-typescript",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,11 +1,35 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview Knip configuration file to identify unused files and dependencies in the project.
+ *
+ */
+
 import type {KnipConfig} from "knip"
 
-import {config} from "./packages/dev-common/Configs/knip.config"
+import {config as baseConfig} from "./packages/dev-common/Configs/knip.config"
 
-const knipConfig: KnipConfig = {
-    ...config,
+const resolvedBase = typeof baseConfig === "function" ? null : baseConfig
+
+const config: KnipConfig = {
+    // eslint-disable-next-line @typescript-eslint/no-misused-spread -- we know the baseConfig is not a function
+    ...baseConfig,
     ignore: [
-        ...config.ignore,
+        ...(resolvedBase.ignore as string[]),
 
         // Temporarily exclude for transition to monorepo (legit issue)
         "packages/ui-common/components/AgentChat/Common/Types.ts",
@@ -14,7 +38,7 @@ const knipConfig: KnipConfig = {
         "jest_quiet.config.ts",
     ],
     ignoreDependencies: [
-        ...config.ignoreDependencies,
+        ...resolvedBase.ignoreDependencies,
         // Used for Speech Recognition API types
         "@types/dom-speech-recognition",
 
@@ -52,4 +76,4 @@ const knipConfig: KnipConfig = {
     },
 }
 
-export default knipConfig
+export default config

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,81 +1,22 @@
-/*
-Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-/**
- * @fileoverview Knip configuration file to identify unused files and dependencies in the project.
- *
- */
-
 import type {KnipConfig} from "knip"
 
-const config: KnipConfig = {
-    // From the doc:
-    // "By default, Knip does not report unused exports in entry files. When a repository (or workspace) is
-    // self-contained or private, you may want to include entry files when reporting unused exports:"
-    includeEntryExports: true,
+import {config} from "./packages/dev-common/Configs/knip.config"
 
-    // Treat hints as errors (will make exit code non-zero)
-    treatConfigHintsAsErrors: true,
-
-    // Opt-in to all issues types
-    include: [
-        "binaries",
-        "catalog",
-        "dependencies",
-        "devDependencies",
-        "duplicates",
-        "enumMembers",
-        "exports",
-        "files",
-        "namespaceMembers",
-        "nsExports",
-        "nsTypes",
-        "optionalPeerDependencies",
-        "types",
-        "unlisted",
-        "unresolved",
-    ],
-
+const knipConfig: KnipConfig = {
+    ...config,
     ignore: [
-        // Used in a sneaky way by jest
-        "babel.jest.config.cjs",
+        ...config.ignore,
 
         // Temporarily exclude for transition to monorepo (legit issue)
         "packages/ui-common/components/AgentChat/Common/Types.ts",
 
         // Used by CommitCheck script
         "jest_quiet.config.ts",
-
-        // Generated type declaration for published dev-common eslint config; consumed by external projects
-        "packages/dev-common/Configs/eslint.config.d.mts",
     ],
-
     ignoreDependencies: [
-        // Used by jest
-        "@babel/core",
-        "@babel/preset-env",
-
+        ...config.ignoreDependencies,
         // Used for Speech Recognition API types
         "@types/dom-speech-recognition",
-
-        // Used by Jest
-        "babel-jest",
-
-        // Used internally by eslint
-        "globals",
 
         // Used by do_openapi_generate.sh
         "openapi-typescript",
@@ -105,13 +46,10 @@ const config: KnipConfig = {
     ],
 
     workspaces: {
-        "apps/main": {
-            ignoreDependencies: [
-                // Declared to satisfy eslint-config-next peer dep; lint itself runs from root
-                "eslint",
-            ],
+        "packages/dev-common": {
+            ignore: ["Configs/eslint.config.d.mts"],
         },
     },
 }
 
-export default config
+export default knipConfig

--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -100,10 +100,9 @@ export default defineConfig([
             parserOptions: {
                 ecmaFeatures: {jsx: true},
                 projectService: {
-                    allowDefaultProject: ["*.mjs", "*.ts"],
+                    allowDefaultProject: ["knip.config.ts"],
                     defaultProject: "../../../tsconfig.json",
                 },
-                tsconfigRootDir: import.meta.dirname,
             },
         },
 
@@ -596,6 +595,14 @@ export default defineConfig([
             "no-class-assign": "error",
             "import/no-anonymous-default-export": "error",
             "@typescript-eslint/no-empty-interface": "error",
+        },
+    },
+    {
+        files: ["**/eslint.config.mjs"],
+        languageOptions: {
+            parserOptions: {
+                projectService: false,
+            },
         },
     },
 ])

--- a/packages/dev-common/Configs/knip.config.ts
+++ b/packages/dev-common/Configs/knip.config.ts
@@ -56,21 +56,7 @@ export const config: RawConfiguration = {
         "unresolved",
     ],
 
-    ignore: [
-        // Used in a sneaky way by jest
-        "babel.jest.config.cjs",
-    ],
+    ignore: [],
 
-    ignoreDependencies: [
-        // Used by jest
-        "@babel/core",
-        "@babel/preset-env",
-        "babel-jest",
-
-        // Used internally by eslint
-        "globals",
-
-        // Used by Jest for TS format config file
-        "ts-node",
-    ],
+    ignoreDependencies: [],
 }

--- a/packages/dev-common/Configs/knip.config.ts
+++ b/packages/dev-common/Configs/knip.config.ts
@@ -21,7 +21,14 @@ import type {KnipConfig} from "knip"
  *
  */
 
-export const config: KnipConfig = {
+/**
+ * Knip's configuration type is a bit complex, but we know that the config object we are creating here is just a
+ * plain object with string keys and unknown values. So we narrow it here to make life easier for consumer projects.
+ * Note: knip does have a RawConfiguration type, but it is not exported for external consumption.
+ */
+type RawConfiguration = Extract<KnipConfig, Record<string, unknown>>
+
+export const config: RawConfiguration = {
     // From the doc:
     // "By default, Knip does not report unused exports in entry files. When a repository (or workspace) is
     // self-contained or private, you may want to include entry files when reporting unused exports:"

--- a/packages/dev-common/Configs/knip.config.ts
+++ b/packages/dev-common/Configs/knip.config.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {RawConfiguration} from "knip/dist/types/config"
+import type {KnipConfig} from "knip"
 
 /**
  * @fileoverview Knip configuration file to identify unused files and dependencies in the project.
  *
  */
 
-export const config: RawConfiguration = {
+export const config: KnipConfig = {
     // From the doc:
     // "By default, Knip does not report unused exports in entry files. When a repository (or workspace) is
     // self-contained or private, you may want to include entry files when reporting unused exports:"

--- a/packages/dev-common/Configs/knip.config.ts
+++ b/packages/dev-common/Configs/knip.config.ts
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {RawConfiguration} from "knip/dist/types/config"
+
+/**
+ * @fileoverview Knip configuration file to identify unused files and dependencies in the project.
+ *
+ */
+
+export const config: RawConfiguration = {
+    // From the doc:
+    // "By default, Knip does not report unused exports in entry files. When a repository (or workspace) is
+    // self-contained or private, you may want to include entry files when reporting unused exports:"
+    includeEntryExports: true,
+
+    // Treat hints as errors (will make exit code non-zero)
+    treatConfigHintsAsErrors: true,
+
+    // Opt-in to all issues types
+    include: [
+        "binaries",
+        "catalog",
+        "dependencies",
+        "devDependencies",
+        "duplicates",
+        "enumMembers",
+        "exports",
+        "files",
+        "namespaceMembers",
+        "nsExports",
+        "nsTypes",
+        "optionalPeerDependencies",
+        "types",
+        "unlisted",
+        "unresolved",
+    ],
+
+    ignore: [
+        // Used in a sneaky way by jest
+        "babel.jest.config.cjs",
+    ],
+
+    ignoreDependencies: [
+        // Used by jest
+        "@babel/core",
+        "@babel/preset-env",
+        "babel-jest",
+
+        // Used internally by eslint
+        "globals",
+
+        // Used by Jest for TS format config file
+        "ts-node",
+    ],
+}

--- a/packages/dev-common/package.json
+++ b/packages/dev-common/package.json
@@ -19,6 +19,7 @@
         "eslint-plugin-testing-library": "*",
         "eslint-plugin-unicorn": "*",
         "globals": "*",
+        "knip": "*",
         "typescript-eslint": "*"
     },
     "repository": {

--- a/packages/dev-common/package.json
+++ b/packages/dev-common/package.json
@@ -34,6 +34,10 @@
         "./eslint": {
             "types": "./Configs/eslint.config.d.mts",
             "default": "./Configs/eslint.config.mjs"
+        },
+        "./knip": {
+            "types": "./Configs/knip.config.ts",
+            "default": "./Configs/knip.config.ts"
         }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,6 +1506,7 @@ __metadata:
     eslint-plugin-testing-library: "*"
     eslint-plugin-unicorn: "*"
     globals: "*"
+    knip: "*"
     typescript-eslint: "*"
   languageName: unknown
   linkType: soft
@@ -1574,7 +1575,6 @@ __metadata:
     "@types/lodash-es": "npm:4.17.12"
     "@types/react": "npm:19.2.14"
     "@xyflow/react": "npm:12.10.1"
-    eslint: "npm:10.2.1"
     http-status: "npm:1.7.3"
     lodash-es: "npm:4.18.1"
     next: "npm:16.2.1"


### PR DESCRIPTION
Low risk PR, as it only affects knip.

Similarly to [ESLint](https://github.com/cognizant-ai-lab/neuro-san-ui/pull/285), this PR consolidates the common knip configuration items into a shared config in `dev-common`.

Not as huge a win as ESLint for reducing config file copy pasta, but a good foundation to build on as we evolve common rulesets.