### PR TITLE
#325 Fix Docker build issues (@mui/system issues)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,7 @@ catalogs:
         "@jest/globals": "30.4.0"
         "@jest/types": "30.4.1"
         "@langchain/core": "1.1.17"
+        "@mui/system": "7.3.11"
         "@testing-library/dom": "10.4.1"
         "@testing-library/react": "16.3.0"
         "@testing-library/user-event": "14.6.1"

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -16,7 +16,7 @@
         "@langchain/openai": "1.2.5",
         "@mui/icons-material": "7.3.1",
         "@mui/material": "7.3.1",
-        "@mui/system": "7.3.9",
+        "@mui/system": "catalog:default",
         "@mui/x-tree-view": "8.22.0",
         "http-status": "catalog:default",
         "lodash-es": "catalog:default",

--- a/packages/ui-common/package.json
+++ b/packages/ui-common/package.json
@@ -49,6 +49,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
+        "@mui/system": "^7.3.11",
         "@mui/x-tree-view": "^8.22.0",
         "next": "^16.2.1",
         "next-auth": "5.0.0-beta.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@ __metadata:
     "@langchain/openai": "npm:1.2.5"
     "@mui/icons-material": "npm:7.3.1"
     "@mui/material": "npm:7.3.1"
-    "@mui/system": "npm:7.3.9"
+    "@mui/system": "catalog:default"
     "@mui/x-tree-view": "npm:8.22.0"
     "@testing-library/dom": "catalog:default"
     "@testing-library/react": "catalog:default"
@@ -1520,6 +1520,7 @@ __metadata:
     "@emotion/styled": ^11.14.1
     "@mui/icons-material": ^7.3.1
     "@mui/material": ^7.3.1
+    "@mui/system": ^7.3.11
     "@mui/x-tree-view": ^8.22.0
     next: ^16.2.1
     next-auth: 5.0.0-beta.30
@@ -2841,7 +2842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^7.3.11, @mui/private-theming@npm:^7.3.9":
+"@mui/private-theming@npm:^7.3.11":
   version: 7.3.11
   resolution: "@mui/private-theming@npm:7.3.11"
   dependencies:
@@ -2858,7 +2859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/styled-engine@npm:^7.3.10, @mui/styled-engine@npm:^7.3.9":
+"@mui/styled-engine@npm:^7.3.10":
   version: 7.3.10
   resolution: "@mui/styled-engine@npm:7.3.10"
   dependencies:
@@ -2881,35 +2882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:7.3.9":
-  version: 7.3.9
-  resolution: "@mui/system@npm:7.3.9"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.6"
-    "@mui/private-theming": "npm:^7.3.9"
-    "@mui/styled-engine": "npm:^7.3.9"
-    "@mui/types": "npm:^7.4.12"
-    "@mui/utils": "npm:^7.3.9"
-    clsx: "npm:^2.1.1"
-    csstype: "npm:^3.2.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10c0/293e4e76e24d3517f8883fe7e8d1a640775a1e7e11b5e9917cd566238d0b0f71f799829d823a022b30a65c6c6f9257c1274a0aec9015b1b7b8d58b27de9d35d8
-  languageName: node
-  linkType: hard
-
-"@mui/system@npm:^7.3.1":
+"@mui/system@npm:7.3.11, @mui/system@npm:^7.3.1":
   version: 7.3.11
   resolution: "@mui/system@npm:7.3.11"
   dependencies:
@@ -2951,7 +2924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^7.3.1, @mui/utils@npm:^7.3.11, @mui/utils@npm:^7.3.5, @mui/utils@npm:^7.3.9":
+"@mui/utils@npm:^7.3.1, @mui/utils@npm:^7.3.11, @mui/utils@npm:^7.3.5":
   version: 7.3.11
   resolution: "@mui/utils@npm:7.3.11"
   dependencies:


### PR DESCRIPTION
Due to @mui/system shenanigans. Fallout from the "catalog" refactoring #289 

@mui/system has to be declared and included explicitly, or else you get issues like this when running `tsc`:

```
TS2742: The inferred type of 'LlmChatButton' cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary.
30 export const LlmChatButton = styled(Button, {
~~~~~~~~~~~~~
components/AgentChat/Common/LlmChatButton.tsx:42:14 - error TS2742: The inferred type of 'SmallLlmChatButton' cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary.
42 export const SmallLlmChatButton = styled(LlmChatButton)({
~~~~~~~~~~~~~~~~~~
components/Common/LlmChatOptionsButton.tsx:27:14 - error TS2742: The inferred type of 'LlmChatOptionsButton' cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary.
27 export const LlmChatOptionsButton = styled(Button, {
```

Perhaps related MUI [ticket](https://github.com/mui/material-ui/issues/43136).

I also moved the `@mui/system` version to the catalog for consistency. Previously we were pulling in a version that wasn't quite consistent with our other MUI deps -- probably harmless, but you never know.

Before this PR (slightly out of sync versions of `@mui/system`):

```script
❯ yarn why @mui/system
├─ @cognizant-ai-lab/neuro-san-web@workspace:apps/main
│  └─ @mui/system@npm:7.3.9 [bf2e4] (via npm:7.3.9 [bf2e4])
│
├─ @mui/material@npm:7.3.1
│  └─ @mui/system@npm:7.3.11 (via npm:^7.3.1)
│
└─ @mui/material@npm:7.3.1 [bf2e4]
   └─ @mui/system@npm:7.3.11 [506b8] (via npm:^7.3.1 [506b8])
```

After (consistent, single version of `@mui/system`):

```script
❯ yarn why @mui/system
├─ @cognizant-ai-lab/neuro-san-web@workspace:apps/main
│  └─ @mui/system@npm:7.3.11 [bf2e4] (via npm:7.3.11 [bf2e4])
│
├─ @mui/material@npm:7.3.1
│  └─ @mui/system@npm:7.3.11 (via npm:^7.3.1)
│
└─ @mui/material@npm:7.3.1 [bf2e4]
   └─ @mui/system@npm:7.3.11 [bf2e4] (via npm:^7.3.1 [506b8])
```