### PR TITLE
Enable more ESLint rules and fix issues

### DIFF
--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -325,8 +325,6 @@ export default defineConfig([
                 },
             ],
 
-            "react-hooks/exhaustive-deps": "error",
-
             // Rules we're not ready to enable yet
 
             // Requires strict type checks enabled in tsc which we're not ready for yet
@@ -448,11 +446,7 @@ export default defineConfig([
             "one-var": "off",
             "prefer-destructuring": "off",
             radix: "off",
-            "react-hooks/preserve-manual-memoization": "off",
-            "react-hooks/purity": "off",
-            "react-hooks/refs": "off",
             "react-hooks/set-state-in-effect": "off",
-            "react/button-has-type": "off",
             "react/destructuring-assignment": "off",
             "react/forbid-component-props": "off",
             // Causes an error: "context.getSourceCode is not a function" -- ESLint 10 issue?

--- a/packages/ui-common/__tests__/components/AgentChat/VoiceChat/MicrophoneButton.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/VoiceChat/MicrophoneButton.test.tsx
@@ -52,6 +52,7 @@ jest.mock("../../../../components/AgentChat/Common/LlmChatButton", () => ({
             onClick={onClick}
             disabled={disabled}
             data-testid="microphone-button"
+            type="button"
         >
             {children}
         </button>

--- a/packages/ui-common/__tests__/components/ChatBot/ChatBot.test.tsx
+++ b/packages/ui-common/__tests__/components/ChatBot/ChatBot.test.tsx
@@ -22,6 +22,7 @@ jest.mock("../../../components/AgentChat/ChatCommon/ChatCommon", () => ({
             <button
                 onClick={props.onClose}
                 data-testid="close-button"
+                type="button"
             >
                 Close
             </button>

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -127,7 +127,8 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
         customURLLocalStorage?.replaceAll('"', "") || backendNeuroSanApiUrl
     )
 
-    const agentCountsRef = useRef<Map<string, number>>(new Map())
+    // Tracks how many times each agent has been involved in the conversation
+    const [agentCounts, setAgentCounts] = useState<Map<string, number>>(new Map())
 
     const conversationsRef = useRef<AgentConversation[] | null>(null)
 
@@ -322,7 +323,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
             // If the selected network is one of the expired ones, deselect it
             if (expiredNetwork.some((n) => n.agentInfo.agent_name === selectedNetwork)) {
                 setSelectedNetwork(null)
-                agentCountsRef.current = new Map()
+                setAgentCounts(new Map())
             }
         }, EXPIRED_NETWORKS_CHECK_INTERVAL_MS)
 
@@ -344,8 +345,10 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                 setCurrentConversations(result)
             }
 
-            // Agent hit counts
-            agentCountsRef.current = getUpdatedAgentCounts(agentCountsRef.current, chatMessage?.origin)
+            // Update agent hit counts
+            setAgentCounts((prevCounts) => {
+                return getUpdatedAgentCounts(prevCounts, chatMessage.origin)
+            })
 
             // Agent network designer progress messages
             if (isNetworkDesignerMode) {
@@ -389,7 +392,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
 
     const onStreamingStarted = useCallback((): void => {
         // Reset agent counts
-        agentCountsRef.current = new Map()
+        setAgentCounts(new Map())
 
         // Reset newly added temporary networks
         setNewlyAddedTemporaryNetworks(new Set())
@@ -458,7 +461,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                         newlyAddedTemporaryNetworks={newlyAddedTemporaryNetworks}
                         onDeleteNetwork={handleDeleteNetwork}
                         setSelectedNetwork={(newNetwork) => {
-                            agentCountsRef.current = new Map()
+                            setAgentCounts(new Map())
                             setSelectedNetwork(newNetwork)
                         }}
                         temporaryNetworks={temporaryNetworks}
@@ -491,7 +494,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                         }}
                     >
                         <AgentFlow
-                            agentCounts={agentCountsRef.current}
+                            agentCounts={agentCounts}
                             agentsInNetwork={agentsInNetwork}
                             agentIconSuggestions={agentIconSuggestions}
                             currentUser={userInfo.userName}
@@ -505,7 +508,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                             neuroSanURL={neuroSanURL}
                             onNetworkReplaced={(oldNetworkId, newNetworkId) => {
                                 if (selectedNetwork === oldNetworkId) {
-                                    agentCountsRef.current = new Map()
+                                    setAgentCounts(new Map())
                                     setSelectedNetwork(newNetworkId)
                                 }
                             }}

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -471,6 +471,16 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
         )
     }
 
+    const onNetworkReplaced = useCallback(
+        (oldNetworkId: string, newNetworkId: string) => {
+            if (selectedNetwork === oldNetworkId) {
+                setAgentCounts(new Map())
+                setSelectedNetwork(newNetworkId)
+            }
+        },
+        [selectedNetwork]
+    )
+
     const getCenterPanel = () => {
         return (
             <Grid
@@ -506,12 +516,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                             isSelectedNetworkTemporary={isSelectedNetworkTemporary}
                             networkId={isSelectedNetworkTemporary ? selectedNetwork : undefined}
                             neuroSanURL={neuroSanURL}
-                            onNetworkReplaced={(oldNetworkId, newNetworkId) => {
-                                if (selectedNetwork === oldNetworkId) {
-                                    setAgentCounts(new Map())
-                                    setSelectedNetwork(newNetworkId)
-                                }
-                            }}
+                            onNetworkReplaced={onNetworkReplaced}
                             thoughtBubbleEdges={thoughtBubbleEdges}
                             setThoughtBubbleEdges={setThoughtBubbleEdges}
                         />

--- a/packages/ui-common/components/MultiAgentAccelerator/ThoughtBubbleOverlay.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/ThoughtBubbleOverlay.tsx
@@ -127,6 +127,14 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
     isStreaming = false,
     onBubbleHoverChange,
 }) => {
+    /**
+     * A pure, managed timestamp that can be safely referenced during renders.
+     * Instead of calling the impure Date.now() directly in the render phase (which violates React's purity rules
+     * and triggers linting warnings), the component captures timestamps at controlled moments and stores them
+     * in state.
+     */
+    const [time, setTime] = useState(() => Date.now())
+
     // hoveredBubbleId: id of currently hovered bubble (or null)
     const [hoveredBubbleId, setHoveredBubbleId] = useState<string | null>(null)
     // truncatedBubbles: set of edge ids whose text overflows the collapsed box
@@ -149,6 +157,15 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
     // rAF ref for scheduling post-paint updates
     const rafRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(null)
     const mountedRef = useRef(true)
+
+    // Effect to update `time` every second to trigger re-renders for animation timing and line updates.
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setTime(Date.now())
+        }, 250)
+
+        return () => clearInterval(interval)
+    }, [])
 
     // Filter edges with meaningful text (memoized to prevent infinite re-renders)
     const thoughtBubbleEdges = useMemo(
@@ -183,9 +200,8 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
 
             // Add new bubbles in entering state. Record when they entered so we can delay showing
             // connecting lines until the bubble's entrance animation delay.
-            const now = Date.now()
             newBubbles.forEach((edge) => {
-                newState.set(edge.id, {isVisible: true, isExiting: false, enteredAt: now})
+                newState.set(edge.id, {isVisible: true, isExiting: false, enteredAt: time})
             })
 
             // Mark removing bubbles as exiting
@@ -216,7 +232,7 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
 
             return newState
         })
-    }, [thoughtBubbleEdges])
+    }, [thoughtBubbleEdges, time])
 
     // Cleanup timeouts on unmount
     useEffect(() => {
@@ -248,9 +264,9 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
         for (const node of nodes) {
             const getConversations = node.data?.["getConversations"]
             if (typeof getConversations === "function") {
-                const convs = getConversations()
-                if (Array.isArray(convs)) {
-                    const hasSelf = convs.some((conv) => conv?.agents?.has?.(node.id))
+                const conversations = getConversations()
+                if (Array.isArray(conversations)) {
+                    const hasSelf = conversations.some((conversation) => conversation?.agents?.has?.(node.id))
                     if (hasSelf) {
                         set.add(node.id)
                     }
@@ -414,7 +430,7 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
                 if (!bubbleState.isVisible || bubbleState.isExiting) return
 
                 // Respect the entrance animation delay gating (lines appear only after bubble start)
-                const elapsed = Date.now() - (bubbleState?.enteredAt ?? 0)
+                const elapsed = time - (bubbleState?.enteredAt ?? 0)
                 const animationDelay = index * LAYOUT_BUBBLES_ANIMATION_DELAY_MS
                 if (elapsed < animationDelay) return
 
@@ -440,7 +456,7 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
 
             console.error("ThoughtBubbleOverlay: updateAllLines error", err)
         }
-    }, [renderableBubbles, bubbleStates, calculateLineCoordinates])
+    }, [bubbleStates, calculateLineCoordinates, renderableBubbles, time])
 
     // Schedule post-paint updates with rAF and ResizeObserver. Also, optionally run a
     // continuous loop while `isStreaming` is true to keep lines in sync during streaming.
@@ -525,7 +541,7 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
                     if (!bubbleState.isVisible) return null
 
                     // Only render lines after the bubble's entrance animation delay has elapsed.
-                    const elapsed = Date.now() - (bubbleState.enteredAt || 0)
+                    const elapsed = time - (bubbleState.enteredAt || 0)
                     const shouldShowLines = elapsed >= animationDelay
                     if (!shouldShowLines) return null
 


### PR DESCRIPTION
Enables almost all¹ the very useful and important `react-hooks` rules and fixes the few issues that resulted.
These linter rules come straight from the React Dev team and help us use React properly. Violating them can lead to subtle bugs that will haunt us, so let's have the linter keep us honest and following React best practices.

¹Unfortunately not `react-hooks/set-state-in-effect`. Too many violations and will need to be a separate PR. 

Can't add Copilot here because,

```
You have reached your monthly limit for [premium requests](https://docs.github.com/en/copilot/concepts/copilot-billing/understanding-and-managing-requests-in-copilot) for Copilot code review. Limit resets on June 1, 2026, at 12:00 am.
```

Local IDE Copilot has looked at it and helped with it though.