### PR TITLE
Bump ui-common version to 1.5.0

### DIFF
--- a/packages/ui-common/package.json
+++ b/packages/ui-common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cognizant-ai-lab/ui-common",
     "description": "A shared UI component library for Cognizant AI Labs projects",
-    "version": "1.2.4",
+    "version": "1.5.0",
     "type": "module",
     "scripts": {
         "build": "yarn clean && yarn generate && yarn run --top-level tsc --project tsconfig.build.json && fix-esm-import-path dist > /dev/null",


### PR DESCRIPTION
## Summary

The bump-version CI job never worked prior to #314, so `packages/ui-common/package.json` still reads `1.2.4`. This one-line change brings it in line with the current `1.5.0` release tag.

Link to Devin session: https://app.devin.ai/sessions/58933069a4904db280f7eb74a70b90bf
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->