### PR TITLE
Fix linter warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,11 +8,6 @@ import sharedConfig from "./packages/dev-common/Configs/eslint.config.mjs"
 export default defineConfig([
     ...sharedConfig,
     {
-        settings: {
-            next: {
-                rootDir: "apps/main",
-            },
-        },
         rules: {
             // Override inherit configs as necessary for this project
             "@next/next/no-html-link-for-pages": ["warn", "apps/main/pages"],

--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -125,6 +125,9 @@ export default defineConfig([
         rules: {
             ...next.configs.recommended.rules,
 
+            // Disable by default - consumers must configure with their project-specific pages path
+            "@next/next/no-html-link-for-pages": "off",
+
             // Turn on some optional, stricter settings for this rule
             "react/jsx-key": [
                 "error",


### PR DESCRIPTION
This was the warning on `yarn lint`:

```
Pages directory cannot be found at .../neuro-san-ui/pages or .../neuro-san-ui/src/pages. If using a custom path, please configure with the `no-html-link-for-pages` rule in your eslint config file.
```

Kind of related ticket: https://github.com/vercel/next.js/issues/51710

The fix is, I made the rule "opt in" so in the default config it's disabled, and consumer projects have to enable it and specify where their Next.js stuff lives. That gets rid of the warning and leaves the linter rules (mostly) intact.

More detailed explanation:

Not the best fix. The rule seems kinda buggy especially in how it locates the Next.js dir. I did some deeper debugging, and found that the warning comes from files like the shared `knip.config.ts` and shared `eslint.config.mjs`. These aren't scooped up by any `tsconfig` so they are technically "not in the project". Therefore, the rule configuration ends up "not applying to them" because they aren't targeted by any files pattern: by default ESLint only targets files that are "included in a tsconfig somewhere".

`"@next/next/no-html-link-for-pages": ["warn", "apps/main/pages"],`

This is the rule config. Note that it overrides the Next.js default locations, which are `./pages` and `./src/pages`. Neither of those defaults applies to our project structure, so we have to override. But, that override only applies to "files that are in the project" (found by a pattern in some tsconfig in the hierarchy) which things like `knip.config.ts` and `eslint.config.mjs` are not.

Here's the relevant [code](https://github.com/vercel/next.js/blob/e2b0d2eadccf2a4ebceb8987b02faa9791f849b7/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts#L77) from the linter rule:

```typescript
    const ruleOptions: (string | string[])[] = context.options
    const [customPagesDirectory] = ruleOptions

    const rootDirs = getRootDirs(context)

    const pagesDirs = (
      customPagesDirectory
        ? [customPagesDirectory]
        : rootDirs.map((dir) => [
            path.join(dir, 'pages'),
            path.join(dir, 'src', 'pages'),
          ])
    ).flat()
```

For files that are "outlaws", meaning not captured by `tsconfig` patterns, that `context` is empty since, as explained above, ESLint only applies the context to files that are "in the project". Result, no context, so it defaults to the hardcoded, "expected" Next.js dirs, `./pages` and `./src/pages`, neither of which we have, resulting in the linter warning 💥 
