### PR TITLE
#259 Disable all next-auth functionality when authentication is off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Node/NextJS/dotenv things
-.env*
+.env
 .env.local
 **/.next
 **/next-env.d.ts

--- a/apps/main/.env.sample
+++ b/apps/main/.env.sample
@@ -1,0 +1,14 @@
+# Determines which backend neuro-san server to access. This one is for the Dev environment -- change as necessary.
+NEURO_SAN_SERVER_URL=<URL for your neuro-san server including port number>
+
+# Set this to false for testing or authentication via load balancer (recommended)
+NEXT_PUBLIC_ENABLE_AUTHENTICATION=false
+
+# Set this to your OpenAI API key (required)
+OPENAI_API_KEY=<Your OpenAI API key here>
+
+# Set this to your support email address
+SUPPORT_EMAIL_ADDRESS=test@example.com
+
+# Set this to your Logo.dev token (for automated logo suggestions in the UI)
+LOGO_SERVICE_TOKEN=<Your logo service token here>

--- a/apps/main/__tests__/pages/App.test.tsx
+++ b/apps/main/__tests__/pages/App.test.tsx
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import type {EnvironmentResponse} from "../../pages/api/environment/Types"
 import {render, screen, waitFor} from "@testing-library/react"
 import {default as userEvent, UserEvent} from "@testing-library/user-event"
 import {useRouter} from "next/router"
@@ -21,7 +22,7 @@ import {ReactNode} from "react"
 
 import {withStrictMocks} from "../../../../__tests__/common/strictMocks"
 import {mockFetch} from "../../../../__tests__/common/TestUtils"
-import {authenticationEnabled, DEFAULT_NEURO_SAN_SERVER_URL} from "../../../../packages/ui-common/const"
+import {authenticationEnabled} from "../../../../packages/ui-common/const"
 import {useEnvironmentStore} from "../../../../packages/ui-common/state/Environment"
 import {useAuthentication} from "../../../../packages/ui-common/utils/Authentication"
 import NeuroSanUI from "../../pages/_app"
@@ -59,6 +60,8 @@ describe("Main App Component", () => {
     const testClientId = "testClientId"
     const testDomain = "testDomain"
     const testSupportEmailAddress = "test@example.com"
+    const testLogoServiceToken = "testLogoServiceToken"
+
     beforeEach(() => {
         ;(useAuthentication as jest.Mock).mockReturnValue({
             data: {user: {name: "mock-user", image: "mock-image-url"}},
@@ -71,18 +74,20 @@ describe("Main App Component", () => {
             auth0ClientId: null,
             auth0Domain: null,
             supportEmailAddress: null,
+            logoServiceToken: null,
         })
 
         user = userEvent.setup()
 
-        window.fetch = mockFetch({
+        const mockEnvironmentResponse: EnvironmentResponse = {
             backendNeuroSanApiUrl: testNeuroSanURL,
             auth0ClientId: testClientId,
             auth0Domain: testDomain,
             supportEmailAddress: testSupportEmailAddress,
-            oidcHeaderFound: true,
-            username: "testUser",
-        })
+            logoServiceToken: testLogoServiceToken,
+        }
+
+        window.fetch = mockFetch(mockEnvironmentResponse as Record<string, unknown>)
         ;(useRouter as jest.Mock).mockReturnValue({
             pathname: "/projects",
         })
@@ -113,6 +118,7 @@ describe("Main App Component", () => {
         expect(state.auth0ClientId).toBe(testClientId)
         expect(state.auth0Domain).toBe(testDomain)
         expect(state.supportEmailAddress).toBe(testSupportEmailAddress)
+        expect(state.logoServiceToken).toBe(testLogoServiceToken)
     })
 
     it("Should render correctly when authentication is disabled", async () => {
@@ -124,10 +130,11 @@ describe("Main App Component", () => {
 
         // No authentication so values should be defaults
         const state = useEnvironmentStore.getState()
-        expect(state.backendNeuroSanApiUrl).toBe(DEFAULT_NEURO_SAN_SERVER_URL)
+        expect(state.backendNeuroSanApiUrl).toBe(testNeuroSanURL)
         expect(state.auth0ClientId).toBe("")
         expect(state.auth0Domain).toBe("")
-        expect(state.supportEmailAddress).toBe("")
+        expect(state.supportEmailAddress).toBe(testSupportEmailAddress)
+        expect(state.logoServiceToken).toBe(testLogoServiceToken)
     })
 
     it("Should handle failure to fetch environment variables", async () => {
@@ -148,6 +155,7 @@ describe("Main App Component", () => {
         expect(state.auth0ClientId).toBe(null)
         expect(state.auth0Domain).toBe(null)
         expect(state.supportEmailAddress).toBe(null)
+        expect(state.logoServiceToken).toBe(null)
 
         expect(consoleSpy).toHaveBeenCalledTimes(2)
 

--- a/apps/main/instrumentation.ts
+++ b/apps/main/instrumentation.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /**
- * This file executes at NextJS startup. It is intended for injecting instrumentation and monitoring but here
+ * This file executes at Next.js startup. It is intended for injecting instrumentation and monitoring but here
  * we are using it to check that the environment variables are set correctly.
  *
  * @see https://nextjs.org/docs/app/guides/instrumentation
@@ -27,15 +27,22 @@ import {authenticationEnabled} from "@cognizant-ai-lab/ui-common/const"
  * List of environment variables that are required for the app to run. If any of these are not set, the app will
  * exit with an error message.
  */
-export const REQUIRED_ENV_VARS = ["NEURO_SAN_SERVER_URL", "SUPPORT_EMAIL_ADDRESS"]
+export const REQUIRED_ENV_VARS = ["NEURO_SAN_SERVER_URL", "OPENAI_API_KEY", "SUPPORT_EMAIL_ADDRESS"]
 
-export const REQUIRED_FOR_AUTH_ENV_VARS = ["AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_DOMAIN", "AUTH0_ISSUER"]
+export const REQUIRED_FOR_AUTH_ENV_VARS = [
+    "AUTH0_CLIENT_ID",
+    "AUTH0_CLIENT_SECRET",
+    "AUTH0_DOMAIN",
+    "AUTH0_ISSUER",
+    "NEXTAUTH_SECRET",
+    "NEXTAUTH_URL",
+]
 
 /**
  * List of environment variables that are optional. If any of these are not set, the app will log a warning but will
  * continue to run. These are typically used for optional features that have a fallback if the env var is not set.
  */
-export const OPTIONAL_ENV_VARS = ["LOGO_SERVICE_TOKEN", "OPENAI_API_KEY"]
+export const OPTIONAL_ENV_VARS = ["LOGO_SERVICE_TOKEN"]
 
 export const register = () => {
     // Always required env vars

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -41,13 +41,7 @@ import {
     Snackbar,
     useAuthentication,
 } from "../../../packages/ui-common"
-import {
-    authenticationEnabled,
-    DEFAULT_NEURO_SAN_SERVER_URL,
-    DEFAULT_USER_IMAGE,
-    DEFAULT_USERNAME,
-    LOGO,
-} from "../../../packages/ui-common/const"
+import {authenticationEnabled, DEFAULT_USER_IMAGE, DEFAULT_USERNAME, LOGO} from "../../../packages/ui-common/const"
 import {useEnvironmentStore} from "../../../packages/ui-common/state/Environment"
 import {useSettingsStore} from "../../../packages/ui-common/state/Settings"
 import {useUserInfoStore} from "../../../packages/ui-common/state/UserInfo"
@@ -154,17 +148,6 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
 
     useEffect(() => {
         const getEnvironment = async () => {
-            if (!authenticationEnabled()) {
-                // Authentication is disabled, so we don't need to get environment variables
-                setBackendNeuroSanApiUrl(
-                    process.env["NEXT_PUBLIC_NEURO_SAN_SERVER_URL"] ?? DEFAULT_NEURO_SAN_SERVER_URL
-                )
-                setAuth0ClientId("")
-                setAuth0Domain("")
-                setSupportEmailAddress(process.env["NEXT_PUBLIC_SUPPORT_EMAIL_ADDRESS"] ?? "")
-                return
-            }
-
             // Fetch environment settings.
             // Save these in the zustand store so that subsequent pages will not need to fetch them again
             const res = await fetch("/api/environment", {
@@ -181,14 +164,22 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
                 return
             }
 
+            // Retrieve environment variables from response
             const data: EnvironmentResponse = await res.json()
 
-            // Save env vars in zustand store
+            // We should always have these whether authentication is enabled or not
             setBackendNeuroSanApiUrl(data.backendNeuroSanApiUrl)
-            setAuth0ClientId(data.auth0ClientId)
-            setAuth0Domain(data.auth0Domain)
             setSupportEmailAddress(data.supportEmailAddress)
             setLogoServiceToken(data.logoServiceToken)
+
+            if (authenticationEnabled()) {
+                // save Auth0 settings if authentication is enabled.
+                setAuth0ClientId(data.auth0ClientId)
+                setAuth0Domain(data.auth0Domain)
+            } else {
+                setAuth0ClientId("")
+                setAuth0Domain("")
+            }
         }
 
         void getEnvironment()

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -26,7 +26,7 @@ import Head from "next/head"
 import {useRouter} from "next/router"
 import {SessionProvider} from "next-auth/react"
 import {SnackbarProvider} from "notistack"
-import {ReactElement, JSX as ReactJSX, ReactNode, useEffect, useState} from "react"
+import {FC, ReactElement, JSX as ReactJSX, ReactNode, useEffect, useState} from "react"
 
 import {
     Auth,
@@ -86,6 +86,14 @@ const NavbarWrapper = (props: Omit<NavbarProps, "userInfo">): ReactElement => {
         />
     )
 }
+
+/**
+ * Shim to conditionally wrap the app in a SessionProvider if authentication is enabled.
+ * Allows us to avoid next-auth errors when authentication is disabled
+ */
+// eslint-disable-next-line react/no-multi-comp -- used only within this module
+const NullableSessionProvider: FC<{children: ReactNode}> = ({children}) =>
+    authenticationEnabled() ? <SessionProvider>{children}</SessionProvider> : <>{children}</>
 
 // Main function.
 // eslint-disable-next-line react/no-multi-comp
@@ -302,10 +310,7 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
         body = (
             <>
                 <CssBaseline />
-                {/*Note: Still need the NextAuth SessionProvider even in ALB case since we have to use useSession
-                unconditionally due to React hooks rules. But it doesn't interfere with ALB log on and will be
-                removed when we fully switch to ALB auth.*/}
-                <SessionProvider>
+                <NullableSessionProvider>
                     <ErrorBoundary id="error_boundary">
                         <NavbarWrapper
                             id="nav-bar"
@@ -338,7 +343,7 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
                             sx={{borderTop: "none", marginTop: 0}}
                         />
                     </ErrorBoundary>
-                </SessionProvider>
+                </NullableSessionProvider>
             </>
         )
     }

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -45,6 +45,7 @@ import {
     authenticationEnabled,
     DEFAULT_NEURO_SAN_SERVER_URL,
     DEFAULT_USER_IMAGE,
+    DEFAULT_USERNAME,
     LOGO,
 } from "../../../packages/ui-common/const"
 import {useEnvironmentStore} from "../../../packages/ui-common/state/Environment"
@@ -197,7 +198,7 @@ export default function NeuroSanUI({Component, pageProps}: ExtendedAppProps): Re
         const getUserInfo = async () => {
             if (!authenticationEnabled()) {
                 // Authentication is disabled, so we don't need to get user info
-                setCurrentUser("Guest")
+                setCurrentUser(DEFAULT_USERNAME)
                 setPicture(DEFAULT_USER_IMAGE)
                 setOidcProvider("None")
                 return

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -72,10 +72,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -102,
+            statements: -103,
             branches: -160,
             functions: -26,
-            lines: -79,
+            lines: -80,
         },
     },
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -72,10 +72,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -103,
-            branches: -160,
+            statements: -101,
+            branches: -155,
             functions: -26,
-            lines: -80,
+            lines: -78,
         },
     },
 

--- a/packages/ui-common/__tests__/unit/Utils/Authentication.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/Authentication.test.ts
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {renderHook} from "@testing-library/react"
 import {signOut} from "next-auth/react"
 
 import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
 import {mockFetch} from "../../../../../__tests__/common/TestUtils"
-import {AD_TENANT_ID, smartSignOut} from "../../../utils/Authentication"
+import {DEFAULT_USER_IMAGE, DEFAULT_USERNAME} from "../../../const"
+import {AD_TENANT_ID, smartSignOut, useAuthentication} from "../../../utils/Authentication"
 import * as BrowserNavigation from "../../../utils/BrowserNavigation"
 import {navigateToUrl} from "../../../utils/BrowserNavigation"
 
@@ -39,42 +41,56 @@ describe("useAuthentication", () => {
 
         oldFetch = window.fetch
         window.fetch = mockFetch({})
+
+        process.env["NEXT_PUBLIC_ENABLE_AUTHENTICATION"] = "true"
     })
 
     afterEach(() => {
         window.fetch = oldFetch
     })
 
-    it("Does nothing if currentUser not available", async () => {
-        ;(signOut as jest.Mock).mockResolvedValueOnce(undefined)
-
-        await smartSignOut(undefined, null, null, null)
-
-        expect(signOut).not.toHaveBeenCalled()
-        expect(navigateToUrl).not.toHaveBeenCalled()
+    describe("useAuthentication", () => {
+        it("Returns default user when authentication is disabled", () => {
+            // Disable auth for this test
+            process.env["NEXT_PUBLIC_ENABLE_AUTHENTICATION"] = "false"
+            const {result} = renderHook(() => useAuthentication())
+            expect(result.current.data.user.name).toBe(DEFAULT_USERNAME)
+            expect(result.current.data.user.image).toBe(DEFAULT_USER_IMAGE)
+        })
     })
 
-    it("Delegates to NextAuth signOut() if provider is NextAuth", async () => {
-        await smartSignOut("user", null, null, "NextAuth")
+    describe("signOut", () => {
+        it("Does nothing if currentUser not available", async () => {
+            ;(signOut as jest.Mock).mockResolvedValueOnce(undefined)
 
-        expect(signOut).toHaveBeenCalled()
-    })
+            await smartSignOut(undefined, null, null, null)
 
-    it("Handles sign-out for ALB with AD provider", async () => {
-        await smartSignOut("user", "example.com", "clientId", "AD")
-        expect(navigateToUrl).toHaveBeenCalledWith(
-            `https://login.microsoftonline.com/${AD_TENANT_ID}/oauth2/v2.0/logout`
-        )
-    })
+            expect(signOut).not.toHaveBeenCalled()
+            expect(navigateToUrl).not.toHaveBeenCalled()
+        })
 
-    it("Handles sign-out for ALB with Github provider", async () => {
-        const auth0Domain = "example.com"
-        const auth0ClientId = "clientId"
-        await smartSignOut("user", auth0Domain, auth0ClientId, "Github")
+        it("Delegates to NextAuth signOut() if provider is NextAuth", async () => {
+            await smartSignOut("user", null, null, "NextAuth")
 
-        const expectedReturnTo = encodeURIComponent(`http://${window.location.host}`)
-        expect(navigateToUrl).toHaveBeenCalledWith(
-            `https://${auth0Domain}/v2/logout?client_id=${auth0ClientId}&returnTo=${expectedReturnTo}`
-        )
+            expect(signOut).toHaveBeenCalled()
+        })
+
+        it("Handles sign-out for ALB with AD provider", async () => {
+            await smartSignOut("user", "example.com", "clientId", "AD")
+            expect(navigateToUrl).toHaveBeenCalledWith(
+                `https://login.microsoftonline.com/${AD_TENANT_ID}/oauth2/v2.0/logout`
+            )
+        })
+
+        it("Handles sign-out for ALB with Github provider", async () => {
+            const auth0Domain = "example.com"
+            const auth0ClientId = "clientId"
+            await smartSignOut("user", auth0Domain, auth0ClientId, "Github")
+
+            const expectedReturnTo = encodeURIComponent(`http://${window.location.host}`)
+            expect(navigateToUrl).toHaveBeenCalledWith(
+                `https://${auth0Domain}/v2/logout?client_id=${auth0ClientId}&returnTo=${expectedReturnTo}`
+            )
+        })
     })
 })

--- a/packages/ui-common/const.ts
+++ b/packages/ui-common/const.ts
@@ -26,6 +26,12 @@ export const getContactUsConfirmationText = (email: string): string =>
     `${email} using a web based email client.`
 
 /**
+ * The default username to use when the user is not authenticated or does not have a name available, or when
+ * auentication is disabled
+ */
+export const DEFAULT_USERNAME = "Guest"
+
+/**
  * The default user image to use when the user does not have a profile picture.
  */
 export const DEFAULT_USER_IMAGE = "https://www.gravatar.com/avatar/?d=mp"

--- a/packages/ui-common/const.ts
+++ b/packages/ui-common/const.ts
@@ -37,6 +37,3 @@ export const DEFAULT_USERNAME = "Guest"
 export const DEFAULT_USER_IMAGE = "https://www.gravatar.com/avatar/?d=mp"
 
 export const authenticationEnabled = (): boolean => process.env["NEXT_PUBLIC_ENABLE_AUTHENTICATION"] !== "false"
-
-// Default "dev URL" for NeuroSan server, to allow for "zero config" execution.
-export const DEFAULT_NEURO_SAN_SERVER_URL = "https://neuro-san-dev.decisionai.ml"

--- a/packages/ui-common/utils/Authentication.ts
+++ b/packages/ui-common/utils/Authentication.ts
@@ -20,6 +20,7 @@ import {signOut, useSession} from "next-auth/react"
 
 import {navigateToUrl} from "./BrowserNavigation"
 import {OidcProvider} from "./types"
+import {authenticationEnabled} from "../const"
 import {useUserInfoStore} from "../state/UserInfo"
 
 /**
@@ -33,11 +34,16 @@ export const AD_TENANT_ID = "de08c407-19b9-427d-9fe8-edf254300ca7"
  * of NextAuth's useSession hook.
  */
 export const useAuthentication = () => {
+    if (!authenticationEnabled()) {
+        // Auth disabled: return a stub
+        return {data: {user: {name: undefined, image: undefined}}}
+    }
+    // Auth enabled: safe to call hooks. Despite the conditional test above, we are guaranteed that
+    // authenticationEnabled is constant for a given build, so we won't be violating the rules of hooks.
+    /* eslint-disable react-hooks/rules-of-hooks */
     const {data: session} = useSession()
     const {currentUser: albUser, picture: albPicture} = useUserInfoStore()
-
-    // Return the user data in the same format as NextAuth's useSession hook. We prioritize the ALB info if we have
-    // it, but if not degrade gracefully to the NextAuth info.
+    /* eslint-enable react-hooks/rules-of-hooks */
     return {
         data: {
             user: {
@@ -87,7 +93,7 @@ export const smartSignOut = async (
     auth0ClientId: string,
     oidcProvider: OidcProvider
 ) => {
-    if (currentUser === undefined) {
+    if (currentUser === undefined || !authenticationEnabled()) {
         // Don't know what authentication provider we're using, so just return
         return
     }

--- a/packages/ui-common/utils/Authentication.ts
+++ b/packages/ui-common/utils/Authentication.ts
@@ -20,7 +20,7 @@ import {signOut, useSession} from "next-auth/react"
 
 import {navigateToUrl} from "./BrowserNavigation"
 import {OidcProvider} from "./types"
-import {authenticationEnabled} from "../const"
+import {authenticationEnabled, DEFAULT_USER_IMAGE, DEFAULT_USERNAME} from "../const"
 import {useUserInfoStore} from "../state/UserInfo"
 
 /**
@@ -36,7 +36,7 @@ export const AD_TENANT_ID = "de08c407-19b9-427d-9fe8-edf254300ca7"
 export const useAuthentication = () => {
     if (!authenticationEnabled()) {
         // Auth disabled: return a stub
-        return {data: {user: {name: undefined, image: undefined}}}
+        return {data: {user: {name: DEFAULT_USERNAME, image: DEFAULT_USER_IMAGE}}}
     }
     // Auth enabled: safe to call hooks. Despite the conditional test above, we are guaranteed that
     // authenticationEnabled is constant for a given build, so we won't be violating the rules of hooks.


### PR DESCRIPTION
Properly degrades gracefully to "anonymous" when authentication is disabled, with no ugly `next-auth` errors in the log.

Also addresses https://github.com/cognizant-ai-lab/neuro-san-ui/issues/259 and paves the way for https://github.com/cognizant-ai-lab/neuro-san-studio/issues/773
