### PR TITLE
Make editable node more obvious - #301

### DIFF
--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
@@ -18,6 +18,7 @@ limitations under the License.
 // eslint-disable-next-line no-restricted-imports
 import * as MuiIcons from "@mui/icons-material"
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome"
+// import EditOutlinedIcon from "@mui/icons-material/EditOutlined"
 import HandymanIcon from "@mui/icons-material/Handyman"
 import PersonIcon from "@mui/icons-material/Person"
 import TravelExploreIcon from "@mui/icons-material/TravelExplore"
@@ -53,6 +54,7 @@ export const NODE_WIDTH = 100
 // Icon sizes
 // These are used to set the size of the icons displayed in the agent nodes.
 const AGENT_ICON_SIZE = "2.25rem"
+const EDIT_BADGE_SIZE = "1.5rem"
 const FRONTMAN_ICON_SIZE = "4.5rem"
 
 // Pulsing glow animation for when an agent is active.
@@ -214,14 +216,46 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
                 isActive={isActiveAgent}
                 sx={{
                     backgroundColor,
+                    border: isEditable ? `2px solid ${theme.palette.primary.main}` : "2px solid transparent",
+                    boxShadow: isEditable ? `0 0 0 0.1875rem ${theme.palette.primary.main}33` : "none",
                     color,
                     cursor: isEditable ? "pointer" : "grab",
                     height: NODE_HEIGHT * (isFrontman ? 1.25 : 1.0),
+                    transition: theme.transitions.create(["border-color", "box-shadow", "transform"], {
+                        duration: theme.transitions.duration.short,
+                    }),
                     width: NODE_WIDTH * (isFrontman ? 1.25 : 1.0),
                     zIndex: getZIndex(1, theme),
+                    "&:hover": {
+                        boxShadow: isEditable ? `0 0 0 0.25rem ${theme.palette.primary.main}55` : "none",
+                        transform: isEditable ? "scale(1.04)" : "none",
+                    },
                 }}
             >
                 {getDisplayAsIcon()}
+                {/* isEditable && (
+                    <EditOutlinedIcon
+                        aria-hidden
+                        sx={{
+                            alignItems: "center",
+                            backgroundColor,
+                            border: `1px solid ${theme.palette.primary.main}`,
+                            borderRadius: "50%",
+                            boxShadow: theme.shadows[2],
+                            color: theme.palette.primary.main,
+                            display: "flex",
+                            fontSize: "1rem",
+                            height: EDIT_BADGE_SIZE,
+                            justifyContent: "center",
+                            padding: "0.1875rem",
+                            pointerEvents: "none",
+                            position: "absolute",
+                            right: "-0.25rem",
+                            top: "-0.25rem",
+                            width: EDIT_BADGE_SIZE,
+                        }}
+                    />
+                ) */}
                 <Handle
                     id={`${agentId}-left-handle`}
                     position={Position.Left}


### PR DESCRIPTION
# Description

Make editable node more obvious - #301

# Screenshot 
### This is more subtle, but on hover the node becomes larger. May need another indicator that's not tied to hover.

https://github.com/user-attachments/assets/b93a819f-e852-4b70-8bcf-c2f4515e091d

# Screenshot with edit icon
### Another idea, currently commented out. I don't quite like it as much, but it could be refined.

<img width="803" height="904" alt="Screenshot 2026-05-15 at 5 01 38 PM" src="https://github.com/user-attachments/assets/f65c94f5-82e3-4884-ae8a-5d23ba12833e" />
