### PR TITLE
Migrate test.yml to build-common setup-node-env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,9 +66,7 @@ jobs:
               # v1.0.7
               uses: cognizant-ai-lab/build-common/actions/setup-node-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
               with:
-                  # Pinned version. 22.18+ breaks tests due to
-                  # https://github.com/nodejs/node/issues/59364
-                  node-version: "22.17.1"
+                  node-version: ${{ vars.NODEJS_VERSION }}
                   clean-install: "true"
 
             - name: Install prerequisites for code generation


### PR DESCRIPTION
## Summary

Switches `test.yml` from a hardcoded `node-version: \"22.17.1\"` to `${{ vars.NODEJS_VERSION }}`, relying on the repo-level variable for version consistency. The setup-node-env migration itself (build-common 1.0.7) was already merged on main; this PR adds the variable-based pinning.

Link to Devin session: https://app.devin.ai/sessions/5af2ecdfbaf04a0cb7bbf4cfa9f469c4
Requested by: @donn-leaf