### PR TITLE
Migrate test.yml to build-common composites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
               uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697 # 1.0.6
               with:
                   node-version: ${{ vars.NODEJS_VERSION }}
-                  clean-install: 'true'
+                  clean-install: "true"
 
             - name: Install prerequisites for code generation
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,36 +56,24 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   ref: ${{ inputs.revision || github.ref }}
 
-            # Install yarn version from package.json packageManager field using corepack
-            # "corepack install" reads package.json and installs the right yarn version from the packageManager field
-            - name: Set up yarn version
-              run: |
-                  corepack enable
-                  corepack install 
-                  yarn --version
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
+            - name: Setup Node.js environment
+              # Node 22.18+ has a known bug that breaks tests
+              # (https://github.com/nodejs/node/issues/59364).
+              # Set vars.NODEJS_VERSION to a safe version (e.g. 22.17.1).
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697 # 1.0.6
               with:
-                  # Specific version. 22.18+ is bad due to https://github.com/nodejs/node/issues/59364 and breaks tests.
-                  node-version: 22.17.1
-                  cache: yarn
-
-            - name: Install dependencies
-              run: |
-                  rm -rf node_modules
-                  yarn cache clean --all
-                  yarn install
+                  node-version: ${{ vars.NODEJS_VERSION }}
+                  clean-install: 'true'
 
             - name: Install prerequisites for code generation
               run: |
-                  sudo apt-get update -y > /dev/null
-                  sudo apt-get install -y --no-install-recommends --no-install-suggests \
+                  sudo apt-get update --yes > /dev/null
+                  sudo apt-get install --yes --no-install-recommends --no-install-suggests \
                     bash shellcheck > /dev/null
 
             - name: Generate OpenAPI types
@@ -118,12 +106,11 @@ jobs:
                   yarn knip
 
             - name: Lint Dockerfiles (hadolint)
-              uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
               id: hadolint
               if: success() || failure()
+              uses: cognizant-ai-lab/build-common/actions/run-hadolint@e5f749a7ba5de8bb8106cb172e89f21ca581a697 # 1.0.6
               with:
                   dockerfile: apps/main/Dockerfile
-                  recursive: true
                   failure-threshold: info
 
             - name: Docker build check


### PR DESCRIPTION
Replaces the inline corepack, setup-node, and yarn-install steps in `test.yml` with the `setup-node-env` composite action from `cognizant-ai-lab/build-common` (pinned to SHA `e5f749a7`, tag 1.0.6). Replaces the direct `hadolint-action` reference with the `run-hadolint` composite. Pins `actions/checkout` to the canonical v6.0.2 SHA per the org actions manifest. Node.js version now reads from `vars.NODEJS_VERSION` instead of the hardcoded `22.17.1` -- ensure the repo variable is set to a safe version since 22.18+ has a [known bug](https://github.com/nodejs/node/issues/59364) that breaks tests.

Link to Devin session: https://app.devin.ai/sessions/a72f962ab8274017ad602ddbb371f482
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->