### PR TITLE
Migrate publish.yml to build-common setup-node-env, bump all to 1.0.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,8 @@ jobs:
                   ref: ${{ inputs.revision || github.ref }}
 
             - name: Setup Node.js and install dependencies
-              # build-common 1.0.5
-              uses: cognizant-ai-lab/build-common/actions/setup-node-env@550f3d7338e598c813b9580a238141328f7baaaa
+              # build-common 1.0.7
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
               with:
                   node-version: ${{ env.NODEJS_VERSION }}
                   clean-install: "true"
@@ -89,16 +89,16 @@ jobs:
               run: yarn generate
 
             - name: Authenticate to AWS and login to ECR
-              # build-common 1.0.5
-              uses: cognizant-ai-lab/build-common/actions/aws-ecr-auth@550f3d7338e598c813b9580a238141328f7baaaa
+              # build-common 1.0.7
+              uses: cognizant-ai-lab/build-common/actions/aws-ecr-auth@3ead7f681f92044709ffc3a533f41c3f48230cfd
               with:
                   aws-account-id: ${{ vars.AWS_ACCOUNT_ID }}
                   aws-role-name: ${{ vars.AWS_ROLE_NAME }}
                   aws-region: ${{ env.AWS_REGION }}
 
             - name: Build and push Docker image to ECR
-              # build-common 1.0.5
-              uses: cognizant-ai-lab/build-common/actions/docker-buildx-push@550f3d7338e598c813b9580a238141328f7baaaa
+              # build-common 1.0.7
+              uses: cognizant-ai-lab/build-common/actions/docker-buildx-push@3ead7f681f92044709ffc3a533f41c3f48230cfd
               with:
                   context: .
                   dockerfile: apps/main/Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
               # Node 22.18+ has a known bug that breaks builds
               # (https://github.com/nodejs/node/issues/59364).
               # Set vars.NODEJS_VERSION to a safe version (e.g. 22.17.1).
-              uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697 # 1.0.6
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@3ead7f681f92044709ffc3a533f41c3f48230cfd # 1.0.7
               with:
                   node-version: ${{ vars.NODEJS_VERSION }}
                   clean-install: "true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,30 +71,19 @@ jobs:
             short_sha: ${{ steps.compute.outputs.short_sha }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
 
-            - name: Set up yarn version
-              run: |
-                  corepack enable
-                  corepack install
-                  yarn --version
-
-            # Pin to Node.js 22.17.1 to avoid 22.18+ regression where experimental-strip-types
-            # was enabled by default, breaking npm package builds (see nodejs/node#59364)
-            - name: Use Node.js
-              uses: actions/setup-node@v4
+            - name: Setup Node.js environment
+              # Node 22.18+ has a known bug that breaks builds
+              # (https://github.com/nodejs/node/issues/59364).
+              # Set vars.NODEJS_VERSION to a safe version (e.g. 22.17.1).
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697 # 1.0.6
               with:
-                  node-version: 22.17.1
+                  node-version: ${{ vars.NODEJS_VERSION }}
+                  clean-install: "true"
                   registry-url: https://registry.npmjs.org/
-                  cache: yarn
-
-            - name: Install dependencies
-              run: |
-                  rm --recursive --force node_modules
-                  yarn cache clean --all
-                  yarn install --immutable
 
             - name: Generate OpenAPI types
               run: yarn generate


### PR DESCRIPTION
## Summary

Replaces the inline corepack, setup-node, and yarn-install steps in `publish.yml` with the `setup-node-env` composite action from `build-common` (pinned to 1.0.7). Pins `actions/checkout` to the canonical v6.0.2 SHA. Node.js version reads from `vars.NODEJS_VERSION` instead of hardcoded `22.17.1`. Also bumps the three existing build-common references in `build.yml` from 1.0.5 to 1.0.7 (setup-node-env, aws-ecr-auth, docker-buildx-push).

Link to Devin session: https://app.devin.ai/sessions/5af2ecdfbaf04a0cb7bbf4cfa9f469c4
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->