### PR TITLE
Enable linter rules and fix violations

### DIFF
--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -3,7 +3,7 @@
 // enables IDEs to type check this config file.
 // See: https://nextjs.org/docs/basic-features/typescript
 
-import path from "path"
+import path from "node:path"
 
 /* eslint-disable no-shadow */
 const __dirname = import.meta.dirname

--- a/apps/main/pages/api/userInfo/index.ts
+++ b/apps/main/pages/api/userInfo/index.ts
@@ -21,19 +21,6 @@ import {OidcProvider, UserInfoResponse} from "../../../../../packages/ui-common/
 
 const EXPECTED_NUMBER_OF_JWT_HEADERS = 3
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse<UserInfoResponse>) {
-    // Fetch user info from ALB or your backend service
-    const userInfo = fetchUserInfoFromALB(req)
-    if (userInfo.oidcHeaderFound && !userInfo.oidcHeaderValid) {
-        // We found the header, but couldn't parse it
-        res.status(httpStatus.UNAUTHORIZED).json({oidcHeaderFound: true, oidcHeaderValid: false})
-        return
-    }
-
-    // We either didn't find the header at all, or we found it and parsed it
-    res.status(httpStatus.OK).json(userInfo)
-}
-
 // Expected header from ALB
 const AWS_OIDC_HEADER = "x-amzn-oidc-data"
 
@@ -88,4 +75,17 @@ const fetchUserInfoFromALB = (req: NextApiRequest): UserInfoResponse => {
         oidcHeaderValid: true,
         oidcProvider,
     }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<UserInfoResponse>) {
+    // Fetch user info from ALB or your backend service
+    const userInfo = fetchUserInfoFromALB(req)
+    if (userInfo.oidcHeaderFound && !userInfo.oidcHeaderValid) {
+        // We found the header, but couldn't parse it
+        res.status(httpStatus.UNAUTHORIZED).json({oidcHeaderFound: true, oidcHeaderValid: false})
+        return
+    }
+
+    // We either didn't find the header at all, or we found it and parsed it
+    res.status(httpStatus.OK).json(userInfo)
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -19,22 +19,21 @@ import "@testing-library/jest-dom"
 import failOnConsole from "jest-fail-on-console"
 // eslint-disable-next-line no-shadow
 import {ReadableStream} from "node:stream/web"
+import {TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder} from "node:util"
 import type {ReactNode} from "react"
 import {createElement} from "react"
 /*
 This next part is a hack to get around "ReferenceError: TextEncoder is not defined" errors when running Jest.
 See: https://stackoverflow.com/questions/68468203/why-am-i-getting-textencoder-is-not-defined-in-jest
  */
-// eslint-disable-next-line no-shadow
-import {TextDecoder, TextEncoder} from "util"
 
 Object.defineProperties(globalThis, {
     ReadableStream: {value: ReadableStream},
 })
 
 // Use the Node.js TextEncoder for Jest, with a type cast to satisfy TypeScript
-global.TextEncoder = TextEncoder as unknown as typeof global.TextEncoder
-global.TextDecoder = TextDecoder as unknown as typeof global.TextDecoder
+global.TextEncoder = NodeTextEncoder as unknown as typeof global.TextEncoder
+global.TextDecoder = NodeTextDecoder as unknown as typeof global.TextDecoder
 
 // End of hack
 

--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -39,10 +39,6 @@ export default defineConfig([
     eslintPluginUnicorn.configs.all,
 
     typescriptEslint.configs.all,
-    {
-        files: ["**/*.{js,mjs,cjs}"],
-        ...typescriptEslint.configs.disableTypeChecked,
-    },
 
     // Have to configure import plugin in the "legacy" way due to:
     // https://github.com/import-js/eslint-plugin-import/issues/3227
@@ -402,7 +398,7 @@ export default defineConfig([
             "@typescript-eslint/prefer-return-this-type": "off",
             "@typescript-eslint/prefer-string-starts-ends-with": "off",
             "@typescript-eslint/require-array-sort-compare": "off",
-            "@typescript-eslint/switch-exhaustiveness-check": "off",
+            "@typescript-eslint/switch-exhaustiveness-check": "error",
             "@typescript-eslint/unbound-method": "off",
             "@typescript-eslint/no-for-in-array": "off",
             "@typescript-eslint/object-curly-spacing": "off",
@@ -593,6 +589,11 @@ export default defineConfig([
             "import/no-anonymous-default-export": "error",
             "@typescript-eslint/no-empty-interface": "error",
         },
+    },
+    // Disable typed linting rules for non-TypeScript files since they're not applicable
+    {
+        files: ["**/*.{js,mjs,cjs}"],
+        ...typescriptEslint.configs.disableTypeChecked,
     },
     {
         files: ["**/eslint.config.mjs"],

--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -396,7 +396,6 @@ export default defineConfig([
             "@typescript-eslint/prefer-reduce-type-parameter": "off",
             "@typescript-eslint/prefer-return-this-type": "off",
             "@typescript-eslint/require-array-sort-compare": "off",
-            "@typescript-eslint/switch-exhaustiveness-check": "error",
             "@typescript-eslint/unbound-method": "off",
             "@typescript-eslint/no-for-in-array": "off",
             "@typescript-eslint/object-curly-spacing": "off",

--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -301,8 +301,8 @@ export default defineConfig([
                 "error",
                 {
                     /*
-                    Bans any import that starts with @mui/ followed by a single segment (i.e., no additional slashes 
-                    after the first segment). For example, imports like @mui/core or @mui/icons would be restricted, 
+                    Bans any import that starts with @mui/ followed by a single segment (i.e., no additional slashes
+                    after the first segment). For example, imports like @mui/core or @mui/icons would be restricted,
                     while deeper imports such as @mui/icons-material/Button would not be affected.
                     Why? According to the MUI documentation, importing directly from @mui/ can lead to larger
                     bundle sizes because it may include the entire library instead of just the specific components
@@ -392,11 +392,9 @@ export default defineConfig([
             "@typescript-eslint/non-nullable-type-assertion-style": "off",
             "@typescript-eslint/prefer-includes": "off",
             "@typescript-eslint/no-unsafe-type-assertion": "off",
-            "@typescript-eslint/no-use-before-define": "off",
             "@typescript-eslint/prefer-readonly": "off",
             "@typescript-eslint/prefer-reduce-type-parameter": "off",
             "@typescript-eslint/prefer-return-this-type": "off",
-            "@typescript-eslint/prefer-string-starts-ends-with": "off",
             "@typescript-eslint/require-array-sort-compare": "off",
             "@typescript-eslint/switch-exhaustiveness-check": "error",
             "@typescript-eslint/unbound-method": "off",
@@ -484,16 +482,12 @@ export default defineConfig([
             "unicorn/no-await-expression-member": "off",
             "unicorn/no-static-only-class": "off",
             "unicorn/prefer-set-has": "off",
-            "unicorn/prefer-string-raw": "off",
             "unicorn/no-useless-undefined": "off",
-            "unicorn/prefer-node-protocol": "off",
-            "unicorn/prefer-string-slice": "off",
             "unicorn/no-named-default": "off",
             "unicorn/no-array-reduce": "off",
             "unicorn/no-array-sort": "off",
             "unicorn/no-useless-switch-case": "off",
             "unicorn/prefer-at": "off",
-            "unicorn/prefer-string-replace-all": "off",
             "unicorn/consistent-destructuring": "off",
             "unicorn/numeric-separators-style": "off",
             "unicorn/prefer-query-selector": "off",
@@ -501,7 +495,6 @@ export default defineConfig([
             "unicorn/prefer-ternary": "off",
             "unicorn/consistent-function-scoping": "off",
             "unicorn/no-negated-condition": "off",
-            "unicorn/prefer-spread": "off",
             "unicorn/no-zero-fractions": "off",
             "unicorn/prefer-number-properties": "off",
             "unicorn/prefer-global-this": "off",

--- a/packages/ui-common/Theme/Theme.ts
+++ b/packages/ui-common/Theme/Theme.ts
@@ -57,9 +57,9 @@ export const isLightColor = (color: string): boolean => {
     const colorWithoutHash = hexColor.replace("#", "")
 
     // Convert to RGB
-    const r = parseInt(colorWithoutHash.substring(0, 2), 16)
-    const g = parseInt(colorWithoutHash.substring(2, 4), 16)
-    const b = parseInt(colorWithoutHash.substring(4, 6), 16)
+    const r = parseInt(colorWithoutHash.slice(0, 2), 16)
+    const g = parseInt(colorWithoutHash.slice(2, 4), 16)
+    const b = parseInt(colorWithoutHash.slice(4, 6), 16)
 
     // Calculate relative luminance (perceived brightness)
     const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow.test.tsx
@@ -152,7 +152,7 @@ describe("AgentFlow", () => {
         expect(nodes).toHaveLength(3)
 
         const agentNames = NETWORK.map((agent) => agent.origin)
-        const nodesArray = Array.from(nodes)
+        const nodesArray = [...nodes]
 
         // Make sure each agent node is rendered at least. Structure in react-flow is:
         // <div class="react-flow__node"><div><p>agentName</p></div></div>

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentNode.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentNode.test.tsx
@@ -89,7 +89,7 @@ describe("AgentNode", () => {
         expect(parentDiv).toBeInTheDocument()
 
         // Check the background color of the associated node (the circle div)
-        const nodeDiv = Array.from(parentDiv.children).find((el) => el.tagName === "DIV") as HTMLDivElement
+        const nodeDiv = [...parentDiv.children].find((el) => el.tagName === "DIV") as HTMLDivElement
         expect(nodeDiv).toBeInTheDocument()
         const style = window.getComputedStyle(nodeDiv)
 

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -481,7 +481,7 @@ describe("Multi Agent Accelerator Page", () => {
         // Verify the conversations array contains the expected agent
         const conversationCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1][0]
         const hasAgent = conversationCall.some((conv: {agents: Set<string>}) =>
-            Array.from(conv.agents).includes(TEST_AGENT_MATH_GUY)
+            [...conv.agents].includes(TEST_AGENT_MATH_GUY)
         )
         expect(hasAgent).toBe(true)
     })

--- a/packages/ui-common/__tests__/unit/Utils/File.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/File.test.ts
@@ -61,7 +61,7 @@ describe("getFileName", () => {
     })
 
     it("should return nothing when the path ends with a backslash", () => {
-        expect(getFileName(String.raw`C:\Users\JaneDoe\Documents\\`)).toBe("")
+        expect(getFileName("C:\\Users\\JaneDoe\\Documents\\")).toBe("")
     })
 
     it("should return the file name when the path ends with a period", () => {

--- a/packages/ui-common/__tests__/unit/Utils/File.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/File.test.ts
@@ -49,11 +49,11 @@ describe("getFileName", () => {
     })
 
     it("should return the file name when the path includes backslashes", () => {
-        expect(getFileName("C:\\Users\\JaneDoe\\Documents\\myfile.txt")).toBe("myfile.txt")
+        expect(getFileName(String.raw`C:\Users\JaneDoe\Documents\myfile.txt`)).toBe("myfile.txt")
     })
 
     it("should return the file name when the path includes both forward and back slashes", () => {
-        expect(getFileName("C:/Users/JaneDoe\\Documents/myfile.txt")).toBe("myfile.txt")
+        expect(getFileName(String.raw`C:/Users/JaneDoe\Documents/myfile.txt`)).toBe("myfile.txt")
     })
 
     it("should return nothing when the path ends with a forward slash", () => {
@@ -61,7 +61,7 @@ describe("getFileName", () => {
     })
 
     it("should return nothing when the path ends with a backslash", () => {
-        expect(getFileName("C:\\Users\\JaneDoe\\Documents\\")).toBe("")
+        expect(getFileName(String.raw`C:\Users\JaneDoe\Documents\\`)).toBe("")
     })
 
     it("should return the file name when the path ends with a period", () => {
@@ -69,7 +69,7 @@ describe("getFileName", () => {
     })
 
     it("should return the file name when the path contains only one backslash", () => {
-        expect(getFileName("C:\\myfile.txt")).toBe("myfile.txt")
+        expect(getFileName(String.raw`C:\myfile.txt`)).toBe("myfile.txt")
     })
 
     it("should return the file name when the path contains only one forward slash", () => {

--- a/packages/ui-common/components/AgentChat/ChatCommon/Conversation.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/Conversation.tsx
@@ -37,7 +37,7 @@ const renderTurn = (
     shadowColor: string,
     shouldWrapOutput: boolean,
     turn: ConversationTurn
-): React.ReactNode => {
+): ReactNode => {
     // extract the parts of the line
     let repairedJson: string
 
@@ -50,7 +50,7 @@ const renderTurn = (
         // Now try to parse it. We don't care about the result, only if it throws on parsing.
         JSON.parse(repairedJson)
 
-        repairedJson = repairedJson.replace(/\\n/gu, "\n").replace(/\\"/gu, "'")
+        repairedJson = repairedJson.replaceAll(String.raw`\n`, "\n").replaceAll(String.raw`\"`, "'")
     } catch {
         // Not valid JSON
         repairedJson = null

--- a/packages/ui-common/components/Common/notification.tsx
+++ b/packages/ui-common/components/Common/notification.tsx
@@ -79,7 +79,7 @@ export const sendNotification = (
     // Use some minor customization to be able to inject ids for testing
     const messageForId = message
         .replaceAll(" ", "-")
-        .replace(/[^a-zA-Z0-9-]/gu, "")
+        .replaceAll(/[^a-zA-Z0-9-]/gu, "")
         .toLowerCase()
     const baseId = `notification-message-${messageForId}-${NotificationType[variantType]}`
     const messageSpan = <span id={`${baseId}-span`}>{message}</span>

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
@@ -277,7 +277,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
 
             for (const conv of currentConversations) {
                 const convText = conv.text?.trim()
-                const agentList = Array.from(conv.agents)
+                const agentList = [...conv.agents]
 
                 if (
                     convText &&
@@ -355,7 +355,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
     const mergedAgentsInNetwork: ConnectivityInfo[] = useMemo(() => {
         // Add any missing agents from bubbles as minimal ConnectivityInfo
         const existingIds = new Set(agentsInNetwork.map((a) => a.origin))
-        const missing = Array.from(bubbleAgentIds).filter((bubbleAgentId) => !existingIds.has(bubbleAgentId))
+        const missing = [...bubbleAgentIds].filter((bubbleAgentId) => !existingIds.has(bubbleAgentId))
         const minimalAgents = missing.map((missingId) => ({
             origin: missingId,
             tools: [] as string[],

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
@@ -115,7 +115,7 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
     const isFrontman = depth === 0
 
     // Determine max agent count for heatmap scaling
-    const maxAgentCount = agentCounts ? Math.max(...Array.from(agentCounts.values())) : 0
+    const maxAgentCount = agentCounts ? Math.max(...agentCounts.values()) : 0
 
     // Unpack the node-specific id
     const agentId = props.id

--- a/packages/ui-common/components/MultiAgentAccelerator/GraphLayouts.ts
+++ b/packages/ui-common/components/MultiAgentAccelerator/GraphLayouts.ts
@@ -53,7 +53,7 @@ export const addThoughtBubbleEdge = (
 
     // Enforce max limit - remove oldest if over limit
     if (thoughtBubbleEdges.size > MAX_GLOBAL_THOUGHT_BUBBLES) {
-        const entries = Array.from(thoughtBubbleEdges.entries())
+        const entries = [...thoughtBubbleEdges.entries()]
         const sorted = entries.sort((a, b) => a[1].timestamp - b[1].timestamp)
         const toRemove = sorted.slice(0, sorted.length - MAX_GLOBAL_THOUGHT_BUBBLES)
 
@@ -73,7 +73,7 @@ export const removeThoughtBubbleEdge = (
 export const getThoughtBubbleEdges = (
     thoughtBubbleEdges: Map<string, {edge: ThoughtBubbleEdgeShape; timestamp: number}>
 ): ThoughtBubbleEdgeShape[] => {
-    return Array.from(thoughtBubbleEdges.values()).map((item) => item.edge)
+    return [...thoughtBubbleEdges.values()].map((item) => item.edge)
 }
 
 // Helper function for plasma edges to check if two agents are in the same conversation
@@ -393,7 +393,7 @@ export const layoutLinear = (
     dagre.layout(dagreGraph)
 
     // Get x positions for the nodes in nodesTmp. Keep only unique values and sort numerically
-    const xPositions = Array.from(new Set(nodesTmp.map((node) => dagreGraph.node(node.id).x))).sort((a, b) => a - b)
+    const xPositions = [...new Set(nodesTmp.map((node) => dagreGraph.node(node.id).x))].sort((a, b) => a - b)
 
     // Convert dagre's layout to what our flow graph needs
     nodesTmp.forEach((node) => {

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -348,9 +348,9 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                         selectedNetwork,
                         userInfo.userName
                     )
-                    const agentsInNetworkSorted: ConnectivityInfo[] = connectivity.connectivity_info
-                        .concat()
-                        .sort((a, b) => a?.origin.localeCompare(b?.origin))
+                    const agentsInNetworkSorted: ConnectivityInfo[] = [...connectivity.connectivity_info].sort((a, b) =>
+                        a?.origin.localeCompare(b?.origin)
+                    )
                     setAgentsInNetwork(agentsInNetworkSorted)
                     setAgentIconSuggestions(null)
                     closeNotification()

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/AgentNetworkTreeItem.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/AgentNetworkTreeItem.tsx
@@ -167,8 +167,7 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
                             </Tooltip>
                             {isChild && tags?.length > 0 ? (
                                 <Tooltip
-                                    title={tags
-                                        .slice()
+                                    title={[...tags]
                                         .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
                                         .map((tag) => (
                                             <Chip

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
@@ -184,6 +184,8 @@ export const Sidebar: FC<SidebarProps> = ({
 
     const [expandedItems, setExpandedItems] = useState<string[]>([])
 
+    const [selectedItem, setSelectedItem] = useState<string | null>(null)
+
     // Theming/Dark mode
     const darkMode = useTheme().palette.mode === "dark"
 
@@ -284,8 +286,6 @@ export const Sidebar: FC<SidebarProps> = ({
         acc[tempNetwork.agentInfo.agent_name] = tempNetwork.networkHocon
         return acc
     }, {})
-
-    const [selectedItem, setSelectedItem] = useState<string | null>(null)
 
     const handleSelectedItemsChange = (_event: unknown, itemId: string | null) => {
         if (!itemId) {

--- a/packages/ui-common/components/MultiAgentAccelerator/ThoughtBubbleOverlay.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/ThoughtBubbleOverlay.tsx
@@ -194,7 +194,7 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
             const newBubbles = thoughtBubbleEdges.filter((e) => !previousBubbleIds.has(e.id))
 
             // Find bubbles that should disappear
-            const removingBubbles = Array.from(previousBubbleIds).filter((id) => !currentEdgeIds.has(id))
+            const removingBubbles = [...previousBubbleIds].filter((id) => !currentEdgeIds.has(id))
 
             const newState = new Map(prev)
 
@@ -409,16 +409,15 @@ export const ThoughtBubbleOverlay: FC<ThoughtBubbleOverlayProps> = ({
         [activeAgentIds]
     )
 
-    // Get all bubbles to render (including exiting ones)
-    const allBubbleIds = Array.from(bubbleStates.keys())
     // Memoize the resolved edges so updateAllLines (and effects depending on it)
     // doesn't get recreated on every render unnecessarily.
     const renderableBubbles = useMemo(
         () =>
-            allBubbleIds
+            // Get all bubbles to render (including exiting ones)
+            [...bubbleStates.keys()]
                 .map((id) => sortedEdges.find((e) => e.id === id) ?? edges.find((e) => e.id === id))
                 .filter((edge) => edge !== undefined),
-        [allBubbleIds, sortedEdges, edges]
+        [bubbleStates, sortedEdges, edges]
     )
 
     // Update all SVG lines imperatively after paint. This reads DOM (getBoundingClientRect)

--- a/packages/ui-common/controller/llm/LlmChat.ts
+++ b/packages/ui-common/controller/llm/LlmChat.ts
@@ -73,10 +73,10 @@ const handleStreamingCallback = async (
             let newlineIndex
             while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
                 // Extract the complete line (without the newline)
-                const line = buffer.substring(0, newlineIndex).trim()
+                const line = buffer.slice(0, Math.max(0, newlineIndex)).trim()
 
                 // Keep the rest for next iteration
-                buffer = buffer.substring(newlineIndex + 1)
+                buffer = buffer.slice(Math.max(0, newlineIndex + 1))
 
                 // Skip empty lines
                 if (line.length > 0) {

--- a/packages/ui-common/utils/Authentication.ts
+++ b/packages/ui-common/utils/Authentication.ts
@@ -67,6 +67,8 @@ const createAuth0LogoutUrl = (oidcProvider: OidcProvider, auth0Domain: string, a
             return `https://login.microsoftonline.com/${AD_TENANT_ID}/oauth2/v2.0/logout`
 
         case "Github":
+        case "NextAuth":
+        case "None":
         default: {
             const baseUrl = `${window.location.protocol}//${window.location.host}`
             const returnTo = encodeURIComponent(baseUrl)

--- a/packages/ui-common/utils/File.ts
+++ b/packages/ui-common/utils/File.ts
@@ -23,10 +23,10 @@ export const toSafeFilename = (input: string): string => {
     }
 
     // Replace any non-alphanumeric characters with underscores
-    let safeFilename = input.replace(/[^a-zA-Z0-9]/gu, "_")
+    let safeFilename = input.replaceAll(/[^a-zA-Z0-9]/gu, "_")
 
     // Trim any leading or trailing underscores
-    safeFilename = safeFilename.replace(/^_+|_+$/gu, "")
+    safeFilename = safeFilename.replaceAll(/^_+|_+$/gu, "")
 
     return safeFilename
 }

--- a/packages/ui-common/utils/text.ts
+++ b/packages/ui-common/utils/text.ts
@@ -18,7 +18,7 @@ limitations under the License.
  * For text processing utility functions
  */
 
-import {createHash} from "crypto"
+import {createHash} from "node:crypto"
 
 /**
  * Tests if input contains only whitespace (meaning, not a valid query)
@@ -48,7 +48,7 @@ export const extractId = (modelId: string, modelType: "prescriptor" | "rio"): st
 
     // conflicts with ESLint newline-per-chained-call rule
     // prettier-ignore
-    return modelId.substring(`${modelType}-`.length) // remove the model type
+    return modelId.slice(`${modelType}-`.length) // remove the model type
         .split("-")     // split by hyphens
         .slice(0, -1)   // remove the last element
         .join("-") // join with hyphens

--- a/packages/ui-common/utils/title.ts
+++ b/packages/ui-common/utils/title.ts
@@ -18,5 +18,5 @@ limitations under the License.
 
 export const getTitleBase = (): string => {
     const subdomain = window.location.host.split(".")[0]
-    return `${subdomain[0].toUpperCase()}${subdomain.substring(1)}`
+    return `${subdomain[0].toUpperCase()}${subdomain.slice(1)}`
 }


### PR DESCRIPTION
The origin of this was in a previous PR #273 I noticed we had no rule for catching when not all cases are handled in a `switch`. So I enabled that rule here, and a bunch more, and fixed the resulting violations.

I picked rules that seemed useful, with a few easy-to-fix violations in the existing codebase.

Broad but shallow PR.