### PR TITLE
Migrate test.yml Node.js setup to build-common

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,31 +56,19 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              # v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
               with:
                   fetch-depth: 0
                   ref: ${{ inputs.revision || github.ref }}
 
-            # Install yarn version from package.json packageManager field using corepack
-            # "corepack install" reads package.json and installs the right yarn version from the packageManager field
-            - name: Set up yarn version
-              run: |
-                  corepack enable
-                  corepack install 
-                  yarn --version
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
+            - name: Setup Node.js and install dependencies
+              # build-common 1.0.6
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
               with:
-                  # Specific version. 22.18+ is bad due to https://github.com/nodejs/node/issues/59364 and breaks tests.
-                  node-version: 22.17.1
-                  cache: yarn
-
-            - name: Install dependencies
-              run: |
-                  rm -rf node_modules
-                  yarn cache clean --all
-                  yarn install
+                  # Pinned to 22.17.1 to avoid 22.18+ regression (nodejs/node#59364)
+                  node-version: '22.17.1'
+                  clean-install: 'true'
 
             - name: Install prerequisites for code generation
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,8 @@ jobs:
               uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
               with:
                   # Pinned to 22.17.1 to avoid 22.18+ regression (nodejs/node#59364)
-                  node-version: '22.17.1'
-                  clean-install: 'true'
+                  node-version: "22.17.1"
+                  clean-install: "true"
 
             - name: Install prerequisites for code generation
               run: |


### PR DESCRIPTION
## Summary

Replaces the inline corepack/yarn setup, `actions/setup-node@v4`, and dependency install steps with the `setup-node-env` composite action from `cognizant-ai-lab/build-common` (pinned to `e5f749a7`, tag 1.0.6). Pins `actions/checkout` to SHA (v6.0.2) per the org actions-manifest. Node.js stays at 22.17.1 (nodejs/node#59364). All quality-gate steps (ESLint, ShellCheck, Prettier, knip, hadolint, Docker build check, tsc, unit tests) are preserved unchanged.

Link to Devin session: https://app.devin.ai/sessions/4e27e08609a64ee7b933898070e4bb8c
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->