### PR TITLE
Migrate test.yml Node.js setup to build-common

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,8 @@ jobs:
                   ref: ${{ inputs.revision || github.ref }}
 
             - name: Setup Node.js environment
-              # v1.0.6
-              uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+              # v1.0.7
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
               with:
                   # Pinned version. 22.18+ breaks tests due to
                   # https://github.com/nodejs/node/issues/59364
@@ -109,10 +109,10 @@ jobs:
             - name: Lint Dockerfiles (hadolint)
               id: hadolint
               if: success() || failure()
-              # v1.0.6
-              uses: cognizant-ai-lab/build-common/actions/run-hadolint@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+              # v1.0.7
+              uses: cognizant-ai-lab/build-common/actions/run-hadolint@3ead7f681f92044709ffc3a533f41c3f48230cfd
               with:
-                  dockerfile: apps/main/Dockerfile
+                  recursive: "true"
                   failure-threshold: info
 
             - name: Docker build check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,8 @@ jobs:
               with:
                   # Pinned version. 22.18+ breaks tests due to
                   # https://github.com/nodejs/node/issues/59364
-                  node-version: '22.17.1'
-                  clean-install: 'true'
+                  node-version: "22.17.1"
+                  clean-install: "true"
 
             - name: Install prerequisites for code generation
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,36 +56,25 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              # v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
               with:
                   fetch-depth: 0
                   ref: ${{ inputs.revision || github.ref }}
 
-            # Install yarn version from package.json packageManager field using corepack
-            # "corepack install" reads package.json and installs the right yarn version from the packageManager field
-            - name: Set up yarn version
-              run: |
-                  corepack enable
-                  corepack install 
-                  yarn --version
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
+            - name: Setup Node.js environment
+              # v1.0.6
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
               with:
-                  # Specific version. 22.18+ is bad due to https://github.com/nodejs/node/issues/59364 and breaks tests.
-                  node-version: 22.17.1
-                  cache: yarn
-
-            - name: Install dependencies
-              run: |
-                  rm -rf node_modules
-                  yarn cache clean --all
-                  yarn install
+                  # Pinned version. 22.18+ breaks tests due to
+                  # https://github.com/nodejs/node/issues/59364
+                  node-version: '22.17.1'
+                  clean-install: 'true'
 
             - name: Install prerequisites for code generation
               run: |
-                  sudo apt-get update -y > /dev/null
-                  sudo apt-get install -y --no-install-recommends --no-install-suggests \
+                  sudo apt-get update --yes > /dev/null
+                  sudo apt-get install --yes --no-install-recommends --no-install-suggests \
                     bash shellcheck > /dev/null
 
             - name: Generate OpenAPI types
@@ -118,12 +107,12 @@ jobs:
                   yarn knip
 
             - name: Lint Dockerfiles (hadolint)
-              uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
               id: hadolint
               if: success() || failure()
+              # v1.0.6
+              uses: cognizant-ai-lab/build-common/actions/run-hadolint@e5f749a7ba5de8bb8106cb172e89f21ca581a697
               with:
                   dockerfile: apps/main/Dockerfile
-                  recursive: true
                   failure-threshold: info
 
             - name: Docker build check


### PR DESCRIPTION
## Summary

Replaces inline corepack, `actions/setup-node`, and `yarn install` steps in `test.yml` with the `setup-node-env` composite action from `cognizant-ai-lab/build-common` (pinned to SHA `3ead7f68`, tag 1.0.7). Replaces the direct `hadolint/hadolint-action` reference with the `run-hadolint` composite using `recursive: "true"` to auto-discover all Dockerfiles in the repo. Pins `actions/checkout` to SHA (v6.0.2) per the org actions-manifest. Dependency install switches from `yarn install` to `yarn install --immutable` via the composite's `clean-install` mode.

Link to Devin session: https://app.devin.ai/sessions/e0006b222b5f442294e5077045e03aa6
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->