### PR TITLE
#381 #266 Improve agent name and title displays

### DIFF
--- a/packages/ui-common/components/AgentChat/Common/Utils.ts
+++ b/packages/ui-common/components/AgentChat/Common/Utils.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import capitalize from "lodash-es/capitalize.js"
 import startCase from "lodash-es/startCase.js"
 
 import {AgentErrorProps} from "./Types"
@@ -78,5 +77,5 @@ export const removeTrailingUuid = (agentName: string): string => {
  * @returns User-friendly agent name.
  */
 export const cleanUpAgentName = (agentName: string): string => {
-    return startCase(capitalize(agentName))
+    return startCase(agentName)
 }

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
@@ -336,7 +336,8 @@ export const AgentFlow: FC<AgentFlowProps> = ({
     }, [setThoughtBubbleEdges]) // mount/unmount only
 
     // Shadow color for icon
-    const shadowColor = theme.palette.mode === "dark" ? theme.palette.common.white : theme.palette.common.black
+    const isDarkMode = theme.palette.mode === "dark"
+    const foregroundColor = isDarkMode ? theme.palette.common.white : theme.palette.common.black
     const isHeatmap = coloringOption === "heatmap"
 
     const palette = usePalette()
@@ -701,11 +702,11 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                 id={`${id}-legend`}
                 sx={{
                     position: "absolute",
-                    top: "5px",
+                    top: "1.5rem",
                     right: "10px",
                     padding: "5px",
                     borderRadius: "5px",
-                    boxShadow: `0 0 5px color-mix(in srgb, ${shadowColor} 30%, transparent)`,
+                    boxShadow: `0 0 5px color-mix(in srgb, ${foregroundColor} 30%, transparent)`,
                     display: "flex",
                     alignItems: "center",
                     zIndex: getZIndex(2, theme),
@@ -800,7 +801,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         if (!isActive) {
             return undefined
         }
-        return theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[200]
+        return isDarkMode ? theme.palette.grey[800] : theme.palette.grey[200]
     }
 
     // Only show radial guides if radial layout is selected, radial guides are enabled, and it's not just Frontman
@@ -895,6 +896,80 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         )
     }
 
+    const titleBackgroundColor = alpha(theme.palette.background.paper, 0.75)
+
+    const getTitle = () => {
+        return (
+            networkDisplayName && (
+                <Box
+                    id={`${id}-network-title-bar`}
+                    sx={{
+                        alignItems: "center",
+                        display: "flex",
+                        gap: 1,
+                        left: "50%",
+                        pointerEvents: "none",
+                        position: "absolute",
+                        top: 0,
+                        transform: "translateX(-50%)",
+                        zIndex: getZIndex(2, theme),
+                    }}
+                >
+                    <Tooltip
+                        title={networkDisplayName}
+                        placement="top"
+                    >
+                        <Box sx={{pointerEvents: "auto"}}>
+                            <Typography
+                                id={`${id}-network-title`}
+                                variant="subtitle1"
+                                sx={{
+                                    backdropFilter: "blur(6px)",
+                                    backgroundColor: titleBackgroundColor,
+                                    border: `1px solid ${alpha(theme.palette.divider, 0.6)}`,
+                                    borderRadius: 2,
+                                    boxShadow:
+                                        theme.palette.mode === "dark"
+                                            ? `0 6px 20px ${alpha(theme.palette.common.black, 0.35)}`
+                                            : `0 6px 16px ${alpha(theme.palette.common.black, 0.12)}`,
+                                    color: theme.palette.getContrastText(alpha(titleBackgroundColor, 0.65)),
+                                    fontWeight: 600,
+                                    letterSpacing: "0.01em",
+                                    lineHeight: 1.35,
+                                    maxWidth: 400,
+                                    overflow: "hidden",
+                                    paddingLeft: 2,
+                                    paddingRight: 2,
+                                    paddingBottom: 0.45,
+                                    paddingTop: 0.45,
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap",
+                                }}
+                            >
+                                {networkDisplayName}
+                            </Typography>
+                        </Box>
+                    </Tooltip>
+                    {isTemporaryNetwork && !isEditMode && !isAwaitingLlm && onEnterEditMode && (
+                        <Button
+                            id={`${id}-enter-edit-mode-btn`}
+                            variant="contained"
+                            size="small"
+                            onClick={onEnterEditMode}
+                            startIcon={<EditIcon />}
+                            sx={{
+                                pointerEvents: "auto",
+                                "&:hover": {backgroundColor: theme.palette.primary.main},
+                            }}
+                        >
+                            Edit
+                        </Button>
+                    )}
+                </Box>
+            )
+        )
+    }
+
     return (
         <Box
             id={`${id}-outer-box`}
@@ -928,59 +1003,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                 id={`${id}-react-flow-wrapper`}
                 sx={{position: "relative", flex: 1, minHeight: 0}}
             >
-                {networkDisplayName && (
-                    <Box
-                        id={`${id}-network-title-bar`}
-                        sx={{
-                            position: "absolute",
-                            top: 44,
-                            left: "50%",
-                            transform: "translateX(-50%)",
-                            zIndex: getZIndex(1, theme),
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 1,
-                            pointerEvents: "none",
-                        }}
-                    >
-                        <Typography
-                            id={`${id}-network-title`}
-                            variant="subtitle1"
-                            sx={{
-                                fontWeight: "bold",
-                                backgroundColor: alpha(theme.palette.background.paper, 0.85),
-                                borderRadius: 1.5,
-                                color:
-                                    theme.palette.mode === "dark"
-                                        ? theme.palette.common.white
-                                        : theme.palette.text.primary,
-                                px: 1.5,
-                                py: 0.25,
-                                whiteSpace: "nowrap",
-                                maxWidth: 400,
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                            }}
-                        >
-                            {networkDisplayName}
-                        </Typography>
-                        {isTemporaryNetwork && !isEditMode && !isAwaitingLlm && onEnterEditMode && (
-                            <Button
-                                id={`${id}-enter-edit-mode-btn`}
-                                variant="contained"
-                                size="small"
-                                onClick={onEnterEditMode}
-                                startIcon={<EditIcon />}
-                                sx={{
-                                    pointerEvents: "auto",
-                                    "&:hover": {backgroundColor: theme.palette.primary.main},
-                                }}
-                            >
-                                Edit
-                            </Button>
-                        )}
-                    </Box>
-                )}
+                <Box sx={{marginBottom: "1rem"}}>{getTitle()}</Box>
                 <ReactFlow
                     id={`${id}-react-flow`}
                     nodes={nodes}

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
@@ -1003,7 +1003,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                 id={`${id}-react-flow-wrapper`}
                 sx={{position: "relative", flex: 1, minHeight: 0}}
             >
-                <Box sx={{marginBottom: "1rem"}}>{getTitle()}</Box>
+                {networkDisplayName ? <Box sx={{marginBottom: "1rem"}}>{getTitle()}</Box> : null}
                 <ReactFlow
                     id={`${id}-react-flow`}
                     nodes={nodes}

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
@@ -48,6 +48,9 @@ export interface AgentNodeProps extends Record<string, unknown> {
     readonly isEditable?: boolean
 }
 
+// A zero-width space character, used to give the browser a hint where to break long names
+const ZERO_WIDTH_SPACE = "\u200B"
+
 // Node dimensions
 export const NODE_HEIGHT = 100
 export const NODE_WIDTH = 100
@@ -211,6 +214,14 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
 
     const [isHovered, setIsHovered] = useState(false)
 
+    const wrappedAgentName = agentName
+        // Allow wrap after underscore
+        .replaceAll("_", `_${ZERO_WIDTH_SPACE}`)
+        // Allow wrap before capitals in camel/PascalCase (e.g., CustomerSupport -> Customer|Support)
+        .replaceAll(/(?<lower>[\da-z])(?<upper>[A-Z])/gu, `$<lower>${ZERO_WIDTH_SPACE}$<upper>`)
+        // Also split acronym->word boundary (e.g., HTTPServer -> HTTP|Server), but not H|T|T|P
+        .replaceAll(/(?<acronym>[A-Z])(?<word>[A-Z][a-z])/gu, `$<acronym>${ZERO_WIDTH_SPACE}$<word>`)
+
     return (
         <>
             <AnimatedNode
@@ -292,20 +303,32 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
                 <Typography
                     id={`${agentId}-name`}
                     sx={{
+                        WebkitBoxOrient: "vertical",
+                        WebkitLineClamp: 4,
+                        backgroundColor: theme.palette.background.paper,
+                        border: `1px solid ${theme.palette.divider}`,
+                        borderRadius: 1,
+                        color: theme.palette.text.primary,
                         display: "-webkit-box",
-                        fontSize: "18px",
-                        fontWeight: "bold",
-                        lineHeight: "1.4em",
+                        fontSize: "17px",
+                        fontWeight: 700,
+                        lineHeight: 1.3,
+                        maxHeight: "4.4em",
+                        mx: "auto",
+                        my: "auto",
                         overflow: "hidden",
+                        overflowWrap: "anywhere",
+                        px: 0.75,
+                        py: 0.45,
                         textAlign: "center",
                         textOverflow: "ellipsis",
-                        WebkitBoxOrient: "vertical",
-                        WebkitLineClamp: 2,
+                        whiteSpace: "normal",
                         width: `${NODE_WIDTH}px`,
+                        wordBreak: "break-word",
                         zIndex: 10,
                     }}
                 >
-                    {agentName}
+                    {wrappedAgentName}
                 </Typography>
             </Tooltip>
         </>

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -717,7 +717,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                             isEditMode={isEditingNetwork}
                             isStreaming={isStreaming}
                             isSelectedNetworkTemporary={isSelectedNetworkTemporary}
-                            networkDisplayName={networkDisplayName || undefined}
+                            networkDisplayName={selectedNetwork || undefined}
                             networkId={isSelectedNetworkTemporary ? selectedNetwork : undefined}
                             neuroSanURL={neuroSanURL}
                             onEnterEditMode={() => setIsEditingNetwork(true)}


### PR DESCRIPTION
[Copilot overview.](https://github.com/cognizant-ai-lab/neuro-san-ui/pull/390#pullrequestreview-4431792094)

Half-step along the path to the "Cadillac" solution of displaying agent and network names, which would be the "Future PR" described below.

This PR:
* Uses native hocon name for network title and adds a tooltip with the full name.
* Makes agent nodes' names display nicely, wrapping intelligently, but still modified to be "user friendly" (see screenshots).
* Even attempts to preserve initialisms in names: API, HR, URL etc.
* Fixes the long-running issue in Agent Network Designer where the nodes all have the same long prefix `AgentNetworkDesigner` so it was hard to tell them apart. Even with the long prefixes, the full name is now displayed so they are easy to distinguish.
* Temp networks will now display in their full ugliness in the title: 
    `temporary/day_of_week_network-fc43beb5-5575-424b-b88c-5ac45f110290`. This will get truncated with ellipsis
on most displays requiring a mouse over to display the full name in a tooltip.
* Fixes title appearance and placement (doesn't overlap with graph nodes).

Future PR:
* Make it an option in Settings so users can decide: use "native" hocon names, or user-friendly names? (with loss of fidelity)
* Based on user choice, display names accordingly and consistently everywhere -- network title, node names, chat.
* Persist user preference for future sessions.
<br /><br />

Before | After
:-------------------------:|:-------------------------:
<img width="808" height="724" alt="image" src="https://github.com/user-attachments/assets/02711d1c-06f3-45c6-b80d-c3ba900cb685" />  |  <img width="793" height="718" alt="image" src="https://github.com/user-attachments/assets/6ef88aeb-fe07-4963-9000-7b735c3ddf55" />
<img width="799" height="721" alt="image" src="https://github.com/user-attachments/assets/339e227d-cef1-49cf-ab05-8896e4f8ff91" /> | <img width="793" height="721" alt="image" src="https://github.com/user-attachments/assets/99768065-171c-4e49-973e-7382f6adcd5f" />
<img width="805" height="730" alt="image" src="https://github.com/user-attachments/assets/e22585cb-569c-4b44-bbf0-8bac55a8a2b5" /> | <img width="799" height="715" alt="image" src="https://github.com/user-attachments/assets/9c3d3227-65e0-4004-8ff2-aceb6c093462" />




