### PR TITLE
Migrate orchestrator.yml to build-common manifest SHAs

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -50,7 +50,7 @@ jobs:
             should_deploy: ${{ steps.version.outputs.should_deploy }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
         if: needs.build.result == 'success' && needs.setup.outputs.should_deploy == 'true'
         steps:
             - name: Trigger deployment to neuro-san-deploy
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ secrets.NEURO_SAN_DEPLOY_DISPATCH_TOKEN }}
                   repository: cognizant-ai-lab/neuro-san-deploy
@@ -116,7 +116,7 @@ jobs:
             cancel-in-progress: false
         steps:
             - name: Checkout main branch
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: main
                   token: ${{ secrets.NEURO_SAN_DEPLOY_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

Pins all third-party actions in the orchestrator to exact commit SHAs per the build-common `actions-manifest.yml`. Updates `actions/checkout` from unpinned `@v4` to v6.0.2, and pins `peter-evans/repository-dispatch` to its v3 commit SHA. Aligns with the SHA-pinning standard already applied to `test.yml` and `build.yml` in this repo.

Link to Devin session: https://app.devin.ai/sessions/a39fc3d451ec44c28f7a8e90b2bbc985
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->