### PR TITLE
#398 Make lines between nodes and Frontman line up properly

### DIFF
--- a/packages/ui-common/__tests__/unit/AgentNetwork/GraphLayouts.test.ts
+++ b/packages/ui-common/__tests__/unit/AgentNetwork/GraphLayouts.test.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
 import {KNOWN_MESSAGE_TYPES_FOR_PLASMA} from "../../../components/AgentChat/Common/Utils"
+import {FRONTMAN_SIZE_MULTIPLIER, NODE_HEIGHT, NODE_WIDTH} from "../../../components/MultiAgentAccelerator/AgentNode"
 import {DEFAULT_FRONTMAN_X_POS, DEFAULT_FRONTMAN_Y_POS} from "../../../components/MultiAgentAccelerator/const"
 import {
     addThoughtBubbleEdge,
@@ -125,8 +126,8 @@ describe("GraphLayouts", () => {
 
         // Check that the nodes are in roughly the correct position
         // agent1 should be at the center
-        expect(nodes[0].position.x).toBe(DEFAULT_FRONTMAN_X_POS)
-        expect(nodes[0].position.y).toBe(DEFAULT_FRONTMAN_Y_POS)
+        expect(nodes[0].position.x).toBe(DEFAULT_FRONTMAN_X_POS - (NODE_WIDTH * (FRONTMAN_SIZE_MULTIPLIER - 1)) / 2)
+        expect(nodes[0].position.y).toBe(DEFAULT_FRONTMAN_Y_POS - (NODE_HEIGHT * (FRONTMAN_SIZE_MULTIPLIER - 1)) / 2)
 
         // agents2 and 5 should be right of frontman
         const agent2 = nodes.find((node) => node.id === "agent2")

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
@@ -55,6 +55,7 @@ const ZERO_WIDTH_SPACE = "\u200B"
 // Node dimensions
 export const NODE_HEIGHT = 100
 export const NODE_WIDTH = 100
+export const FRONTMAN_SIZE_MULTIPLIER = 1.25
 
 // Icon sizes
 // These are used to set the size of the icons displayed in the agent nodes.
@@ -221,7 +222,7 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
         // Also split abbreviation->word boundary (e.g., HTTPServer -> HTTP|Server), but not H|T|T|P
         .replaceAll(/(?<abbr>[A-Z])(?<word>[A-Z][a-z])/gu, `$<abbr>${ZERO_WIDTH_SPACE}$<word>`)
 
-    const height = NODE_HEIGHT * (isFrontman ? 1.25 : 1.0)
+    const height = NODE_HEIGHT * (isFrontman ? FRONTMAN_SIZE_MULTIPLIER : 1.0)
     const width = height
 
     const getEditButton = () => (

--- a/packages/ui-common/components/MultiAgentAccelerator/GraphLayouts.ts
+++ b/packages/ui-common/components/MultiAgentAccelerator/GraphLayouts.ts
@@ -22,7 +22,7 @@ import {Edge, MarkerType, Node as RFNode} from "@xyflow/react"
 import cloneDeep from "lodash-es/cloneDeep.js"
 
 import {AgentConversation} from "./AgentConversations"
-import {AgentNodeProps, NODE_HEIGHT, NODE_WIDTH} from "./AgentNode"
+import {AgentNodeProps, FRONTMAN_SIZE_MULTIPLIER, NODE_HEIGHT, NODE_WIDTH} from "./AgentNode"
 import {BASE_RADIUS, DEFAULT_FRONTMAN_X_POS, DEFAULT_FRONTMAN_Y_POS, LEVEL_SPACING} from "./const"
 import {isEditableAgent} from "./TemporaryNetworks"
 import {ThoughtBubbleEdgeShape} from "./ThoughtBubbleEdge"
@@ -31,6 +31,9 @@ import {ConnectivityInfo} from "../../generated/neuro-san/NeuroSanClient"
 import {cleanUpAgentName, KNOWN_MESSAGE_TYPES_FOR_PLASMA} from "../AgentChat/Common/Utils"
 
 export const MAX_GLOBAL_THOUGHT_BUBBLES = 5
+
+const FRONTMAN_OFFSET_X = (NODE_WIDTH * (FRONTMAN_SIZE_MULTIPLIER - 1)) / 2
+const FRONTMAN_OFFSET_Y = (NODE_HEIGHT * (FRONTMAN_SIZE_MULTIPLIER - 1)) / 2
 
 /**
  * Result of the layout algorithms, containing the nodes and edges with their computed positions and properties.
@@ -273,7 +276,10 @@ export const layoutRadial = (
                         isTemporaryNetwork &&
                         isEditableAgent(agentsInNetwork.find((a) => a.origin === nodeId)?.display_as),
                 },
-                position: isFrontman ? {x: DEFAULT_FRONTMAN_X_POS, y: DEFAULT_FRONTMAN_Y_POS} : {x, y},
+                // position: allow for Frontman being larger
+                position: isFrontman
+                    ? {x: DEFAULT_FRONTMAN_X_POS - FRONTMAN_OFFSET_X, y: DEFAULT_FRONTMAN_Y_POS - FRONTMAN_OFFSET_Y}
+                    : {x, y},
                 style: {
                     border: "none",
                     background: "transparent",
@@ -398,12 +404,15 @@ export const layoutLinear = (
     // Convert dagre's layout to what our flow graph needs
     nodesTmp.forEach((node) => {
         const nodeWithPosition = dagreGraph.node(node.id)
+        const isFrontman = frontman?.origin === node.id
 
         // We are shifting the dagre node position (anchor=center) to the top left
         // so it matches the React Flow node anchor point (top left).
+        const x = nodeWithPosition.x - NODE_WIDTH / 2 - (isFrontman ? FRONTMAN_OFFSET_X : 0)
+        const y = nodeWithPosition.y - NODE_HEIGHT / 2 - (isFrontman ? FRONTMAN_OFFSET_Y : 0)
         node.position = {
-            x: nodeWithPosition.x - NODE_WIDTH / 2,
-            y: nodeWithPosition.y - NODE_HEIGHT / 2,
+            x,
+            y,
         }
 
         // Depth is index of x position in xPositions array


### PR DESCRIPTION
Just this.

Before | After
:-------------------------:|:-------------------------:
<img width="709" height="625" alt="image" src="https://github.com/user-attachments/assets/ac820267-033e-4795-bc7a-5df292263176" />|<img width="703" height="634" alt="image" src="https://github.com/user-attachments/assets/f75b3b88-bf1e-48c8-82a4-6374b155725d" />
