### PR TITLE
Add Checkmarx One workflow

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -6,9 +6,6 @@ permissions:
     security-events: write
 
 on:
-    push:
-        branches:
-            - devin/1781032792-add-checkmarx
     schedule:
         # M-F at 2:30 am UTC (offset from neuro-san to avoid contention)
         - cron: "30 2 * * 1-5"

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -6,6 +6,9 @@ permissions:
     security-events: write
 
 on:
+    push:
+        branches:
+            - devin/1781032792-add-checkmarx
     schedule:
         # M-F at 2:30 am UTC (offset from neuro-san to avoid contention)
         - cron: "30 2 * * 1-5"

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,0 +1,31 @@
+---
+name: Checkmarx One
+
+permissions:
+    contents: read
+    security-events: write
+
+on:
+    schedule:
+        # M-F at 2:30 am UTC (offset from neuro-san to avoid contention)
+        - cron: "30 2 * * 1-5"
+    workflow_dispatch:
+
+jobs:
+    checkmarx-scan:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              # v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+              with:
+                  fetch-depth: 0
+
+            - name: Run Checkmarx One scan
+              # build-common 1.0.7
+              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@3ead7f681f92044709ffc3a533f41c3f48230cfd
+              with:
+                  base-uri: ${{ vars.CX_BASE_URI }}
+                  cx-tenant: ${{ vars.CX_TENANT }}
+                  cx-client-id: ${{ vars.CX_CLIENT_ID }}
+                  cx-client-secret: ${{ secrets.CX_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary

Adds a Checkmarx One SAST/SCA scan workflow to close the gap with neuro-san. Runs on a M–F schedule (2:30 UTC, offset from neuro-san) and supports `workflow_dispatch` so it can be triggered manually from a branch. Uses the `build-common/actions/checkmarx-one@1.0.7` composite action with the same repo-level vars/secrets pattern as neuro-san.

Note that in neuro-san, we tried the action at PR time, but it was sometimes too slow. Therefore, we opted to just run it nightly on main. If any Checkmarx regressions are added, they will trigger a failure. This pipeline (like neuro-san) has been added to the NightWatcher so we'll see it in the morning.

Link to Devin session: https://app.devin.ai/sessions/fa003ff86bb34485a399856794ea8d65
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->