### PR TITLE
#316 Cache icon suggestions for agents and networks

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -95,10 +95,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -126,
-            branches: -158,
-            functions: -34,
-            lines: -97,
+            statements: -116,
+            branches: -156,
+            functions: -29,
+            lines: -89,
         },
     },
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -95,10 +95,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -145,
-            branches: -165,
-            functions: -43,
-            lines: -114,
+            statements: -126,
+            branches: -158,
+            functions: -34,
+            lines: -97,
         },
     },
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -95,10 +95,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -119,
-            branches: -159,
-            functions: -31,
-            lines: -92,
+            statements: -145,
+            branches: -165,
+            functions: -43,
+            lines: -114,
         },
     },
 

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -54,13 +54,8 @@ import {
 } from "../../../components/MultiAgentAccelerator/MultiAgentAccelerator"
 import {SidebarProps} from "../../../components/MultiAgentAccelerator/Sidebar/Sidebar"
 import {MAIN_TOUR_STEPS} from "../../../components/MultiAgentAccelerator/Tour/MainTourSteps"
-import {
-    getAgentFunction,
-    getAgentNetworks,
-    getConnectivity,
-    getNetworkIconSuggestions,
-    testConnection,
-} from "../../../controller/agent/Agent"
+import {getAgentFunction, getAgentNetworks, getConnectivity, testConnection} from "../../../controller/agent/Agent"
+import {getNetworkIconSuggestions} from "../../../controller/agent/IconSuggestions"
 import {ChatMessageType, ChatResponse, ConnectivityInfo} from "../../../generated/neuro-san/NeuroSanClient"
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
 import {useSettingsStore} from "../../../state/Settings"
@@ -82,6 +77,7 @@ let setSelectedNetwork: (network: string) => void
 jest.mock("next-auth/react")
 
 jest.mock("../../../controller/agent/Agent")
+jest.mock("../../../controller/agent/IconSuggestions")
 
 jest.mock("../../../components/MultiAgentAccelerator/AgentFlow", () => ({
     __esModule: true,

--- a/packages/ui-common/__tests__/unit/Controller/agent/Agent.test.ts
+++ b/packages/ui-common/__tests__/unit/Controller/agent/Agent.test.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {LIST_NETWORKS_RESPONSE, TEST_AGENT_MATH_GUY} from "../../../../../__tests__/common/NetworksListMock"
-import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
-import {mockFetch} from "../../../../../__tests__/common/TestUtils"
-import {AgentNetworkDefinitionEntry} from "../../../components/MultiAgentAccelerator/const"
+import {LIST_NETWORKS_RESPONSE, TEST_AGENT_MATH_GUY} from "../../../../../../__tests__/common/NetworksListMock"
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {mockFetch} from "../../../../../../__tests__/common/TestUtils"
+import {AgentNetworkDefinitionEntry} from "../../../../components/MultiAgentAccelerator/const"
 import {
     getAgentFunction,
     getAgentNetworks,
@@ -26,8 +26,8 @@ import {
     sendNetworkDesignerUpdate,
     testConnection,
     TestConnectionResult,
-} from "../../../controller/agent/Agent"
-import {sendLlmRequest, StreamingUnit} from "../../../controller/llm/LlmChat"
+} from "../../../../controller/agent/Agent"
+import {sendLlmRequest, StreamingUnit} from "../../../../controller/llm/LlmChat"
 import {
     ApiPaths,
     // eslint-disable-next-line camelcase
@@ -35,9 +35,9 @@ import {
     ChatHistory,
     ChatMessageType,
     ChatRequest,
-} from "../../../generated/neuro-san/NeuroSanClient"
+} from "../../../../generated/neuro-san/NeuroSanClient"
 
-jest.mock("../../../controller/llm/LlmChat")
+jest.mock("../../../../controller/llm/LlmChat")
 
 const NEURO_SAN_EXAMPLE_URL = "https://neuro-san.example.com"
 
@@ -111,7 +111,6 @@ describe("Controller/Agent/sendChatQuery", () => {
     const testQuery = "test query with special characters: !@#$%^&*()_+"
     const testUser = "test user"
     const chatContext = {chat_histories: [] as ChatHistory[]}
-    // TODO: ugly cast due to how openapi-typescript generates object types. What to do here?
     const slyData = {login: testUser}
 
     const expectedRequestParams: ChatRequest = {

--- a/packages/ui-common/__tests__/unit/Controller/agent/IconSuggestions.test.ts
+++ b/packages/ui-common/__tests__/unit/Controller/agent/IconSuggestions.test.ts
@@ -1,0 +1,108 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {mockFetch} from "../../../../../../__tests__/common/TestUtils"
+import {getAgentIconSuggestions, getNetworkIconSuggestions} from "../../../../controller/agent/IconSuggestions"
+import {AgentInfo, ConnectivityResponse} from "../../../../generated/neuro-san/NeuroSanClient"
+import {useIconSuggestionsStore} from "../../../../state/IconSuggestions"
+
+describe("Controller/Agent/getNetworkIconSuggestions", () => {
+    withStrictMocks()
+
+    beforeEach(() => {
+        // Clear the icon suggestions cache before each test
+        useIconSuggestionsStore.setState({
+            networkIconSuggestions: {},
+            agentIconSuggestions: {},
+        })
+    })
+
+    it("should retrieve network icon suggestions from the server and cache them", async () => {
+        const mockSuggestions = {test_agent: "home", other_agent: "settings"}
+        global.fetch = mockFetch(mockSuggestions)
+
+        const agentInfo: AgentInfo[] = [
+            {
+                agent_name: "test_agent",
+            },
+            {
+                agent_name: "other_agent",
+            },
+        ]
+        const result = await getNetworkIconSuggestions(agentInfo)
+
+        expect(result).toEqual(mockSuggestions)
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+
+        // Second time should be cached
+        const cachedResult = await getNetworkIconSuggestions(agentInfo)
+        expect(cachedResult).toEqual(mockSuggestions)
+        expect(global.fetch).toHaveBeenCalledTimes(1) // No additional fetch calls
+    })
+
+    it("should retrieve agent icon suggestions from the server and cache them", async () => {
+        const mockSuggestions = {test_agent: "home", other_agent: "settings"}
+        global.fetch = mockFetch(mockSuggestions)
+
+        const connectivityInfo: ConnectivityResponse = {
+            connectivity_info: [
+                {
+                    origin: "test_agent",
+                },
+                {
+                    origin: "other_agent",
+                },
+            ],
+        }
+        const result = await getAgentIconSuggestions(connectivityInfo)
+
+        expect(result).toEqual(mockSuggestions)
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+
+        // Second time should be cached
+        const cachedResult = await getAgentIconSuggestions(connectivityInfo)
+        expect(cachedResult).toEqual(mockSuggestions)
+        expect(global.fetch).toHaveBeenCalledTimes(1) // No additional fetch calls
+    })
+
+    it("Should throw on errors from fetch", async () => {
+        // Simulate failed fetch
+        const error = "Expected error"
+        global.fetch = mockFetch({error}, false)
+        await expect(
+            getAgentIconSuggestions({
+                connectivity_info: [{origin: "test_agent"}],
+            })
+        ).rejects.toThrow(error)
+
+        // Now with a bad response from the service with an "error" block
+        const badRequestText = "Bad Request"
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: false,
+                statusText: badRequestText,
+                json: () => Promise.resolve({}),
+            } as unknown as Response)
+        )
+
+        await expect(
+            getAgentIconSuggestions({
+                connectivity_info: [{origin: "test_agent"}],
+            })
+        ).rejects.toThrow(badRequestText)
+    })
+})

--- a/packages/ui-common/__tests__/unit/Controller/llm/LlmChat.test.ts
+++ b/packages/ui-common/__tests__/unit/Controller/llm/LlmChat.test.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import httpStatus from "http-status"
 
-import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
-import {sendLlmRequest, StreamingUnit} from "../../../controller/llm/LlmChat"
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {sendLlmRequest, StreamingUnit} from "../../../../controller/llm/LlmChat"
 
 const mockFetch = (mockChunks: Uint8Array<ArrayBuffer>[]) => {
     let readIndex = 0

--- a/packages/ui-common/__tests__/unit/Controller/llm/Providers.test.ts
+++ b/packages/ui-common/__tests__/unit/Controller/llm/Providers.test.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
-import {mockFetch} from "../../../../../__tests__/common/TestUtils"
-import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../../controller/llm/Providers"
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {mockFetch} from "../../../../../../__tests__/common/TestUtils"
+import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../../../controller/llm/Providers"
 
 describe("Providers controller", () => {
     withStrictMocks()

--- a/packages/ui-common/__tests__/unit/State/IconSuggestions.test.ts
+++ b/packages/ui-common/__tests__/unit/State/IconSuggestions.test.ts
@@ -1,0 +1,36 @@
+// Include mock for IndexedDB
+import "fake-indexeddb/auto"
+
+import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
+import {MAX_SUGGESTIONS, useIconSuggestionsStore} from "../../../state/IconSuggestions"
+
+describe("IconSuggestions", () => {
+    withStrictMocks()
+
+    it("should evict from the cache when the limit is reached", async () => {
+        useIconSuggestionsStore
+            .getState()
+            .setAgentIconSuggestions(
+                Object.fromEntries(Array.from({length: MAX_SUGGESTIONS}, (_, i) => [`agent${i}`, `icon${i}`]))
+            )
+
+        const suggestions = useIconSuggestionsStore.getState().agentIconSuggestions
+
+        // Make sure first and last item are in the cache
+        expect(suggestions["agent0"]).toBe("icon0")
+        expect(suggestions[`agent${MAX_SUGGESTIONS - 1}`]).toBe(`icon${MAX_SUGGESTIONS - 1}`)
+
+        // Now add a new item that exceeds the cache limit
+        useIconSuggestionsStore
+            .getState()
+            .setAgentIconSuggestions({[`agent${MAX_SUGGESTIONS}`]: `icon${MAX_SUGGESTIONS}`})
+
+        const newSuggestions = useIconSuggestionsStore.getState().agentIconSuggestions
+
+        // First item should be evicted
+        expect(newSuggestions["agent0"]).toBeUndefined()
+
+        // Last item should be present
+        expect(newSuggestions[`agent${MAX_SUGGESTIONS}`]).toBe(`icon${MAX_SUGGESTIONS}`)
+    })
+})

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -41,12 +41,11 @@ import {extractTemporaryNetworksFromMessage, isTemporaryNetwork, mergeNetworks} 
 import {ThoughtBubbleEdgeShape} from "./ThoughtBubbleEdge"
 import {
     getAgentFunction,
-    getAgentIconSuggestions,
     getAgentNetworks,
     getConnectivity,
-    getNetworkIconSuggestions,
     sendNetworkDesignerUpdate,
 } from "../../controller/agent/Agent"
+import {getAgentIconSuggestions, getNetworkIconSuggestions} from "../../controller/agent/IconSuggestions"
 import {AgentIconSuggestions} from "../../controller/Types/AgentIconSuggestions"
 import {NetworkIconSuggestions} from "../../controller/Types/NetworkIconSuggestions"
 import {AgentInfo, ConnectivityInfo, ConnectivityResponse} from "../../generated/neuro-san/NeuroSanClient"

--- a/packages/ui-common/controller/agent/Agent.ts
+++ b/packages/ui-common/controller/agent/Agent.ts
@@ -18,6 +18,7 @@ limitations under the License.
  * Controller module for interacting with the Agent LLM API.
  */
 
+import {postJsonRequest} from "./IconSuggestions"
 import {
     AGENT_NETWORK_DEFINITION_KEY,
     AGENT_NETWORK_DESIGNER_ID,
@@ -40,9 +41,7 @@ import {
     FunctionResponse,
 } from "../../generated/neuro-san/NeuroSanClient"
 import {sendLlmRequest, StreamingUnit} from "../llm/LlmChat"
-import {AgentIconSuggestions} from "../Types/AgentIconSuggestions"
 import {BrandingSuggestions} from "../Types/Branding"
-import {NetworkIconSuggestions} from "../Types/NetworkIconSuggestions"
 
 /**
  * Insert the target agent name into the path. The paths Api enum contains values like:
@@ -99,52 +98,6 @@ export const testConnection = async (url: string): Promise<TestConnectionResult>
         clearTimeout(timeout)
     }
 }
-
-/**
- * Utility function to send POST requests with JSON body and handle errors.
- * Used for getting LLM suggestions for icons and branding colors.
- * @template T The expected response type from the server.
- * @param endpoint The API endpoint to send the request to.
- * @param body The request body to send, which will be stringified to JSON.
- * @returns The response from the server parsed as JSON.
- * @throws An error if the request fails or the response is not ok.
- */
-const postJsonRequest = async <T>(endpoint: string, body: Record<string, unknown>): Promise<T> => {
-    const response = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-    })
-
-    const jsonResponse = await response.json()
-    if (!response.ok || jsonResponse.error) {
-        throw new Error(jsonResponse.error || response.statusText)
-    }
-
-    return jsonResponse
-}
-
-/**
- * Get LLM suggestions for network icons.
- * @param networks The list of networks to get icon suggestions for.
- * @returns A promise that resolves to a record mapping network names to icon names.
- */
-export const getNetworkIconSuggestions = async (networks: readonly AgentInfo[]): Promise<NetworkIconSuggestions> =>
-    postJsonRequest<Exclude<NetworkIconSuggestions, "error">>("/api/networkIconSuggestions", {networks})
-
-/**
- * Get LLM suggestions for agent icons based on their descriptions from Neuro-san
- * @param connectivity The connectivity information for the agents in the network, including their descriptions,
- * tools, and connections.
- * @return A promise that resolves to a record mapping agent names to suggested icon names.
- */
-export const getAgentIconSuggestions = async (connectivity: ConnectivityResponse): Promise<AgentIconSuggestions> =>
-    postJsonRequest<AgentIconSuggestions>("/api/agentIconSuggestions", {
-        connectivity_info: connectivity.connectivity_info,
-        metadata: connectivity.metadata,
-    })
 
 /**
  * Get LLM suggestions for branding colors based on the company name. This is used to customize the UI colors
@@ -308,7 +261,7 @@ export const sendNetworkDesignerUpdate = async (
     await sendChatQuery(
         url,
         signal,
-        // Shouldn't have to pass a user message, but API behaves different without it
+        // Shouldn't have to pass a user message, but API behaves differently without it
         `Update instructions for agent "${agentName}"`,
         AGENT_NETWORK_DESIGNER_ID,
         onChunk,

--- a/packages/ui-common/controller/agent/IconSuggestions.ts
+++ b/packages/ui-common/controller/agent/IconSuggestions.ts
@@ -1,0 +1,113 @@
+import {AgentInfo, ConnectivityResponse} from "../../generated/neuro-san/NeuroSanClient"
+import {useIconSuggestionsStore} from "../../state/IconSuggestions"
+import {AgentIconSuggestions} from "../Types/AgentIconSuggestions"
+import {NetworkIconSuggestions} from "../Types/NetworkIconSuggestions"
+
+/**
+ * Utility function to send POST requests with JSON body and handle errors.
+ * Used for getting LLM suggestions for icons and branding colors.
+ * @template T The expected response type from the server.
+ * @param endpoint The API endpoint to send the request to.
+ * @param body The request body to send, which will be stringified to JSON.
+ * @returns The response from the server parsed as JSON.
+ * @throws An error if the request fails or the response is not ok.
+ */
+export const postJsonRequest = async <T>(endpoint: string, body: Record<string, unknown>): Promise<T> => {
+    const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+    })
+
+    const jsonResponse = await response.json()
+    if (!response.ok || jsonResponse.error) {
+        throw new Error(jsonResponse.error || response.statusText)
+    }
+
+    return jsonResponse
+}
+
+// The two types of suggestions we can get from the LLM
+type Suggestions = AgentIconSuggestions | NetworkIconSuggestions
+
+/**
+ * Utility function to get icon suggestions from the cache or fetch from the server if not available in the cache.
+ *
+ * @param keys - The list of keys (agent names or network names) to get suggestions for.
+ * @param storeKey - The key in the cache (zustand store) to save the suggestions under.
+ * @param fetchSuggestions - Fetch function to query the LLM for suggestions
+ * @returns A promise that resolves to a record mapping the keys to suggested MUI icon names.
+ */
+const getSuggestions = async (
+    keys: readonly string[],
+    storeKey: "networkIconSuggestions" | "agentIconSuggestions",
+    fetchSuggestions: () => Promise<Suggestions>
+): Promise<Suggestions> => {
+    // Check the cache for suggestions for all the keys.
+    // If any key is missing, we will fetch suggestions for all keys to keep it simple.
+    const cache = useIconSuggestionsStore.getState()[storeKey]
+
+    // Get the cached suggestions for the keys that are available in the cache
+    const cachedSuggestions = keys.reduce<Suggestions>((acc, key) => {
+        const cached = cache[key]
+        if (cached) acc[key] = cached
+        return acc
+    }, {})
+
+    // If we have cached suggestions for all keys, return them
+    if (Object.keys(cachedSuggestions).length === keys.length) {
+        return cachedSuggestions
+    }
+
+    // Cache miss. Request suggestions from LLM
+    const fetched = await fetchSuggestions()
+
+    // Write-through cache.
+    useIconSuggestionsStore.setState((state) => ({
+        [storeKey]: {
+            ...state[storeKey],
+            ...fetched,
+        },
+    }))
+
+    return fetched
+}
+
+/**
+ * Get LLM suggestions for network icons.
+ *
+ * @note Will use cached suggestions if available to avoid unnecessary LLM calls
+ *
+ * @param networks The list of networks to get icon suggestions for.
+ * @returns A promise that resolves to a record mapping network names to suggested MUI icon names.
+ */
+export const getNetworkIconSuggestions = async (networks: readonly AgentInfo[]): Promise<NetworkIconSuggestions> =>
+    getSuggestions(
+        networks.map((network) => network.agent_name),
+        "networkIconSuggestions",
+        () => postJsonRequest<NetworkIconSuggestions>("/api/networkIconSuggestions", {networks})
+    )
+/**
+ * Get LLM suggestions for agent icons based on their descriptions from Neuro-san.
+ *
+ * @note The entire connectivity information and metadata are sent as input to the LLM to help the LLM come up with
+ * better suggestions.
+ *
+ * @note Will use cached suggestions if available to avoid unnecessary LLM calls
+ *
+ * @param connectivity The connectivity information for the agents in the network, including their descriptions,
+ * tools, and connections.
+ * @return A promise that resolves to a record mapping agent names to suggested MUI icon names.
+ */
+export const getAgentIconSuggestions = async (connectivity: ConnectivityResponse): Promise<AgentIconSuggestions> =>
+    getSuggestions(
+        connectivity.connectivity_info.map((agent) => agent.origin),
+        "agentIconSuggestions",
+        () =>
+            postJsonRequest<AgentIconSuggestions>("/api/agentIconSuggestions", {
+                connectivity_info: connectivity.connectivity_info,
+                metadata: connectivity.metadata,
+            })
+    )

--- a/packages/ui-common/controller/agent/IconSuggestions.ts
+++ b/packages/ui-common/controller/agent/IconSuggestions.ts
@@ -23,7 +23,7 @@ export const postJsonRequest = async <T>(endpoint: string, body: Record<string, 
 
     const jsonResponse = await response.json()
     if (!response.ok || jsonResponse.error) {
-        throw new Error(jsonResponse.error || response.statusText)
+        throw new Error(jsonResponse?.error || response?.statusText)
     }
 
     return jsonResponse
@@ -52,7 +52,9 @@ const getSuggestions = async (
     // Get the cached suggestions for the keys that are available in the cache
     const cachedSuggestions = keys.reduce<Suggestions>((acc, key) => {
         const cached = cache[key]
-        if (cached) acc[key] = cached
+        if (cached) {
+            acc[key] = cached
+        }
         return acc
     }, {})
 

--- a/packages/ui-common/controller/agent/IconSuggestions.ts
+++ b/packages/ui-common/controller/agent/IconSuggestions.ts
@@ -67,12 +67,13 @@ const getSuggestions = async (
     const fetched = await fetchSuggestions()
 
     // Write-through cache.
-    useIconSuggestionsStore.setState((state) => ({
-        [storeKey]: {
-            ...state[storeKey],
-            ...fetched,
-        },
-    }))
+    const state = useIconSuggestionsStore.getState()
+
+    if (storeKey === "agentIconSuggestions") {
+        state.setAgentIconSuggestions(fetched)
+    } else {
+        state.setNetworkIconSuggestions(fetched)
+    }
 
     return fetched
 }

--- a/packages/ui-common/state/IconSuggestions.ts
+++ b/packages/ui-common/state/IconSuggestions.ts
@@ -21,7 +21,7 @@ import {AgentIconSuggestions} from "../controller/Types/AgentIconSuggestions"
 import {NetworkIconSuggestions} from "../controller/Types/NetworkIconSuggestions"
 
 // Store this many suggestions of each type before we start discarding the oldest ones.
-const MAX_SUGGESTIONS = 250
+export const MAX_SUGGESTIONS = 250
 
 /**
  * Zustand state store for temporary networks, such as vibe coded networks created by the user.

--- a/packages/ui-common/state/IconSuggestions.ts
+++ b/packages/ui-common/state/IconSuggestions.ts
@@ -1,0 +1,76 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {create} from "zustand"
+import {persist} from "zustand/middleware"
+
+import {AgentIconSuggestions} from "../controller/Types/AgentIconSuggestions"
+import {NetworkIconSuggestions} from "../controller/Types/NetworkIconSuggestions"
+
+// Store this many suggestions of each type before we start discarding the oldest ones.
+const MAX_SUGGESTIONS = 250
+
+/**
+ * Zustand state store for temporary networks, such as vibe coded networks created by the user.
+ */
+interface IconSuggestionsStore {
+    readonly networkIconSuggestions: NetworkIconSuggestions
+    readonly setNetworkIconSuggestions: (networkIconSuggestions: NetworkIconSuggestions) => void
+    readonly agentIconSuggestions: AgentIconSuggestions
+    readonly setAgentIconSuggestions: (agentIconSuggestions: AgentIconSuggestions) => void
+}
+
+/**
+ * Combines new suggestions with existing ones and truncates the result to MAX_SUGGESTIONS (cache eviction)
+ *
+ * @param current - The current suggestion object.
+ * @param newSuggestions - The new suggestions to add.
+ * @returns The updated and trimmed suggestion object.
+ **/
+const updateSuggestions = <T extends object>(current: T, newSuggestions: T): T => {
+    const combined = {...current, ...newSuggestions}
+    const entries = Object.entries(combined)
+
+    if (entries.length > MAX_SUGGESTIONS) {
+        const sliced = entries.slice(entries.length - MAX_SUGGESTIONS)
+        return Object.fromEntries(sliced) as T
+    }
+
+    return combined
+}
+
+/**
+ * The hook that lets apps use the store.
+ */
+export const useIconSuggestionsStore = create<IconSuggestionsStore>()(
+    persist(
+        (set) => ({
+            networkIconSuggestions: {},
+            setNetworkIconSuggestions: (newSuggestions) =>
+                set((state) => ({
+                    networkIconSuggestions: updateSuggestions(state.networkIconSuggestions, newSuggestions),
+                })),
+            agentIconSuggestions: {},
+            setAgentIconSuggestions: (newSuggestions) =>
+                set((state) => ({
+                    agentIconSuggestions: updateSuggestions(state.agentIconSuggestions, newSuggestions),
+                })),
+        }),
+        {
+            name: "icon-suggestions-store",
+        }
+    )
+)


### PR DESCRIPTION
Technical PR only.

Uses a simple caching strategy to cache the suggested icons for agents and entire networks. The suggestions are stored in local storage using a standard Zustand store with auto persistence, and cache eviction when the item limit is hit. Other than that, no expiration.

This will save a lot of calls to the icon-suggesting services and thereby will save us a lot of provider tokens.

Another benefit: for cached networks, the custom icons load instantaneously.

Tested locally, confirmed that when the cache is warmed up, no outgoing network requests are made.

I considered using a server-side cache, which is certainly possible, but (1) that would mean either hand-rolling, 3rd party lib/memcached/nginx stuff, or doubling down on Next.js's cache which we don't want to do because we have a troubled relationship with Next.js and (2) this solution is even better, as it avoids the network traffic in the first place as well as saving on LLM tokens. This will also still work when/if we migrate the icon suggestion agents to Neuro-san.