### PR TITLE
#415 Clean up various absolute positioning hacks; fix fast reload

### DIFF
--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
@@ -26,12 +26,8 @@ import {
 } from "../../../../../../__tests__/common/NetworksListMock"
 import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
 import {USER_AGENTS} from "../../../../../../__tests__/common/UserAgentTestUtils"
-import {
-    ChatCommon,
-    ChatCommonHandle,
-    ChatCommonProps,
-    MAX_TURNS,
-} from "../../../../components/AgentChat/ChatCommon/ChatCommon"
+import {ChatCommon, ChatCommonHandle, ChatCommonProps} from "../../../../components/AgentChat/ChatCommon/ChatCommon"
+import {MAX_TURNS} from "../../../../components/AgentChat/ChatCommon/Const"
 import {MAX_SAMPLE_QUERIES, QUERY_TRUNCATE_LENGTH} from "../../../../components/AgentChat/ChatCommon/SampleQueries"
 import {CombinedAgentType, givesFinalAnswer, LegacyAgentType} from "../../../../components/AgentChat/Common/Types"
 import {getAgentFunction, getConnectivity, sendChatQuery} from "../../../../controller/agent/Agent"
@@ -39,6 +35,7 @@ import {sendLlmRequest, StreamingUnit} from "../../../../controller/llm/LlmChat"
 import {ChatContext, ChatMessage, ChatMessageType, ChatResponse} from "../../../../generated/neuro-san/NeuroSanClient"
 import {useAgentChatHistoryStore} from "../../../../state/ChatHistory"
 import {useSettingsStore} from "../../../../state/Settings"
+import {getZIndex} from "../../../../utils/zIndexLayers"
 
 // Mock agent API
 jest.mock("../../../../controller/agent/Agent")
@@ -89,28 +86,29 @@ describe("ChatCommon", () => {
     const renderChatCommonComponent = (
         overrides: Partial<ChatCommonProps> & {ref?: Ref<ChatCommonHandle>} = {},
         mode: PaletteMode = "light"
-    ) =>
-        render(
-            <ThemeProvider
-                theme={createTheme({
-                    colorSchemes: {
-                        light: {palette: {text: {primary: "#112233"}}},
-                        dark: {palette: {text: {primary: "#445566"}}},
-                    },
-                    palette: {
-                        mode,
-                    },
-                    zIndex: {
-                        modal: MODAL_Z_INDEX,
-                    },
-                })}
-            >
-                <ChatCommon
-                    {...defaultProps}
-                    {...overrides}
-                />
-            </ThemeProvider>
-        )
+    ) => {
+        const theme = createTheme({
+            colorSchemes: {
+                light: {palette: {text: {primary: "#112233"}}},
+                dark: {palette: {text: {primary: "#445566"}}},
+            },
+            palette: {
+                mode,
+            },
+            zIndex: {modal: MODAL_Z_INDEX},
+        })
+        return {
+            render: render(
+                <ThemeProvider theme={theme}>
+                    <ChatCommon
+                        {...defaultProps}
+                        {...overrides}
+                    />
+                </ThemeProvider>
+            ),
+            theme,
+        }
+    }
 
     beforeEach(() => {
         user = userEvent.setup({delay: null})
@@ -582,7 +580,9 @@ describe("ChatCommon", () => {
     })
 
     it("Should correctly handle chat context", async () => {
-        const {rerender} = renderChatCommonComponent()
+        const {
+            render: {rerender},
+        } = renderChatCommonComponent()
 
         const responseMessage = getResponseMessage(ChatMessageType.AGENT_FRAMEWORK, "Sample AI response")
 
@@ -613,7 +613,9 @@ describe("ChatCommon", () => {
     })
 
     it("Should not clear chat when a new agent is selected", async () => {
-        const {rerender} = renderChatCommonComponent()
+        const {
+            render: {rerender},
+        } = renderChatCommonComponent()
 
         // Make sure first agent greeting appears
         await screen.findByText(TEST_AGENT_MATH_GUY)
@@ -645,7 +647,7 @@ describe("ChatCommon", () => {
 
     it("Should refuse interaction when no target agent is set", async () => {
         const mockSendFunction = jest.fn()
-        renderChatCommonComponent({onSend: mockSendFunction, selectedNetwork: null})
+        const {theme} = renderChatCommonComponent({onSend: mockSendFunction, selectedNetwork: null})
 
         // Should be no "Chat with"
         expect(screen.queryByPlaceholderText(/Chat with/u)).not.toBeInTheDocument()
@@ -653,14 +655,14 @@ describe("ChatCommon", () => {
         const overlay = document.getElementById("chat-disabled-overlay")
         expect(overlay).toHaveStyle({
             position: "absolute",
-            zIndex: MODAL_Z_INDEX - 1,
+            zIndex: getZIndex(2, theme),
             cursor: "not-allowed",
             pointerEvents: "all",
         })
     })
 
     it("Should refuse interaction when API keys are required but not present", async () => {
-        renderChatCommonComponent({missingApiKeys: ["OpenAI"]})
+        const {theme} = renderChatCommonComponent({missingApiKeys: ["OpenAI"]})
 
         // Should be no "Chat with"
         expect(screen.queryByPlaceholderText(/Chat with/u)).not.toBeInTheDocument()
@@ -670,7 +672,7 @@ describe("ChatCommon", () => {
         const overlay = document.getElementById("chat-disabled-overlay")
         expect(overlay).toHaveStyle({
             position: "absolute",
-            zIndex: MODAL_Z_INDEX - 1,
+            zIndex: getZIndex(2, theme),
             cursor: "not-allowed",
             pointerEvents: "all",
         })

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -44,14 +44,12 @@ import {
     AGENT_NETWORK_NAME_KEY,
     AGENT_PROGRESS_CONNECTIVITY_KEY,
     AGENT_RESERVATIONS_KEY,
+    GRACE_PERIOD_MS,
+    SHOW_TOUR_DELAY_MS,
     TEMPORARY_NETWORK_FOLDER,
     TRIGGER_APP_TOUR_EVENT_NAME,
 } from "../../../components/MultiAgentAccelerator/const"
-import {
-    GRACE_PERIOD_MS,
-    MultiAgentAccelerator,
-    SHOW_TOUR_DELAY_MS,
-} from "../../../components/MultiAgentAccelerator/MultiAgentAccelerator"
+import {MultiAgentAccelerator} from "../../../components/MultiAgentAccelerator/MultiAgentAccelerator"
 import {SidebarProps} from "../../../components/MultiAgentAccelerator/Sidebar/Sidebar"
 import {MAIN_TOUR_STEPS} from "../../../components/MultiAgentAccelerator/Tour/MainTourSteps"
 import {getAgentFunction, getAgentNetworks, getConnectivity, testConnection} from "../../../controller/agent/Agent"

--- a/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
@@ -51,6 +51,7 @@ import {
 import {v4 as uuid} from "uuid"
 
 import {ChatHistory} from "./ChatHistory"
+import {MAX_TURNS} from "./Const"
 import {ControlButtons} from "./ControlButtons"
 import {Conversation} from "./Conversation"
 import {ConversationTurn, MessageRole} from "./ConversationTurn"
@@ -63,12 +64,14 @@ import {ChatMessage, ChatMessageType} from "../../../generated/neuro-san/NeuroSa
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
 import {LLMProvider, useSettingsStore} from "../../../state/Settings"
 import {hasOnlyWhitespace} from "../../../utils/text"
+import {getZIndex} from "../../../utils/zIndexLayers"
 import {AGENT_NETWORK_DESIGNER_ID} from "../../MultiAgentAccelerator/const"
 import {CombinedAgentType, givesFinalAnswer, isLegacyAgentType} from "../Common/Types"
 import {chatMessageFromChunk, checkError, cleanUpAgentName, removeTrailingUuid} from "../Common/Utils"
 import {MicrophoneButton} from "../VoiceChat/MicrophoneButton"
 import {cleanupAndStopSpeechRecognition, setupSpeechRecognition, SpeechRecognitionState} from "../VoiceChat/VoiceChat"
 
+//#region Types and Interfaces
 export interface ChatCommonProps {
     /**
      * HTML id to use for the outer component
@@ -191,18 +194,22 @@ export interface ChatCommonProps {
     readonly missingApiKeys?: LLMProvider[]
 }
 
+// Type for forward ref to expose the handleStop and handleClearChat functions
+export type ChatCommonHandle = {
+    handleStop: () => void
+    handleClearChat: () => void
+}
+
+//#endregion
+
+//#region Constants
+
 // Define fancy EMPTY constant to avoid linter error about using object literals as default props
 const EMPTY: Partial<Record<CombinedAgentType, string>> = {}
 
 // How many times to retry the entire agent interaction process. Some networks have a well-defined success condition.
 // For others, it's just "whenever the stream is done".
 const MAX_AGENT_RETRIES = 3
-
-// Type for forward ref to expose the handleStop and handleClearChat functions
-export type ChatCommonHandle = {
-    handleStop: () => void
-    handleClearChat: () => void
-}
 
 /**
  * Extract the final answer from the response from a legacy agent
@@ -212,8 +219,7 @@ export type ChatCommonHandle = {
 const extractFinalAnswer = (response: string) =>
     /Final Answer: (?<finalAnswerText>.*)/su.exec(response)?.groups?.["finalAnswerText"]
 
-// Maximum number of turns to save
-export const MAX_TURNS = 50
+//#endregion
 
 /**
  * Common chat component for agent chat. This component is used by all agent chat components to provide a consistent
@@ -800,7 +806,7 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                 left: 0,
                 right: 0,
                 bottom: 0,
-                zIndex: theme.zIndex.modal - 1,
+                zIndex: getZIndex(2, theme),
                 cursor: "not-allowed",
                 // Capture all pointer events to prevent interaction with the chat when no agent is selected
                 pointerEvents: "all",
@@ -855,9 +861,12 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
     const getOptionsMenuButton = () => (
         <Box
             sx={{
+                backgroundColor: theme.palette.background.paper,
+                borderRadius: "var(--bs-border-radius)",
                 position: "absolute",
-                top: "0.25rem",
-                right: "0.0rem",
+                right: theme.spacing(2.5),
+                top: theme.spacing(1),
+                zIndex: getZIndex(2, theme),
             }}
         >
             <IconButton
@@ -866,7 +875,7 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                     setOptionsMenuOpen(true)
                 }}
             >
-                <TuneIcon sx={{fontSize: "1.2rem"}} />
+                <TuneIcon fontSize="small" />
             </IconButton>
         </Box>
     )
@@ -927,6 +936,103 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
         </Menu>
     )
 
+    const getNetworkIntro = () => (
+        <Box sx={{marginBottom: "0.5rem", marginTop: "1rem"}}>
+            <Typography
+                component="span"
+                sx={{fontWeight: 700}}
+                variant="inherit"
+            >
+                {networkDisplayName}
+                {networkDescription && ":"}
+            </Typography>
+            {networkDescription && (
+                <Typography
+                    component="span"
+                    sx={{ml: 0.5}}
+                    variant="inherit"
+                >
+                    {" "}
+                    {networkDescription}
+                </Typography>
+            )}
+        </Box>
+    )
+
+    const getChatHistory = () => (
+        <>
+            {agentChatHistory?.chatHistory?.length > 0 && (
+                <Box sx={{my: "0.5rem"}}>
+                    <ChatHistory
+                        id={id}
+                        messages={agentChatHistory.chatHistory}
+                    />
+                </Box>
+            )}
+        </>
+    )
+
+    const getAgentGreeting = () => <Box sx={{marginBottom: "0.5rem", marginTop: "1rem"}}>{agentGreeting}</Box>
+
+    const getControlButtons = () => (
+        <Box
+            sx={{
+                bottom: theme.spacing(3),
+                right: theme.spacing(3),
+                position: "absolute",
+                zIndex: getZIndex(2, theme),
+            }}
+        >
+            <ControlButtons
+                enableClearChatButton={enableClearChatButton}
+                handleClearChat={handleClearChat}
+                handleSend={handleSend}
+                handleStop={handleStop}
+                isAwaitingLlm={isAwaitingLlm}
+                previousUserQuery={previousUserQuery}
+                shouldEnableRegenerateButton={shouldEnableRegenerateButton}
+            />
+        </Box>
+    )
+
+    const getWorkingSpinner = () => (
+        <>
+            {isAwaitingLlm && (
+                <Box
+                    id="awaitingOutputContainer"
+                    sx={{display: "flex", alignItems: "center", fontSize: "smaller"}}
+                >
+                    <span
+                        id="working-span"
+                        style={{marginRight: "1rem"}}
+                    >
+                        Working...
+                    </span>
+                    <CircularProgress
+                        id="awaitingOutputSpinner"
+                        sx={{
+                            color: "var(--bs-primary)",
+                        }}
+                        size="1rem"
+                    />
+                </Box>
+            )}
+        </>
+    )
+
+    const getThinking = () => (
+        <>
+            {!isAwaitingLlm && turns.length > 0 && (
+                // Only show thinking once streaming is complete
+                <Thinking
+                    id={id}
+                    turns={turns}
+                    useNativeNames={useNativeNames}
+                />
+            )}
+        </>
+    )
+
     const getResponseBox = () => (
         <Box
             id="llm-response-div"
@@ -960,33 +1066,9 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
             >
                 {getOptionsMenu()}
                 {getOptionsMenuButton()}
-                {agentChatHistory?.chatHistory?.length > 0 && (
-                    <ChatHistory
-                        id={id}
-                        messages={agentChatHistory.chatHistory}
-                    />
-                )}
-                <Box sx={{marginBottom: "0.5rem", marginTop: "1rem", color: "var(--bs-gray)"}}>
-                    <Typography
-                        component="span"
-                        sx={{fontWeight: 700}}
-                        variant="inherit"
-                    >
-                        {networkDisplayName}
-                        {networkDescription && ":"}
-                    </Typography>
-                    {networkDescription && (
-                        <Typography
-                            component="span"
-                            sx={{ml: 0.5}}
-                            variant="inherit"
-                        >
-                            {" "}
-                            {networkDescription}
-                        </Typography>
-                    )}
-                </Box>
-                <Box sx={{marginBottom: "0.5rem", marginTop: "1rem"}}>{agentGreeting}</Box>
+                {getChatHistory()}
+                {getNetworkIntro()}
+                {getAgentGreeting()}
                 <SampleQueries
                     disabled={isAwaitingLlm}
                     handleSend={handleSend}
@@ -998,45 +1080,10 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                     shouldWrapOutput={shouldWrapOutput}
                     turns={turns}
                 />
-                {!isAwaitingLlm && turns.length > 0 && (
-                    // Only show thinking once streaming is complete
-                    <Thinking
-                        id={id}
-                        turns={turns}
-                        useNativeNames={useNativeNames}
-                    />
-                )}
-                {isAwaitingLlm && (
-                    <Box
-                        id="awaitingOutputContainer"
-                        sx={{display: "flex", alignItems: "center", fontSize: "smaller"}}
-                    >
-                        <span
-                            id="working-span"
-                            style={{marginRight: "1rem"}}
-                        >
-                            Working...
-                        </span>
-                        <CircularProgress
-                            id="awaitingOutputSpinner"
-                            sx={{
-                                color: "var(--bs-primary)",
-                            }}
-                            size="1rem"
-                        />
-                    </Box>
-                )}
+                {getThinking()}
+                {getWorkingSpinner()}
+                {getControlButtons()}
             </Box>
-
-            <ControlButtons
-                enableClearChatButton={enableClearChatButton}
-                handleClearChat={handleClearChat}
-                handleSend={handleSend}
-                handleStop={handleStop}
-                isAwaitingLlm={isAwaitingLlm}
-                previousUserQuery={previousUserQuery}
-                shouldEnableRegenerateButton={shouldEnableRegenerateButton}
-            />
         </Box>
     )
 
@@ -1045,9 +1092,9 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
             id="user-input-div"
             sx={{
                 ...divStyle,
+                alignItems: "center",
                 display: "flex",
                 margin: "10px",
-                alignItems: "flex-end",
                 position: "relative",
             }}
         >
@@ -1115,21 +1162,21 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                 }
             />
 
-            {/* Microphone Button */}
-            <MicrophoneButton
-                isMicOn={isMicOn}
-                onMicToggle={setIsMicOn}
-                speechRecognitionRef={speechRecognitionRef}
-                voiceInputState={voiceInputState}
-                setVoiceInputState={setVoiceInputState}
-            />
+            <Box sx={{display: "flex", gap: "0.25rem", position: "relative", alignItems: "center"}}>
+                <MicrophoneButton
+                    isMicOn={isMicOn}
+                    onMicToggle={setIsMicOn}
+                    setVoiceInputState={setVoiceInputState}
+                    speechRecognitionRef={speechRecognitionRef}
+                    voiceInputState={voiceInputState}
+                />
 
-            {/* Send Button */}
-            <SendButton
-                enableSendButton={shouldEnableSendButton}
-                id="submit-query-button"
-                onClickCallback={() => handleSend(chatInput)}
-            />
+                <SendButton
+                    enableSendButton={shouldEnableSendButton}
+                    id="submit-query-button"
+                    onClickCallback={() => handleSend(chatInput)}
+                />
+            </Box>
         </Box>
     )
 
@@ -1152,48 +1199,51 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
         </Box>
     )
 
+    const getSelectNetworkOverlayBody = () => (
+        <Typography component="span">
+            Please select a Network from the list to start the chat, or click
+            <IconButton
+                onClick={() => setSelectedNetwork?.(AGENT_NETWORK_DESIGNER_ID)}
+                aria-label="select-network-designer"
+                sx={{
+                    px: 0.5,
+                    verticalAlign: "middle",
+                    mb: "4px",
+                }}
+            >
+                <AddBoxRounded
+                    sx={{
+                        color: "var(--bs-secondary)",
+                        fontSize: "1rem",
+                    }}
+                />
+            </IconButton>
+            to design your own network!
+        </Typography>
+    )
+
+    const allApiKeysPresent = missingApiKeys?.length === 0
+
+    const getMissingApiKeysOverlayBody = () => (
+        <Typography component="span">
+            {`API key(s) required for: ${missingApiKeys.join(", ")}. Please add the required key(s) in
+                              "Settings" to use this Network.`}
+        </Typography>
+    )
+
     return (
         <Box
             id={`llm-chat-${id}`}
             sx={{
-                display: "flex",
-                flexDirection: "column",
-                flexGrow: 1,
                 height: "100%",
                 position: "relative",
             }}
         >
             {selectedNetwork
-                ? missingApiKeys?.length === 0
+                ? allApiKeysPresent
                     ? getChatBox()
-                    : getErrorOverlay(
-                          <Typography component="span">
-                              {`API key(s) required for: ${missingApiKeys.join(", ")}. Please add the required key(s) in
-                              "Settings" to use this Network.`}
-                          </Typography>
-                      )
-                : getErrorOverlay(
-                      <Typography component="span">
-                          Please select a Network from the list to start the chat, or click
-                          <IconButton
-                              onClick={() => setSelectedNetwork?.(AGENT_NETWORK_DESIGNER_ID)}
-                              aria-label="select-network-designer"
-                              sx={{
-                                  px: 0.5,
-                                  verticalAlign: "middle",
-                                  mb: "4px",
-                              }}
-                          >
-                              <AddBoxRounded
-                                  sx={{
-                                      color: "var(--bs-secondary)",
-                                      fontSize: "1rem",
-                                  }}
-                              />
-                          </IconButton>
-                          to design your own network!
-                      </Typography>
-                  )}
+                    : getErrorOverlay(getMissingApiKeysOverlayBody())
+                : getErrorOverlay(getSelectNetworkOverlayBody())}
         </Box>
     )
 }

--- a/packages/ui-common/components/AgentChat/ChatCommon/Const.ts
+++ b/packages/ui-common/components/AgentChat/ChatCommon/Const.ts
@@ -1,0 +1,2 @@
+// Maximum number of turns to save
+export const MAX_TURNS = 50

--- a/packages/ui-common/components/AgentChat/ChatCommon/ControlButtons.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/ControlButtons.tsx
@@ -17,11 +17,12 @@ limitations under the License.
 import DeleteOutlined from "@mui/icons-material/DeleteOutlined"
 import Loop from "@mui/icons-material/Loop"
 import StopCircle from "@mui/icons-material/StopCircle"
+import Box from "@mui/material/Box"
 import {FC} from "react"
 
 import {SmallLlmChatButton} from "../Common/LlmChatButton"
 
-// #region: Types
+//#region: Types
 interface ControlButtonsProps {
     handleClearChat: () => void
     enableClearChatButton: boolean
@@ -31,10 +32,10 @@ interface ControlButtonsProps {
     previousUserQuery: string
     shouldEnableRegenerateButton: boolean
 }
-// #endregion: Types
+//#endregion: Types
 
 /**
- * Generate the Control Buttons for a chat window.
+ * Generate the Control Buttons for a chat window (resend, clear chat, stop)
  * @returns A fragment containing the Control Buttons.
  */
 export const ControlButtons: FC<ControlButtonsProps> = ({
@@ -47,58 +48,47 @@ export const ControlButtons: FC<ControlButtonsProps> = ({
     shouldEnableRegenerateButton,
 }) => (
     <>
-        {/*Clear Chat button*/}
-        {!isAwaitingLlm && (
-            <SmallLlmChatButton
-                aria-label="Clear Chat"
-                disabled={!enableClearChatButton}
-                id="clear-chat-button"
-                onClick={handleClearChat}
-                posBottom={8}
-                posRight={65}
-            >
-                <DeleteOutlined
-                    fontSize="small"
-                    id="stop-button-icon"
-                    sx={{color: "var(--bs-white)"}}
-                />
-            </SmallLlmChatButton>
-        )}
-
-        {/*Stop Button*/}
-        {isAwaitingLlm && (
+        {isAwaitingLlm ? (
+            // Stop Button
             <SmallLlmChatButton
                 aria-label="Stop"
                 disabled={!isAwaitingLlm}
                 id="stop-output-button"
                 onClick={() => handleStop()}
-                posBottom={8}
-                posRight={23}
             >
                 <StopCircle
                     fontSize="small"
                     id="stop-button-icon"
-                    sx={{color: "var(--bs-white)"}}
                 />
             </SmallLlmChatButton>
-        )}
+        ) : (
+            <Box sx={{display: "flex", gap: 1}}>
+                {/*Clear Chat button*/}
+                <SmallLlmChatButton
+                    aria-label="Clear Chat"
+                    disabled={!enableClearChatButton}
+                    id="clear-chat-button"
+                    onClick={handleClearChat}
+                >
+                    <DeleteOutlined
+                        fontSize="small"
+                        id="stop-button-icon"
+                    />
+                </SmallLlmChatButton>
 
-        {/*Regenerate Button*/}
-        {!isAwaitingLlm && (
-            <SmallLlmChatButton
-                aria-label="Regenerate"
-                disabled={!shouldEnableRegenerateButton}
-                id="regenerate-output-button"
-                onClick={() => handleSend(previousUserQuery)}
-                posBottom={8}
-                posRight={23}
-            >
-                <Loop
-                    fontSize="small"
-                    id="generate-icon"
-                    sx={{color: "var(--bs-white)"}}
-                />
-            </SmallLlmChatButton>
+                {/*Regenerate Button*/}
+                <SmallLlmChatButton
+                    aria-label="Regenerate"
+                    disabled={!shouldEnableRegenerateButton}
+                    id="regenerate-output-button"
+                    onClick={() => handleSend(previousUserQuery)}
+                >
+                    <Loop
+                        fontSize="small"
+                        id="generate-icon"
+                    />
+                </SmallLlmChatButton>
+            </Box>
         )}
     </>
 )

--- a/packages/ui-common/components/AgentChat/ChatCommon/SendButton.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SendButton.tsx
@@ -15,38 +15,47 @@ limitations under the License.
 */
 
 import SendIcon from "@mui/icons-material/Send"
+import Tooltip from "@mui/material/Tooltip"
 import {FC} from "react"
 
 import {LlmChatButton} from "../Common/LlmChatButton"
 
-// #region: Types
+//#region: Types
 interface SendButtonProps {
     enableSendButton: boolean
     id: string
     onClickCallback: () => void
 }
-// #endregion: Types
+//#endregion: Types
 
 /**
  * Generate the Send Button for a chat window.
  * @returns The Send Button.
  */
 export const SendButton: FC<SendButtonProps> = ({enableSendButton, id, onClickCallback}) => (
-    <LlmChatButton
-        aria-label="Send"
-        disabled={!enableSendButton}
-        id={id}
-        onClick={onClickCallback}
-        sx={{
-            padding: "0.6rem",
-            position: "relative",
-        }}
-        tabIndex={0}
+    <Tooltip
+        placement="top"
+        title={enableSendButton ? "Send" : "Enter a message to enable the send button"}
     >
-        <SendIcon
-            fontSize="small"
-            id="stop-button-icon" // Could update this but it would impact QA
-            sx={{color: "var(--bs-white)"}}
-        />
-    </LlmChatButton>
+        {/*Span required so that tooltip is displayed when button is disabled. Known MUI issue.*/}
+        <span
+            style={{
+                display: "inline-block",
+                cursor: enableSendButton ? "inherit" : "not-allowed",
+            }}
+        >
+            <LlmChatButton
+                aria-label="Send"
+                disabled={!enableSendButton}
+                id={id}
+                onClick={onClickCallback}
+                tabIndex={0}
+            >
+                <SendIcon
+                    fontSize="small"
+                    id="stop-button-icon" // Could update this but it would impact QA
+                />
+            </LlmChatButton>
+        </span>
+    </Tooltip>
 )

--- a/packages/ui-common/components/AgentChat/Common/LlmChatButton.tsx
+++ b/packages/ui-common/components/AgentChat/Common/LlmChatButton.tsx
@@ -17,26 +17,21 @@ limitations under the License.
 import Button from "@mui/material/Button"
 import {styled} from "@mui/material/styles"
 
-// #region: Types
+//#region: Types
 
 type LLMChatGroupConfigBtnProps = {
     disabled?: boolean
-    posRight?: number
-    posBottom?: number
 }
 
-// #endregion: Types
+//#endregion: Types
 
-export const LlmChatButton = styled(Button, {
-    shouldForwardProp: (prop) => !["posRight", "posBottom"].includes(String(prop)),
-})<LLMChatGroupConfigBtnProps>(({theme, disabled, posRight, posBottom}) => ({
-    background: `${theme.palette.primary.main} !important`,
+// In LlmChatButton.tsx
+export const LlmChatButton = styled(Button)<LLMChatGroupConfigBtnProps>(({disabled, theme}) => ({
+    backgroundColor: theme.palette.background.paper,
     borderRadius: "var(--bs-border-radius)",
-    bottom: posBottom !== undefined ? posBottom : 0,
-    cursor: disabled ? "default" : "pointer",
+    cursor: disabled ? "not-allowed" : "pointer",
     opacity: disabled ? "50%" : "100%",
-    right: posRight !== undefined ? posRight : 0,
-    position: "absolute",
+    padding: "0.5rem",
 }))
 
 export const SmallLlmChatButton = styled(LlmChatButton)({

--- a/packages/ui-common/components/AgentChat/VoiceChat/MicrophoneButton.tsx
+++ b/packages/ui-common/components/AgentChat/VoiceChat/MicrophoneButton.tsx
@@ -22,7 +22,7 @@ import {Dispatch, FC, RefObject, SetStateAction} from "react"
 import {checkSpeechSupport, SpeechRecognitionState, toggleListening} from "./VoiceChat"
 import {LlmChatButton} from "../Common/LlmChatButton"
 
-// #region: Types
+//#region: Types
 export interface MicrophoneButtonProps {
     /**
      * Whether microphone/voice mode is currently enabled
@@ -49,7 +49,7 @@ export interface MicrophoneButtonProps {
      */
     setVoiceInputState: Dispatch<SetStateAction<SpeechRecognitionState>>
 }
-// #endregion: Types
+//#endregion: Types
 
 /**
  * Microphone button component for voice input functionality.
@@ -83,37 +83,45 @@ export const MicrophoneButton: FC<MicrophoneButtonProps> = ({
     }
 
     const isDisabled = !speechSupported
-    const tooltipText = !speechSupported
-        ? "Voice input is only supported in Google Chrome on Mac or Windows."
-        : isMicOn
-          ? "Turn microphone off"
-          : "Turn microphone on"
+    const tooltipText = speechSupported
+        ? isMicOn
+            ? "Turn microphone off"
+            : "Turn microphone on"
+        : "Voice input is only supported in Google Chrome on Mac or Windows."
+
+    const isListeningActive = isMicOn && voiceInputState.isListening
 
     return (
-        <Tooltip title={tooltipText}>
-            <span style={{display: "inline-block", height: 50, width: 64}}>
+        <Tooltip
+            placement="top"
+            title={tooltipText}
+        >
+            {/*Span required so that tooltip is displayed when button is disabled. Known MUI issue.*/}
+            <span
+                style={{
+                    display: "inline-block",
+                    cursor: isDisabled ? "not-allowed" : "inherit",
+                }}
+            >
                 <LlmChatButton
                     data-testid="microphone-button"
                     disabled={isDisabled}
                     id="microphone-button"
                     onClick={handleClick}
                     sx={{
-                        padding: "0.5rem",
-                        right: 70,
-                        backgroundColor:
-                            isMicOn && voiceInputState.isListening ? "var(--bs-success)" : "var(--bs-secondary)",
+                        backgroundColor: isListeningActive ? "success.main" : "background.paper",
                     }}
                     tabIndex={0}
                 >
                     {voiceInputState.isListening ? (
                         <MicNoneIcon
-                            sx={{color: "var(--bs-white)"}}
                             data-testid="MicNoneIcon"
+                            fontSize="small"
                         />
                     ) : (
                         <MicOffIcon
-                            sx={{color: "var(--bs-white)"}}
                             data-testid="MicOffIcon"
+                            fontSize="small"
                         />
                     )}
                 </LlmChatButton>

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -19,6 +19,7 @@ import Box from "@mui/material/Box"
 import Grid from "@mui/material/Grid"
 import Slide from "@mui/material/Slide"
 import {useTheme} from "@mui/material/styles"
+import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
 import {ReactFlowProvider} from "@xyflow/react"
 import {FC, JSX as ReactJSX, useCallback, useEffect, useMemo, useRef, useState} from "react"
@@ -34,6 +35,8 @@ import {
     AGENT_NETWORK_HOCON,
     AGENT_NETWORK_NAME_KEY,
     AgentNetworkDefinitionEntry,
+    GRACE_PERIOD_MS,
+    SHOW_TOUR_DELAY_MS,
     TRIGGER_APP_TOUR_EVENT_NAME,
 } from "./const"
 import {Sidebar} from "./Sidebar/Sidebar"
@@ -56,7 +59,7 @@ import {TourPromptState, useTourStore} from "../../state/Tour"
 import {useLocalStorage} from "../../utils/useLocalStorage"
 import {getZIndex} from "../../utils/zIndexLayers"
 import {ChatCommon, ChatCommonHandle} from "../AgentChat/ChatCommon/ChatCommon"
-import {SmallLlmChatButton} from "../AgentChat/Common/LlmChatButton"
+import {LlmChatButton} from "../AgentChat/Common/LlmChatButton"
 import {isLegacyAgentType} from "../AgentChat/Common/Types"
 import {chatMessageFromChunk, cleanUpAgentName, removeTrailingUuid} from "../AgentChat/Common/Utils"
 import {ConfirmationModal, StyledButton} from "../Common/ConfirmationModal"
@@ -72,17 +75,11 @@ export interface MultiAgentAcceleratorProps {
 // Check for expired networks every this many milliseconds
 const EXPIRED_NETWORKS_CHECK_INTERVAL_MS = 10 * 1000
 
-// Display expired temporary networks for this amount of time after they expire so users can see what happened
-export const GRACE_PERIOD_MS = 5 * 60 * 1000 // 5 minutes
-
 // Animation time for the left and right panels to slide in or out when launching the animation
 const GROW_ANIMATION_TIME_MS = 800
 
 // Optimization to avoid creating a new empty map on every render
 const EMPTY_THOUGHT_BUBBLE_EDGES = new Map<string, {edge: ThoughtBubbleEdgeShape; timestamp: number}>()
-
-// We show the tour modal after this amount of time so as not to "pounce" on the user when they first open the app
-export const SHOW_TOUR_DELAY_MS = 5000
 
 // #region: Agent-save helpers
 
@@ -902,23 +899,26 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                             position: "absolute",
                             bottom: "1rem",
                             right: "1rem",
-                            zIndex: 10,
+                            zIndex: getZIndex(2, theme),
                         }}
                     >
-                        <SmallLlmChatButton
-                            aria-label="Stop"
-                            disabled={!isAwaitingLlm}
-                            id="stop-output-button"
-                            onClick={handleExternalStop}
-                            posBottom={8}
-                            posRight={23}
-                        >
-                            <StopCircle
-                                fontSize="small"
-                                id="stop-button-icon"
-                                sx={{color: "var(--bs-white)"}}
-                            />
-                        </SmallLlmChatButton>
+                        <Tooltip title="Stop response (Esc)">
+                            <LlmChatButton
+                                aria-label="Stop"
+                                id="stop-output-button"
+                                onClick={handleExternalStop}
+                                sx={{
+                                    "&:hover": {
+                                        backgroundColor: "error.main",
+                                    },
+                                }}
+                            >
+                                <StopCircle
+                                    fontSize="large"
+                                    id="stop-button-icon"
+                                />
+                            </LlmChatButton>
+                        </Tooltip>
                     </Box>
                 )}
             </>

--- a/packages/ui-common/components/MultiAgentAccelerator/const.ts
+++ b/packages/ui-common/components/MultiAgentAccelerator/const.ts
@@ -67,3 +67,9 @@ export enum DisplayAs {
     LANGCHAIN_TOOL = "langchain_tool",
     EXTERNAL_AGENT = "external_agent",
 }
+
+// Display expired temporary networks for this amount of time after they expire so users can see what happened
+export const GRACE_PERIOD_MS = 5 * 60 * 1000 // 5 minutes
+
+// We show the tour modal after this amount of time so as not to "pounce" on the user when they first open the app
+export const SHOW_TOUR_DELAY_MS = 5000


### PR DESCRIPTION
# Overview

Aesthetic + technical PR. Mostly affects only the chat window part of the UI. Also fixes the "fast refresh not working" issue.

# Screenshots
Before 🙁  | After 🎉 
:-------------------------:|:-------------------------:
<img width="580" height="643" alt="image" src="https://github.com/user-attachments/assets/68fa040c-6274-4ce1-a04b-ae9b63f9d640" />|<img width="589" height="646" alt="image" src="https://github.com/user-attachments/assets/99581308-bda5-47cb-b2d4-d92cc05db120" />
<img width="580" height="640" alt="image" src="https://github.com/user-attachments/assets/f3e33a13-1aa3-479a-85a5-ab1d14bc86ee" />|<img width="583" height="637" alt="image" src="https://github.com/user-attachments/assets/768d9802-b26d-4041-a557-7b77afaf4980" />
<img width="1602" height="750" alt="image" src="https://github.com/user-attachments/assets/0778e000-5baf-46cf-8459-d12497c93e2f" />|<img width="1602" height="750" alt="image" src="https://github.com/user-attachments/assets/6758632c-193e-4f5c-908a-8eb1fbaead93" />

# Details
1) Gets rid of a ton of absolute positioning hacks for the various Chat buttons (resend, clear, stop, etc.) Now we use the natural layout and let MUI do the work.
1) Fixes the issues with buttons overlapping scrollbars.
1) Remove anti-MUI-theme hacks and let the theme do its thing.
1) Move some exported consts out to allow fast reload to work. Major QoL improvement for development as, without this, any minor change causes a full page refresh and the ugly message to be logged to the console:
    ```console
    ⚠ Fast Refresh had to perform a full reload when ./packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx changed. Read more: https://nextjs.org/docs/messages/fast-refresh-reload
    ```
1) Generally fix Chat layout and spacing. Use natural, theme-aware units rather than hard-coded pixel values and even REMs.
1) Get rid of color & style overrides and let the theme do its work. Buttons were hardcoded to white for example, with super dark blue background. Now they use the MUI theme colors, with `paper` for the background.
1) In "Zen" mode, make the stop button larger and "angry red" on hover to alert the user it's destructive.
1) Add a few helpful tooltips.