### PR TITLE
#419 Cleans up the theming of the "legend"

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -96,7 +96,7 @@ const config: Config.InitialOptions = {
     coverageThreshold: {
         global: {
             statements: -116,
-            branches: -156,
+            branches: -155,
             functions: -29,
             lines: -89,
         },

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow.test.tsx
@@ -249,18 +249,6 @@ describe("AgentFlow", () => {
         expect(screen.queryByRole("button", {name: "Edit"})).not.toBeInTheDocument()
     })
 
-    it.each([{darkMode: false}, {darkMode: true}])("Should render correctly in %s mode", async ({darkMode}) => {
-        const mode = darkMode ? "dark" : "light"
-        const {container} = renderAgentFlowComponent({}, mode)
-
-        expect(await screen.findByText(cleanUpAgentName("React Flow"))).toBeInTheDocument()
-        verifyAgentNodes(container)
-
-        const legend = container.querySelector("#test-flow-id-legend")
-        const computed = window.getComputedStyle(legend)
-        expect(computed.boxShadow).toContain(darkMode ? "#fff" : "#000")
-    })
-
     it("Should allow switching between heatmap and depth displays", async () => {
         const {container} = renderAgentFlowComponent()
 

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
@@ -1096,10 +1096,11 @@ export const AgentFlow: FC<AgentFlowProps> = ({
             {isEditMode && isTemporaryNetwork && !isAwaitingLlm && (
                 <Box
                     sx={{
+                        backdropFilter: "blur(8px)",
+                        backgroundColor: alpha(theme.palette.background.paper, 0.2),
                         borderTop: `2px solid ${theme.palette.primary.main}`,
-                        backgroundColor: theme.palette.background.paper,
                         flexShrink: 0,
-
+                        position: "relative",
                         zIndex: getZIndex(2, theme),
                     }}
                 >
@@ -1122,8 +1123,6 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                                 alignItems: "center",
                                 // Frost the banner like the dock header, so the graph doesn't show through the
                                 // app's translucent paper background; keep a tinted, mostly opaque severity wash.
-                                backdropFilter: "blur(8px)",
-                                backgroundColor: alpha(theme.palette[dockBanner.severity].main, 0.2),
                                 "& .MuiAlert-action": {
                                     alignItems: "center",
                                     marginRight: 0,

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow.tsx
@@ -322,7 +322,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         })
     }, [currentConversations, showThoughtBubbles, setThoughtBubbleEdges])
 
-    // Cleanup expired thought bubble edges — created once on mount, reads isStreaming via ref.
+    // Clean up expired thought bubble edges — created once on mount, reads isStreaming via ref.
     useEffect(() => {
         const cleanupInterval = setInterval(() => {
             if (!isStreamingRef.current) return
@@ -345,9 +345,6 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         return () => clearInterval(cleanupInterval)
     }, [setThoughtBubbleEdges]) // mount/unmount only
 
-    // Shadow color for icon
-    const isDarkMode = theme.palette.mode === "dark"
-    const foregroundColor = isDarkMode ? theme.palette.common.white : theme.palette.common.black
     const isHeatmap = coloringOption === "heatmap"
 
     const palette = usePalette()
@@ -435,7 +432,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
     } | null>(null)
     const [isPopupOpen, setIsPopupOpen] = useState<boolean>(false)
 
-    // True while the agent-edit request is in-flight so we can disable the Save button.
+    // True, while the agent-edit request is in-flight so we can disable the Save button.
     const [isSavingAgent, setIsSavingAgent] = useState<boolean>(false)
 
     // AbortController for the in-flight save request — stored in a ref so handlePopupClose can cancel it.
@@ -449,7 +446,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
     // Stop-confirm overlay state: null = not shown, "confirming" = abort dialog open.
     const [stopState, setStopState] = useState<"confirming" | null>(null)
 
-    // Inline status banner shown above the dock header after an apply succeeds, is canceled, or fails.
+    // Inline status banner shown above the dock header after an "apply" succeeds, is canceled, or fails.
     const [dockBanner, setDockBanner] = useState<{severity: AlertColor; title: string; detail: string} | null>(null)
     const bannerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -551,7 +548,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                 return true
             }
 
-            // Reservations came back but none matched the current network — surface this in the dock banner.
+            // Reservations came back, but none matched the current network — surface this in the dock banner.
             showDockBanner({
                 severity: "error",
                 title: "Failed to apply network change.",
@@ -697,8 +694,8 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         (changes: NodeChange<RFNode<AgentNodeProps>>[]) => {
             setNodes((currentNodes) =>
                 applyNodeChanges<RFNode<AgentNodeProps>>(
-                    // For now, we only allow dragging, no updates. In agent network designer mode, doesn't make sense
-                    // to allow position changes since the user isn't actually manipulating a real network
+                    // For now, we only allow dragging, no updates. In agent network designer mode, it doesn't make
+                    // sense to allow position changes since the user isn't actually manipulating a real network
                     changes.filter((c) => c.type === "position" && !isAgentNetworkDesignerMode),
                     currentNodes
                 )
@@ -775,14 +772,16 @@ export const AgentFlow: FC<AgentFlowProps> = ({
             <Box
                 id={`${id}-legend`}
                 sx={{
-                    position: "absolute",
-                    top: "1.5rem",
-                    right: "10px",
-                    padding: "5px",
-                    borderRadius: "5px",
-                    boxShadow: `0 0 5px color-mix(in srgb, ${foregroundColor} 30%, transparent)`,
-                    display: "flex",
                     alignItems: "center",
+                    backgroundColor: theme.palette.background.paper,
+                    border: `1px solid ${theme.palette.divider}`,
+                    boxShadow: `0 2px 8px ${alpha(theme.palette.text.primary, 0.18)}`,
+                    borderRadius: "5px",
+                    display: "flex",
+                    padding: theme.spacing(0.5),
+                    position: "absolute",
+                    right: theme.spacing(2),
+                    top: theme.spacing(4),
                     zIndex: getZIndex(2, theme),
                 }}
             >
@@ -791,26 +790,19 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                     <Box
                         id={`${id}-legend-depth-${i}`}
                         key={i}
-                        style={{
+                        sx={{
                             alignItems: "center",
                             backgroundColor: palette[i],
                             borderRadius: "50%",
                             color: theme.palette.getContrastText(palette[i]),
                             display: "flex",
-                            height: "15px",
+                            fontSize: "0.5rem",
                             justifyContent: "center",
-                            marginLeft: "5px",
+                            marginLeft: theme.spacing(0.75),
                             width: "15px",
                         }}
                     >
-                        <Typography
-                            id={`${id}-legend-depth-${i}-text`}
-                            sx={{
-                                fontSize: "8px",
-                            }}
-                        >
-                            {i}
-                        </Typography>
+                        {i}
                     </Box>
                 ))}
                 <ToggleButtonGroup
@@ -822,48 +814,48 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                             setColoringOption(newValue)
                         }
                     }}
-                    sx={{
-                        fontSize: "2rem",
-                        zIndex: 10,
-                        marginLeft: "0.5rem",
-                    }}
                     size="small"
+                    sx={{
+                        marginLeft: theme.spacing(2),
+                        "& .MuiToggleButton-root": {
+                            backgroundColor: theme.palette.background.paper,
+                            borderColor: theme.palette.divider,
+                            color: theme.palette.text.primary,
+                            minHeight: 22,
+                            px: 1,
+                            "&:hover": {
+                                backgroundColor: theme.palette.action.hover,
+                            },
+                            "&.Mui-selected": {
+                                backgroundColor: theme.palette.action.selected,
+                                borderColor: theme.palette.text.primary,
+                            },
+                            "&.Mui-selected:hover": {
+                                backgroundColor: theme.palette.action.selected,
+                                borderColor: theme.palette.text.primary,
+                            },
+                        },
+                    }}
                 >
                     <ToggleButton
                         id={`${id}-depth-toggle`}
-                        size="small"
                         value="depth"
                         sx={{
                             fontSize: "0.5rem",
                             height: "1rem",
                         }}
                     >
-                        <Typography
-                            id={`${id}-depth-label`}
-                            sx={{
-                                fontSize: "10px",
-                            }}
-                        >
-                            Depth
-                        </Typography>
+                        Depth
                     </ToggleButton>
                     <ToggleButton
                         id={`${id}-heatmap-toggle`}
-                        size="small"
                         value="heatmap"
                         sx={{
                             fontSize: "0.5rem",
                             height: "1rem",
                         }}
                     >
-                        <Typography
-                            id={`${id}-heatmap-label`}
-                            sx={{
-                                fontSize: "10px",
-                            }}
-                        >
-                            Heatmap
-                        </Typography>
+                        Heatmap
                     </ToggleButton>
                 </ToggleButtonGroup>
             </Box>
@@ -872,10 +864,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
 
     // Get the background color for the control buttons based on the layout and dark mode setting
     const getControlButtonBackgroundColor = (isActive: boolean) => {
-        if (!isActive) {
-            return undefined
-        }
-        return isDarkMode ? theme.palette.grey[800] : theme.palette.grey[200]
+        return isActive ? theme.palette.action.selected : undefined
     }
 
     // Only show radial guides if radial layout is selected, radial guides are enabled, and it's not just Frontman
@@ -1110,9 +1099,11 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                         borderTop: `2px solid ${theme.palette.primary.main}`,
                         backgroundColor: theme.palette.background.paper,
                         flexShrink: 0,
+
+                        zIndex: getZIndex(2, theme),
                     }}
                 >
-                    {/* Status banner: shown after an apply succeeds, is canceled, or fails */}
+                    {/* Status banner: shown after an "apply" succeeds, is canceled, or fails */}
                     {dockBanner && (
                         <MUIAlert
                             closeable
@@ -1129,13 +1120,10 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                                 // vertically with the header's close X below it.
                                 paddingRight: 0.5,
                                 alignItems: "center",
-                                // Frost the banner like the dock header so the graph doesn't show through the
-                                // app's translucent paper background; keep a tinted, mostly-opaque severity wash.
+                                // Frost the banner like the dock header, so the graph doesn't show through the
+                                // app's translucent paper background; keep a tinted, mostly opaque severity wash.
                                 backdropFilter: "blur(8px)",
-                                backgroundColor: alpha(
-                                    theme.palette[dockBanner.severity].main,
-                                    isDarkMode ? 0.28 : 0.16
-                                ),
+                                backgroundColor: alpha(theme.palette[dockBanner.severity].main, 0.2),
                                 "& .MuiAlert-action": {
                                     alignItems: "center",
                                     marginRight: 0,

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -235,7 +235,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
             updateSettings({
                 branding: {
                     iconSuggestion: brandingSuggestions["iconSuggestion"],
-                    logoSource: "auto",
+                    logoSource: logoServiceToken ? "auto" : "generic",
                 },
             })
         }


### PR DESCRIPTION
# Overview

Legend was all but hidden in some lighter brand themes. This PR formats it in a theme-friendly way so that it always has a border and shadow, and the text and buttons are always visible.

Also clean up some other theme-related stuff in the same module while at it. 

Fix the zIndex issue with the edit dock so that dragged nodes don't overwrite its top border.

Fix the theming of the graph control buttons so they are more visible, participate better in the standard theme, and easier to see when they are selected.

# Screenshots
Before  | After
:-------------------------:|:-------------------------:
<img width="274" height="43" alt="image" src="https://github.com/user-attachments/assets/bd48a4f0-81fe-4442-a0c5-519411134d94" />|<img width="304" height="46" alt="image" src="https://github.com/user-attachments/assets/6c14f254-9ea1-4226-8171-19866b8ca11e" />
<img width="277" height="43" alt="image" src="https://github.com/user-attachments/assets/69d0e58b-2cd8-4ba5-b9a5-791ae9fc9092" />|<img width="292" height="46" alt="image" src="https://github.com/user-attachments/assets/a1cae0fe-07c6-42fe-b54b-f3a0b8cf65bd" />
<img width="274" height="43" alt="image" src="https://github.com/user-attachments/assets/fc13411c-3d92-408e-889e-0668c72df475" />|<img width="292" height="46" alt="image" src="https://github.com/user-attachments/assets/e7ef61da-4e6e-42e5-852d-a85440c47333" />
<img width="703" height="190" alt="image" src="https://github.com/user-attachments/assets/8905ee23-365a-467b-be52-5688d156a62e" />|<img width="703" height="148" alt="image" src="https://github.com/user-attachments/assets/9805f34a-fc1d-4dda-aab0-6b54f9ed3efb" />
<img width="40" height="190" alt="image" src="https://github.com/user-attachments/assets/22a1fb48-bc96-45ef-8b94-9147b590e304" />|<img width="37" height="199" alt="image" src="https://github.com/user-attachments/assets/d88058c2-ece7-4294-878c-214d10474c0b" />


