### PR TITLE
#422 Improve error handling when Branding service call fails

### DIFF
--- a/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
@@ -594,6 +594,31 @@ describe("SettingsDialog", () => {
         )
     })
 
+    it("Handles null response when retrieving branding suggestions", async () => {
+        global.fetch = mockFetch(null)
+
+        const customer = "OldCustomer"
+
+        useSettingsStore.getState().updateSettings({
+            branding: {
+                customer,
+            },
+        })
+
+        render(
+            <SettingsDialog
+                id="settings-dialog"
+                isOpen={true}
+            />
+        )
+
+        const customerName = "Acme"
+        await enterCustomerName(customerName)
+
+        // Customer name should be unchanged
+        expect(useSettingsStore.getState().settings.branding.customer).toBe(customer)
+    })
+
     it("Handles customer but no logo token", async () => {
         global.fetch = mockFetch(BRANDING_SUGGESTIONS_RESPONSE)
 

--- a/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
@@ -583,12 +583,12 @@ describe("SettingsDialog", () => {
         )
 
         // Spy on console.warn to suppress output during test
-        const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation()
+        const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
 
         const customerName = "Acme"
         await enterCustomerName(customerName)
 
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
             expect.stringMatching(new RegExp(`Failed to fetch branding suggestions.*"${customerName}"`, "u")),
             expect.objectContaining({message: networkError})
         )

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -152,12 +152,6 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     const handleBrandingApply = async () => {
         setIsBrandingApplying(true)
 
-        updateSettings({
-            branding: {
-                customer: customerInput,
-            },
-        })
-
         let brandingSuggestions
         try {
             brandingSuggestions = await getBrandingSuggestions(customerInput)
@@ -170,7 +164,15 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                     "branding service."
             )
             return
+        } finally {
+            setIsBrandingApplying(false)
         }
+
+        updateSettings({
+            branding: {
+                customer: customerInput,
+            },
+        })
 
         updateSettings({
             appearance: {

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import {ApiKeyInput} from "./ApiKeyInput"
 import {FadingCheckmark, useCheckmarkFade} from "./FadingCheckmark"
 import {getBrandingSuggestions} from "../../controller/agent/Agent"
 import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../controller/llm/Providers"
+import {BrandingSuggestions} from "../../controller/Types/Branding"
 import {DEFAULT_SETTINGS, LLMProvider, PaletteKey, useSettingsStore} from "../../state/Settings"
 import {PALETTES} from "../../Theme/Palettes"
 import {ConfirmationModal} from "../Common/ConfirmationModal"
@@ -146,27 +147,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
         rangePaletteCheckmark.trigger()
     }
 
-    /**
-     * Handle applying branding based on customer input. Calls backend to get colors then updates settings store.
-     */
-    const handleBrandingApply = async () => {
-        setIsBrandingApplying(true)
-
-        let brandingSuggestions
-        try {
-            brandingSuggestions = await getBrandingSuggestions(customerInput)
-            setIsBrandingApplying(false)
-        } catch (e) {
-            console.warn(`Failed to fetch branding suggestions for customer "${customerInput}"`, e)
-            sendNotification(
-                NotificationType.error,
-                `Failed to fetch branding suggestions for "${customerInput}"`,
-                "Please check the name and try again. If the problem persists, there may be an issue with the " +
-                    "branding service."
-            )
-            return
-        }
-
+    const updateBranding = (brandingSuggestions: BrandingSuggestions) => {
         updateSettings({
             branding: {
                 customer: customerInput,
@@ -240,9 +221,32 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                 },
             })
         }
+    }
 
-        brandingCheckmark.trigger()
-        setIsBrandingApplying(false)
+    /**
+     * Handle applying branding based on customer input. Calls backend to get colors then updates settings store.
+     */
+    const handleBrandingApply = async () => {
+        setIsBrandingApplying(true)
+
+        let brandingSuggestions
+        try {
+            brandingSuggestions = await getBrandingSuggestions(customerInput)
+            if (brandingSuggestions) {
+                updateBranding(brandingSuggestions)
+                brandingCheckmark.trigger()
+            }
+        } catch (e) {
+            console.error(`Failed to fetch branding suggestions for customer "${customerInput}"`, e)
+            sendNotification(
+                NotificationType.error,
+                `Failed to fetch branding suggestions for "${customerInput}"`,
+                "Please check the name and try again. If the problem persists, there may be an issue with the " +
+                    "branding service."
+            )
+        } finally {
+            setIsBrandingApplying(false)
+        }
     }
 
     const handleBrandingClear = () => {

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -229,9 +229,8 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     const handleBrandingApply = async () => {
         setIsBrandingApplying(true)
 
-        let brandingSuggestions
         try {
-            brandingSuggestions = await getBrandingSuggestions(customerInput)
+            const brandingSuggestions = await getBrandingSuggestions(customerInput)
             if (brandingSuggestions) {
                 updateBranding(brandingSuggestions)
                 brandingCheckmark.trigger()

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -155,6 +155,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
         let brandingSuggestions
         try {
             brandingSuggestions = await getBrandingSuggestions(customerInput)
+            setIsBrandingApplying(false)
         } catch (e) {
             console.warn(`Failed to fetch branding suggestions for customer "${customerInput}"`, e)
             sendNotification(
@@ -164,8 +165,6 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                     "branding service."
             )
             return
-        } finally {
-            setIsBrandingApplying(false)
         }
 
         updateSettings({

--- a/packages/ui-common/controller/agent/IconSuggestions.ts
+++ b/packages/ui-common/controller/agent/IconSuggestions.ts
@@ -22,7 +22,7 @@ export const postJsonRequest = async <T>(endpoint: string, body: Record<string, 
     })
 
     const jsonResponse = await response.json()
-    if (!response.ok || jsonResponse.error) {
+    if (!response.ok || jsonResponse?.error) {
         throw new Error(jsonResponse?.error || response?.statusText)
     }
 


### PR DESCRIPTION
Previously if the service failed for whatever reason, the dialog got stuck in a "spinner" state.