### PR TITLE
#425 Rewrite tree builder logic to be cleaner and functionally pure

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -95,10 +95,10 @@ const config: Config.InitialOptions = {
 
     coverageThreshold: {
         global: {
-            statements: -116,
-            branches: -155,
+            statements: -115,
+            branches: -154,
             functions: -29,
-            lines: -89,
+            lines: -88,
         },
     },
 

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import {createTheme, PaletteMode, ThemeProvider} from "@mui/material/styles"
 import {act, render, screen, waitFor, within} from "@testing-library/react"
 import {userEvent, UserEvent} from "@testing-library/user-event"
+import {ComponentProps} from "react"
 
 import {
     LEVEL_1_FOLDER,
@@ -33,15 +34,19 @@ import {
     TEST_AGENTS_FOLDER_DISPLAY,
     TEST_DEEP_AGENT,
     TEST_DEEP_AGENT_DISPLAY,
-} from "../../../../../__tests__/common/NetworksListMock"
-import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
-import {cleanUpAgentName} from "../../../components/AgentChat/Common/Utils"
-import {Sidebar, SidebarProps, SPARKLE_HIGHLIGHT_CLASS} from "../../../components/MultiAgentAccelerator/Sidebar/Sidebar"
-import {testConnection} from "../../../controller/agent/Agent"
-import {NetworkIconSuggestions} from "../../../controller/Types/NetworkIconSuggestions"
-import {useEnvironmentStore} from "../../../state/Environment"
-import {useSettingsStore} from "../../../state/Settings"
-import {downloadFile} from "../../../utils/File"
+} from "../../../../../../__tests__/common/NetworksListMock"
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {cleanUpAgentName} from "../../../../components/AgentChat/Common/Utils"
+import {
+    Sidebar,
+    SidebarProps,
+    SPARKLE_HIGHLIGHT_CLASS,
+} from "../../../../components/MultiAgentAccelerator/Sidebar/Sidebar"
+import {testConnection} from "../../../../controller/agent/Agent"
+import {NetworkIconSuggestions} from "../../../../controller/Types/NetworkIconSuggestions"
+import {useEnvironmentStore} from "../../../../state/Environment"
+import {useSettingsStore} from "../../../../state/Settings"
+import {downloadFile} from "../../../../utils/File"
 
 const AGENT_NETWORK_SETTINGS_NAME = {name: /Agent Network Settings/u}
 const AGENT_SERVER_ADDRESS = "Agent server address"
@@ -52,9 +57,33 @@ const EDIT_EXAMPLE_URL = "https://edit.example.com"
 const TEST_EXAMPLE_URL = "https://test.example.com"
 const TOOLTIP_EXAMPLE_URL = "https://tooltip.example.com"
 
-jest.mock("../../../controller/agent/Agent")
-jest.mock("../../../utils/File", () => ({
-    ...jest.requireActual("../../../utils/File"),
+// mock MUI TreeView so we can generate normally impossible values
+let mockSelectedTreeItemId: string | null | undefined
+jest.mock("@mui/x-tree-view/RichTreeView", () => {
+    const OriginalModule = jest.requireActual("@mui/x-tree-view/RichTreeView")
+
+    return {
+        ...OriginalModule,
+        RichTreeView: (props: ComponentProps<typeof OriginalModule.RichTreeView>) => {
+            const OriginalRichTreeView = OriginalModule.RichTreeView
+
+            return (
+                <>
+                    <OriginalRichTreeView {...props} />
+                    <button
+                        type="button"
+                        data-testid="force-tree-selection"
+                        onClick={() => props.onSelectedItemsChange?.(null, mockSelectedTreeItemId ?? null)}
+                    />
+                </>
+            )
+        },
+    }
+})
+
+jest.mock("../../../../controller/agent/Agent")
+jest.mock("../../../../utils/File", () => ({
+    ...jest.requireActual("../../../../utils/File"),
     downloadFile: jest.fn(),
 }))
 
@@ -130,6 +159,8 @@ describe("SideBar", () => {
     })
 
     beforeEach(() => {
+        mockSelectedTreeItemId = undefined
+
         user = userEvent.setup()
         ;(testConnection as jest.Mock).mockResolvedValue({success: true, status: "ok", version: TEST_VERSION})
 
@@ -195,7 +226,7 @@ describe("SideBar", () => {
         const header = screen.getByText(TEST_AGENTS_FOLDER_DISPLAY)
         await user.click(header)
 
-        // The display name should be the cleaned up version of the agent name, not the raw agent name
+        // The display name should be the cleaned-up version of the agent name, not the raw agent name
         screen.getByText(TEST_AGENT_MATH_GUY_DISPLAY)
         expect(screen.queryByText(TEST_AGENT_MATH_GUY)).not.toBeInTheDocument()
 
@@ -408,7 +439,7 @@ describe("SideBar", () => {
             onEditNetwork: onEditNetworkMock,
         })
 
-        // First select the network by clicking its label
+        // First, select the network by clicking its label
         const networkLabel = await screen.findByText(cleanUpAgentName(TEMPORARY_NETWORK_NAME))
         await user.click(networkLabel)
 
@@ -424,6 +455,18 @@ describe("SideBar", () => {
         expect(setSelectedNetworkMock).not.toHaveBeenCalled()
         // Should still have called onEditNetwork
         expect(onEditNetworkMock).toHaveBeenCalledWith(TEMPORARY_NETWORK.agentInfo.agent_name)
+    })
+
+    it("Should handle invalid items in select handler", async () => {
+        renderSidebarComponent()
+
+        mockSelectedTreeItemId = null
+        await user.click(screen.getByTestId("force-tree-selection"))
+
+        mockSelectedTreeItemId = "not-a-real-tree-item"
+        await user.click(screen.getByTestId("force-tree-selection"))
+
+        expect(setSelectedNetworkMock).not.toHaveBeenCalled()
     })
 
     it("should disable the Settings button when isAwaitingLlm is true", async () => {
@@ -563,7 +606,7 @@ describe("SideBar", () => {
         // Simulate clicking outside the popover (triggers onClose)
         await user.click(document.body)
 
-        // Popover should close and input should reset to customURLLocalStorage
+        // Popover should close, and input should reset to customURLLocalStorage
         // Can't use document.body due to MuiBackdrop
         await user.click(document.querySelector(".MuiBackdrop-root"))
 
@@ -689,7 +732,7 @@ describe("SideBar", () => {
         // Fake timers make the 50ms callback fire deterministically.
         jest.useFakeTimers()
 
-        // Render with empty networks so there are NO treeitem elements in the DOM.
+        // Render with empty networks, so there are NO treeitem elements in the DOM.
         // When the 50ms timer fires, querySelector returns null → covers the false
         // arm of `if (selectedNode)` in the highlight callback.
         renderSidebarComponent({

--- a/packages/ui-common/__tests__/unit/MultiAgentAccelerator/Sidebar/TreeBuilder.test.ts
+++ b/packages/ui-common/__tests__/unit/MultiAgentAccelerator/Sidebar/TreeBuilder.test.ts
@@ -1,0 +1,16 @@
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {buildTreeViewItems} from "../../../../components/MultiAgentAccelerator/Sidebar/TreeBuilder"
+
+describe("TreeBuilder", () => {
+    withStrictMocks()
+
+    it("should handle undefined inputs", async () => {
+        const tree = buildTreeViewItems(true, undefined, undefined)
+        expect(tree).toEqual([])
+    })
+
+    it("should handle missing inputs", async () => {
+        const tree = buildTreeViewItems(true)
+        expect(tree).toEqual([])
+    })
+})

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/AgentNetworkTreeItem.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/AgentNetworkTreeItem.tsx
@@ -8,8 +8,8 @@ import Edit from "@mui/icons-material/Edit"
 import Box from "@mui/material/Box"
 import Chip from "@mui/material/Chip"
 import IconButton from "@mui/material/IconButton"
-import {useTheme} from "@mui/material/styles"
 import Tooltip from "@mui/material/Tooltip"
+import {useTreeItemModel} from "@mui/x-tree-view/hooks"
 import {
     TreeItemContent,
     TreeItemGroupTransition,
@@ -21,11 +21,8 @@ import {TreeItemProvider} from "@mui/x-tree-view/TreeItemProvider"
 import {useTreeItem} from "@mui/x-tree-view/useTreeItem"
 import {FC, useRef} from "react"
 
-import {NodeIndex} from "./TreeBuilder"
-import {useSettingsStore} from "../../../state/Settings"
+import {AgentNetworkTreeItemModel} from "./TreeBuilder"
 import {downloadFile, toSafeFilename} from "../../../utils/File"
-import {cleanUpAgentName} from "../../AgentChat/Common/Utils"
-
 // Palette of colors we can use for tags
 const TAG_COLORS = [
     "--bs-accent2-light",
@@ -46,12 +43,8 @@ type TagColor = (typeof TAG_COLORS)[number]
 const tagsToColors = new Map<string, TagColor>()
 
 export interface AgentNetworkNodeProps extends TreeItemProps {
-    readonly nodeIndex: NodeIndex
     readonly onDeleteNetwork?: (network: string, isExpired: boolean) => void
     readonly onEditNetwork?: (network: string) => void
-    readonly networkIconSuggestions: Record<string, string>
-    readonly temporaryNetworkExpirationTimes?: Record<string, Date>
-    readonly temporaryNetworkHoconStrings?: Record<string, string | null>
 }
 
 /**
@@ -73,23 +66,13 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
     disabled,
     itemId,
     label,
-    networkIconSuggestions,
-    nodeIndex,
     onDeleteNetwork,
     onEditNetwork,
-    temporaryNetworkExpirationTimes,
-    temporaryNetworkHoconStrings,
 }) => {
-    const theme = useTheme()
-
-    // Display option for agent/network names
-    const useNativeNames = useSettingsStore((state) => state.settings.appearance.useNativeNames)
+    const item = useTreeItemModel<AgentNetworkTreeItemModel>(itemId)
 
     // We know all labels are strings because we set them that way in the tree view items
     const labelString = label as string
-    const displayLabel = useNativeNames
-        ? labelString
-        : nodeIndex.get(itemId)?.displayName || cleanUpAgentName(labelString)
 
     const {getContextProviderProps, getRootProps, getContentProps, getLabelProps, getGroupTransitionProps} =
         useTreeItem({itemId, children, label, disabled})
@@ -99,13 +82,7 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
     const isParent = Array.isArray(children) && children.length > 0
     const isChild = !isParent
 
-    const agentNode = nodeIndex?.get(itemId)?.agentInfo
-
-    // Only child items (the actual networks, not the containing folders) have tags. Retrieve tags from the
-    // networkFolders data structure passed in as a prop. This could in theory be a custom property for the
-    // RichTreeView item, but that isn't well-supported at this time.
-    // Discussion: https://stackoverflow.com/questions/69481071/material-ui-how-to-pass-custom-props-to-a-custom-treeitem
-    const tags = isChild ? agentNode?.tags || [] : []
+    const tags = item.tags ?? []
 
     // Assign colors to tags as needed and store in tagsToColors map
     for (const tag of tags) {
@@ -116,14 +93,15 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
     }
 
     // Determine if expired (temporary networks only)
-    const expirationTime = temporaryNetworkExpirationTimes?.[itemId]
+    const expirationTime = item?.temporaryNetworkExpirationTime
     const isTemporaryNetwork = Boolean(expirationTime)
     const isExpired = isChild && isTemporaryNetwork && isTemporaryNetworkExpired(expirationTime)
-    const networkHocon = isTemporaryNetwork ? temporaryNetworkHoconStrings?.[itemId] : null
+    const networkHocon = item?.temporaryNetworkHocon ?? null
 
-    const iconNameSuggestion = isTemporaryNetwork ? "HourglassTop" : isChild ? networkIconSuggestions?.[itemId] : null
+    const iconNameSuggestion = item.iconSuggestion
 
     let muiIconElement = null
+
     if (iconNameSuggestion && MuiIcons[iconNameSuggestion as keyof typeof MuiIcons]) {
         const IconComponent = MuiIcons[iconNameSuggestion as keyof typeof MuiIcons]
         muiIconElement = <IconComponent sx={{fontSize: "1rem"}} />
@@ -167,11 +145,11 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
                                             },
                                         }}
                                     >
-                                        {displayLabel}
+                                        {item.displayName}
                                     </TreeItemLabel>
                                 </Box>
                             </Tooltip>
-                            {isChild && tags?.length > 0 ? (
+                            {isChild && tags.length > 0 ? (
                                 <Tooltip
                                     title={[...tags]
                                         .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
@@ -253,7 +231,7 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
                                         }}
                                         sx={{
                                             color: "var(--bs-secondary)",
-                                            "&:hover": {color: theme.palette.warning.main},
+                                            "&:hover": {color: (theme) => theme.palette.warning.main},
                                             "&.Mui-disabled": {
                                                 color: "var(--bs-secondary)",
                                                 opacity: 0.3,

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
@@ -38,7 +38,7 @@ import {
 } from "react"
 
 import {AgentNetworkNodeProps, AgentNetworkTreeItem} from "./AgentNetworkTreeItem"
-import {buildTreeViewItems} from "./TreeBuilder"
+import {buildTreeViewItems, findTreeItemById} from "./TreeBuilder"
 import {testConnection, TestConnectionResult} from "../../../controller/agent/Agent"
 import {NetworkIconSuggestions} from "../../../controller/Types/NetworkIconSuggestions"
 import {AgentInfo} from "../../../generated/neuro-san/NeuroSanClient"
@@ -228,7 +228,7 @@ export const Sidebar: FC<SidebarProps> = ({
         if (tempUrl && !tempUrl.startsWith("http://") && !tempUrl.startsWith("https://")) {
             tempUrl = `https://${tempUrl}`
         }
-        // Call setSelectedNetwork(null) otherwise it can cause issues when switching agent networks (i.e. for Save)
+        // Call setSelectedNetwork(null) otherwise it can cause issues when switching agent networks (i.e., for Save)
         setSelectedNetwork(null)
         handleSettingsClose()
         customURLCallback(tempUrl)
@@ -277,33 +277,25 @@ export const Sidebar: FC<SidebarProps> = ({
         onEditNetwork?.(network)
     }
 
-    const {treeViewItems, nodeIndex} = buildTreeViewItems(networks, temporaryNetworks, useNativeNames)
-    const temporaryNetworkExpirationTimes = temporaryNetworks.reduce(
-        (acc, tempNetwork) => {
-            acc[tempNetwork.agentInfo.agent_name] = new Date(tempNetwork.reservation.expiration_time_in_seconds * 1000)
-            return acc
-        },
-        {} as Record<string, Date>
-    )
-
-    const temporaryNetworkHoconStrings = temporaryNetworks.reduce((acc: Record<string, string | null>, tempNetwork) => {
-        acc[tempNetwork.agentInfo.agent_name] = tempNetwork.networkHocon
-        return acc
-    }, {})
+    const treeViewItems = buildTreeViewItems(useNativeNames, networks, temporaryNetworks, networkIconSuggestions)
 
     const handleSelectedItemsChange = (_event: unknown, itemId: string | null) => {
         if (!itemId) {
             return
         }
 
-        // Only select leaf nodes (items in nodeIndex) as networks
-        const isLeafNode = nodeIndex.has(itemId)
-        if (!isLeafNode) {
+        const treeItem = findTreeItemById(treeViewItems, itemId)
+        if (!treeItem) {
+            return
+        }
+
+        // Only allow selecting child nodes (i.e., actual networks), not parent nodes (folders).
+        if (!treeItem.isNetwork) {
             return
         }
 
         // Don't allow selecting expired temporary networks
-        const expirationTime = temporaryNetworkExpirationTimes[itemId]
+        const expirationTime = treeItem?.temporaryNetworkExpirationTime
         if (expirationTime && expirationTime < new Date()) {
             return
         }
@@ -396,29 +388,17 @@ export const Sidebar: FC<SidebarProps> = ({
                     </Box>
                 </SidebarHeading>
                 <RichTreeView
-                    key={Object.keys(networkIconSuggestions || {}).length} // Force remount when suggestions change
-                    items={treeViewItems}
+                    disableSelection={isAwaitingLlm}
                     expandedItems={expandedItems}
-                    onExpandedItemsChange={(_event, itemIds) => setExpandedItems(itemIds)}
+                    items={treeViewItems}
                     multiSelect={false}
+                    onExpandedItemsChange={(_event, itemIds) => setExpandedItems(itemIds)}
                     onSelectedItemsChange={handleSelectedItemsChange}
                     selectedItems={selectedItem}
-                    disableSelection={isAwaitingLlm}
-                    slots={{
-                        item: AgentNetworkTreeItem as RichTreeViewSlots["item"],
-                    }}
-                    // Pass custom props to tree items via slotProps.
-                    // Reference: https://github.com/mui/mui-x/issues/13351
                     slotProps={{
-                        item: {
-                            networkIconSuggestions,
-                            nodeIndex,
-                            onDeleteNetwork,
-                            onEditNetwork: handleEditNetworkWithSelect,
-                            temporaryNetworkExpirationTimes,
-                            temporaryNetworkHoconStrings,
-                        } as AgentNetworkNodeProps,
+                        item: {onDeleteNetwork, onEditNetwork: handleEditNetworkWithSelect} as AgentNetworkNodeProps,
                     }}
+                    slots={{item: AgentNetworkTreeItem as RichTreeViewSlots["item"]}}
                 />
             </SidebarAside>
             <Popover

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/TreeBuilder.ts
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/TreeBuilder.ts
@@ -4,161 +4,262 @@ import {AgentInfo} from "../../../generated/neuro-san/NeuroSanClient"
 import {TemporaryNetwork} from "../../../state/TemporaryNetworks"
 import {cleanUpAgentName, removeTrailingUuid} from "../../AgentChat/Common/Utils"
 
-export type NodeIndex = Map<string, {agentInfo: AgentInfo; displayName: string}>
+//#region Types and Interfaces
 
 /**
- * Iteratively sort all children of tree nodes using a queue-based approach
- * @param nodes - Array of tree nodes to sort
- * @param nodeIndex - Index mapping node IDs to their AgentInfo and display names, used for sorting by display name
+ * Represents either a category (folder) or a network (leaf) in the tree view.
+ * Note that we omit the `children` property from the parent as we want to use read-only semantics
  */
-const sortTreeNodes = (nodes: TreeViewDefaultItemModelProperties[], nodeIndex: NodeIndex): void => {
-    // Sort the top level nodes first. We sort by displayName because that's what the user sees
-    nodes.sort((a, b) => {
-        const aDisplayName = nodeIndex.get(a.id)?.displayName ?? a.label
-        const bDisplayName = nodeIndex.get(b.id)?.displayName ?? b.label
-        return aDisplayName.localeCompare(bDisplayName)
-    })
+export interface AgentNetworkTreeItemModel extends Omit<TreeViewDefaultItemModelProperties, "children"> {
+    readonly children?: readonly AgentNetworkTreeItemModel[]
+    readonly displayName: string
+    readonly iconSuggestion?: string
+    readonly isNetwork: boolean
+    readonly tags?: readonly string[]
+    readonly temporaryNetworkExpirationTime?: Date
+    readonly temporaryNetworkHocon?: string | null
+}
 
-    // Use a queue for breadth-first traversal to avoid recursion
-    const queue: TreeViewDefaultItemModelProperties[] = [...nodes]
-    let index = 0
+interface NetworkTreeItemMetadata {
+    readonly iconSuggestion?: string
+    readonly temporaryNetworkExpirationTime?: Date
+    readonly temporaryNetworkHocon?: string | null
+}
 
-    // For each node in the queue, sort its children and add them to the end of the queue
-    while (index < queue.length) {
-        const node = queue[index]
-        index += 1
+interface TreeBuildState {
+    readonly categorizedItems: readonly AgentNetworkTreeItemModel[]
+    readonly uncategorizedItems: readonly AgentNetworkTreeItemModel[]
+}
 
-        if (node.children && node.children.length > 0) {
-            node.children.sort((a, b) => {
-                const aDisplayName = nodeIndex.get(a.id)?.displayName ?? a.label
-                const bDisplayName = nodeIndex.get(b.id)?.displayName ?? b.label
-                return aDisplayName.localeCompare(bDisplayName)
-            })
-            queue.push(...node.children)
+//#endregion
+
+/**
+ * Recursively searches for a tree item with the specified ID within the given list of tree items.
+ * @param items - The list of tree items to search through
+ * @param itemId - The ID of the tree item to find
+ * @returns The tree item with the matching ID, or undefined if not found
+ *
+ * @note Short-circuiting is used to avoid unnecessary searches once a match is found (compared to e.g., `flatMap()`)
+ */
+export const findTreeItemById = (
+    items: readonly AgentNetworkTreeItemModel[],
+    itemId: string
+): AgentNetworkTreeItemModel | undefined => {
+    for (const item of items) {
+        if (item.id === itemId) {
+            return item
+        }
+
+        const childMatch = item.children ? findTreeItemById(item.children, itemId) : undefined
+        if (childMatch) {
+            return childMatch
         }
     }
+
+    return undefined
 }
 
 /**
- * Add a single AgentInfo entry into the tree structure
+ * Converts a raw agent name into a display name for the tree view, respecting the user's preference for native
+ * vs cleaned names.
+ * @param itemName - The raw agent name from the API
+ * @param useNativeNames - Whether to use native names or cleaned-up names for display
+ * @returns The display name to show in the tree view
  */
-const addNetworkToTree = (
+const toDisplayName = (itemName: string, useNativeNames: boolean): string =>
+    useNativeNames ? itemName : cleanUpAgentName(removeTrailingUuid(itemName))
+
+/**
+ * Converts an AgentInfo object into a tree item model representing a network (leaf node).
+ * @param network - The AgentInfo object containing details about the network
+ * @param label - The label to use for the tree item (usually derived from the agent name)
+ * @param useNativeNames - Whether to use native names or cleaned-up names for display
+ * @param metadata - Additional metadata for the network tree item, such as icon suggestions and temporary network info
+ * @returns An AgentNetworkTreeItemModel representing the network as a leaf node in the tree
+ */
+const toNetworkLeaf = (
     network: AgentInfo,
-    result: TreeViewDefaultItemModelProperties[],
-    uncategorized: TreeViewDefaultItemModelProperties,
-    map: Map<string, TreeViewDefaultItemModelProperties>,
-    nodeIndex: NodeIndex,
-    useNativeNames: boolean
-): void => {
+    label: string,
+    useNativeNames: boolean,
+    metadata: NetworkTreeItemMetadata = {}
+): AgentNetworkTreeItemModel => ({
+    id: network.agent_name,
+    label,
+    displayName: toDisplayName(label, useNativeNames),
+    iconSuggestion: metadata.iconSuggestion,
+    isNetwork: true,
+    tags: network.tags,
+    temporaryNetworkExpirationTime: metadata.temporaryNetworkExpirationTime,
+    temporaryNetworkHocon: metadata.temporaryNetworkHocon,
+})
+
+/**
+ * Recursively sort tree nodes and their children by display name
+ * @param nodes - Array of tree nodes to sort
+ * @returns New array of tree nodes sorted by display name, with children also sorted
+ */
+const toSortedTreeNodes = (nodes: readonly AgentNetworkTreeItemModel[]): AgentNetworkTreeItemModel[] =>
+    [...nodes]
+        .sort((a, b) => a.displayName.localeCompare(b.displayName))
+        .map((node) => ({
+            ...node,
+            children: node.children ? toSortedTreeNodes(node.children) : undefined,
+        }))
+
+/**
+ * Creates a tree item model representing a category (folder node) in the tree view.
+ * @param id - The unique ID for the folder node, typically derived from the category path
+ * @param label - The label to use for the tree item (usually derived from the category name)
+ * @param useNativeNames - Whether to use native names or cleaned-up names for display
+ * @returns An AgentNetworkTreeItemModel representing the category as a folder node in the tree
+ */
+const toFolderNode = (id: string, label: string, useNativeNames: boolean): AgentNetworkTreeItemModel => ({
+    id,
+    label,
+    displayName: toDisplayName(label, useNativeNames),
+    isNetwork: false,
+    children: [],
+})
+
+/**
+ * Recursively adds a network to the categorized tree structure based on its agent name parts.
+ * @param nodes - The current list of tree nodes at this level of the hierarchy
+ * @param network - The AgentInfo object representing the network to add
+ * @param useNativeNames - Whether to use native names or cleaned-up names for display
+ * @param metadata - Additional metadata for the network tree item, such as icon suggestions and temporary network info
+ * @param parts - The parts of the agent name split by "/", used to determine the category hierarchy
+ * @param depth - The current depth in the category hierarchy, used to determine which part of the agent name to use
+ * for this level. For example, if the agent name is "category/subcategory/network", then at depth 0 we use "category",
+ * at depth 1 we use "subcategory", and at depth 2 we use "network".
+ */
+const withCategorizedNetworkAdded = (
+    nodes: readonly AgentNetworkTreeItemModel[],
+    network: AgentInfo,
+    useNativeNames: boolean,
+    metadata: NetworkTreeItemMetadata,
+    parts: readonly string[],
+    depth = 0
+): AgentNetworkTreeItemModel[] => {
+    const label = parts[depth]
+
+    // The node ID is constructed from the parts up to the current depth, analogous to a file path.
+    const nodeId = parts.slice(0, depth + 1).join("/")
+
+    // It's a network (leaf node) if we're at the last part of the agent name, otherwise it's a category (folder node)
+    const isNetwork = depth === parts.length - 1
+
+    // Check if a node with this ID already exists at the current level
+    const existingIndex = nodes.findIndex((node) => node.id === nodeId)
+
+    // If it's a network, we create a leaf node. If it's a category, we either create a new folder node or
+    // update the existing one with the new child.
+    const nextNode: AgentNetworkTreeItemModel = isNetwork
+        ? toNetworkLeaf(network, label, useNativeNames, metadata)
+        : {
+              ...(existingIndex >= 0 ? nodes[existingIndex] : toFolderNode(nodeId, label, useNativeNames)),
+              children: withCategorizedNetworkAdded(
+                  existingIndex >= 0 ? (nodes[existingIndex].children ?? []) : [],
+                  network,
+                  useNativeNames,
+                  metadata,
+                  parts,
+                  depth + 1
+              ),
+          }
+
+    // If the node doesn't already exist, we add it to the list. If it does exist, we replace it with the updated node.
+    if (existingIndex < 0) {
+        return [...nodes, nextNode]
+    }
+
+    // Return a new array with the existing node replaced by the updated node
+    return nodes.map((node, index) => (index === existingIndex ? nextNode : node))
+}
+
+/**
+ * Adds a network to the tree build state, either as an uncategorized item if its agent name has no "/"
+ * or as a categorized item
+ * @param state - The current state of the tree build, containing categorized and uncategorized items
+ * @param network - The AgentInfo object representing the network to add to the tree
+ * @param useNativeNames - Whether to use native names or cleaned-up names for display
+ * @param metadata - Additional metadata for the network tree item, such as icon suggestions and temporary network info
+ */
+const withNetworkAdded = (
+    state: TreeBuildState,
+    network: AgentInfo,
+    useNativeNames: boolean,
+    metadata: NetworkTreeItemMetadata
+): TreeBuildState => {
+    // Split the agent name into parts based on "/", which indicates category hierarchy. For example, an agent name
     const parts = network.agent_name.split("/")
 
-    // If there's only one part, it means this network isn't in any folder, so we add it directly under "Uncategorized"
+    // If there are no "/" in the agent name, we consider it uncategorized and add it to the uncategorized items list.
     if (parts.length === 1) {
-        uncategorized.children.push({id: network.agent_name, label: network.agent_name, children: []})
-        nodeIndex.set(network.agent_name, {
-            agentInfo: network,
-            displayName: useNativeNames ? network.agent_name : cleanUpAgentName(network.agent_name),
-        })
-    } else {
-        // Otherwise, we need to build out the tree structure based on the parts of the agent_name. Some paths might
-        // already exist if we've processed another network that shares the same parent folders,
-        // so we check the map to avoid duplicating nodes.
-        let currentLevel = result
+        return {
+            ...state,
+            uncategorizedItems: [
+                ...state.uncategorizedItems,
+                toNetworkLeaf(network, network.agent_name, useNativeNames, metadata),
+            ],
+        }
+    }
 
-        parts.forEach((part, index) => {
-            // Build the full path ID by joining all parts up to the current position
-            const nodeId = parts.slice(0, index + 1).join("/")
-            let node = map.get(nodeId)
-
-            if (!node) {
-                // If we haven't created a node for this path yet, create it and add it to the map
-                node = {id: nodeId, label: part, children: []}
-                map.set(nodeId, node)
-                if (index === parts.length - 1) {
-                    const displayName = useNativeNames ? part : cleanUpAgentName(removeTrailingUuid(part))
-
-                    // Add the AgentInfo to the nodeIndex for quick lookup later, using the full path as the key
-                    nodeIndex.set(nodeId, {agentInfo: network, displayName})
-                }
-
-                // If this is a top-level node (index 0), add it directly to the result.
-                // Otherwise, find its parent and add it there.
-                if (index === 0) {
-                    // Top-level node, add directly to result
-                    currentLevel.push(node)
-                } else {
-                    // Not a top-level node, find parent and add to its children
-                    const parentId = parts.slice(0, index).join("/")
-                    const parentNode = map.get(parentId)
-                    if (parentNode) {
-                        parentNode.children.push(node)
-                    }
-                }
-            }
-
-            // Move down to the next level of the tree for the next iteration
-            currentLevel = node.children
-        })
+    // Return the updated state with the network added to the categorized items
+    return {
+        ...state,
+        categorizedItems: withCategorizedNetworkAdded(state.categorizedItems, network, useNativeNames, metadata, parts),
     }
 }
 
 /**
  * Build a tree view structure from a flat list of networks.
  * The list of networks comes from a call to the Neuro-san /list API
- * The tree structure is used by the RichTreeView component to display the networks
- * @param networks - Array of networks from the Neuro-san /list API
- * @param temporaryNetworks - Array of temporary networks (e.g. ones recently created by the user)
+ * The tree structure is used by the RichTreeView component to display the networks.
+ *
  * @param useNativeNames - Whether to use the raw agent names from the API or to clean them up for display.
- * @returns Array of {@linkcode TreeViewDefaultItemModelProperties} objects representing the tree structure and an
- * index for rapid access
+ * @param regularNetworks - Array of networks from the Neuro-san /list API
+ * @param temporaryNetworks - Array of temporary networks (e.g., ones recently created by the user)
+ * @param iconSuggestions
+ * @returns Array of {@linkcode AgentNetworkTreeItemModel} objects representing the tree structure
  */
 export const buildTreeViewItems = (
-    networks: readonly AgentInfo[],
-    temporaryNetworks: readonly TemporaryNetwork[],
-    useNativeNames: boolean
-): {treeViewItems: TreeViewDefaultItemModelProperties[]; nodeIndex: NodeIndex} => {
-    // Map to keep track of created nodes in a tree structure
-    const treeBuilderMap = new Map<string, TreeViewDefaultItemModelProperties>()
-
-    // Index to quickly look up AgentInfo by node ID without having to traverse the tree
-    const nodeIndex: NodeIndex = new Map()
-
-    // Resulting tree view items, ready for consumption by RichTreeView
-    const treeViewItems: TreeViewDefaultItemModelProperties[] = []
-
-    // Special parent node for networks that aren't in any folder
-    const uncategorized: TreeViewDefaultItemModelProperties = {
-        id: "uncategorized",
-        label: "uncategorized",
-        children: [],
+    useNativeNames: boolean,
+    regularNetworks: readonly AgentInfo[] = [],
+    temporaryNetworks: readonly TemporaryNetwork[] = [],
+    iconSuggestions: Record<string, string> = {}
+): AgentNetworkTreeItemModel[] => {
+    let tree: TreeBuildState = {
+        categorizedItems: [],
+        uncategorizedItems: [],
     }
 
-    // Build a tree structure from the flat list of networks.
-    // The networks come in as a series of "paths" like "industry/retail/macys" and we need to build a tree
-    // structure from that.
-    networks.forEach((network) =>
-        addNetworkToTree(network, treeViewItems, uncategorized, treeBuilderMap, nodeIndex, useNativeNames)
-    )
-
-    // Now handle temporary networks
-    temporaryNetworks?.forEach((temporaryNetwork) =>
-        addNetworkToTree(
-            temporaryNetwork.agentInfo,
-            treeViewItems,
-            uncategorized,
-            treeBuilderMap,
-            nodeIndex,
-            useNativeNames
-        )
-    )
-
-    // Add "Uncategorized" to the result if there are any such networks
-    if (uncategorized.children.length > 0) {
-        treeViewItems.push(uncategorized)
+    for (const network of regularNetworks) {
+        tree = withNetworkAdded(tree, network, useNativeNames, {
+            iconSuggestion: iconSuggestions[network.agent_name],
+        })
     }
 
-    // Sort all nodes in the tree
-    sortTreeNodes(treeViewItems, nodeIndex)
+    for (const temporaryNetwork of temporaryNetworks) {
+        tree = withNetworkAdded(tree, temporaryNetwork.agentInfo, useNativeNames, {
+            iconSuggestion: "HourglassTop",
+            temporaryNetworkExpirationTime: new Date(temporaryNetwork.reservation.expiration_time_in_seconds * 1000),
+            temporaryNetworkHocon: temporaryNetwork.networkHocon,
+        })
+    }
 
-    return {treeViewItems, nodeIndex}
+    const treeViewItems: readonly AgentNetworkTreeItemModel[] =
+        tree.uncategorizedItems.length > 0
+            ? [
+                  ...tree.categorizedItems,
+                  {
+                      id: "uncategorized",
+                      label: "uncategorized",
+                      displayName: toDisplayName("uncategorized", useNativeNames),
+                      isNetwork: false,
+                      children: tree.uncategorizedItems,
+                  },
+              ]
+            : tree.categorizedItems
+
+    return toSortedTreeNodes(treeViewItems)
 }


### PR DESCRIPTION
**No changes to UI appearance or behavior.**

Another tech debt/technical PR, but will help a lot with future efforts that touch this area of the code.

Modify the tree building/tree items to be clean, functional, pure, and immutable. No longer build those ugly "indices" that get passed to every node, and instead, each node now carries relevant info for that node alone.

Allowed removing a lot of shaky code and cleaning  up a lot of stuff.

I couldn't get this approach to work initially, perhaps because earlier versions of MUI didn't support custom props on tree items very well. But now we're on MUI v9, it seems to work just fine.