### PR TITLE
#255 Improve default icon handling logic

### DIFF
--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentNode.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentNode.test.tsx
@@ -189,10 +189,10 @@ describe("AgentNode", () => {
     })
 
     it("warns and falls back to default icon when agentIconSuggestion is invalid", async () => {
-        const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined)
         renderAgentNode({agentIconSuggestion: "NotARealMuiIconAtAll"})
-        expect(warnSpy).toHaveBeenCalledWith("Invalid MUI icon suggestion: NotARealMuiIconAtAll")
-        warnSpy.mockRestore()
+
+        // check for fallback icon
+        await screen.findByTestId("AutoAwesomeIcon")
     })
 
     it.each([

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
@@ -30,6 +30,7 @@ import {
     TEST_AGENT_MATH_GUY,
     TEST_AGENT_MATH_GUY_DISPLAY,
     TEST_AGENT_MUSIC_NERD,
+    TEST_AGENT_MUSIC_NERD_DISPLAY,
     TEST_AGENTS_FOLDER,
     TEST_AGENTS_FOLDER_DISPLAY,
     TEST_DEEP_AGENT,
@@ -249,7 +250,6 @@ describe("SideBar", () => {
     })
 
     it("Should handle invalid icon suggestions correctly", async () => {
-        const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation()
         renderSidebarComponent({
             // Override networkIconSuggestions to include an invalid icon name for TEST_AGENT_MUSIC_NERD
             networkIconSuggestions: {
@@ -262,10 +262,9 @@ describe("SideBar", () => {
         const header = screen.getByText(TEST_AGENTS_FOLDER_DISPLAY)
         await user.click(header)
 
-        screen.getByText(TEST_AGENT_MATH_GUY_DISPLAY)
-        expect(screen.queryByText("NonExistentIcon")).not.toBeInTheDocument()
-
-        expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("NonExistentIcon"))
+        // Check for fallback to default icon
+        const treeItem = screen.getByText(TEST_AGENT_MUSIC_NERD_DISPLAY).closest('[role="treeitem"]')
+        within(treeItem as HTMLElement).getByTestId("HubIcon")
     })
 
     it("Should render the tags when user mouses over the icon", async () => {

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentNode.tsx
@@ -157,49 +157,56 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
     // Determine which icon to display based on the agent type whether it is Frontman or not
     const getDisplayAsIcon = () => {
         const id = `${agentId}-icon`
-        if (agentIconSuggestion && MuiIcons[agentIconSuggestion as keyof typeof MuiIcons]) {
-            const IconComponent = MuiIcons[agentIconSuggestion as keyof typeof MuiIcons]
-            return <IconComponent sx={{fontSize: AGENT_ICON_SIZE}} />
-        } else {
-            if (agentIconSuggestion) {
-                console.warn(`Invalid MUI icon suggestion: ${agentIconSuggestion}`)
-            }
-            if (isFrontman) {
+
+        // Check for valid MUI icon suggestion from the LLM suggestion service
+        const SuggestedIcon = agentIconSuggestion ? MuiIcons[agentIconSuggestion as keyof typeof MuiIcons] : undefined
+
+        // If the LLM provided a valid icon suggestion, use it. Otherwise, fall back to default icons based on
+        // agent type.
+        if (SuggestedIcon) {
+            return (
+                <SuggestedIcon
+                    id={id}
+                    sx={{fontSize: AGENT_ICON_SIZE}}
+                />
+            )
+        }
+
+        if (isFrontman) {
+            return (
+                // Use special icon and larger size for Frontman
+                <PersonIcon
+                    id={id}
+                    sx={{fontSize: FRONTMAN_ICON_SIZE}}
+                />
+            )
+        }
+
+        switch (displayAs) {
+            case DisplayAs.EXTERNAL_AGENT:
                 return (
-                    // Use special icon and larger size for Frontman
-                    <PersonIcon
+                    <TravelExploreIcon
                         id={id}
-                        sx={{fontSize: FRONTMAN_ICON_SIZE}}
+                        sx={{fontSize: AGENT_ICON_SIZE}}
                     />
                 )
-            } else {
-                switch (displayAs) {
-                    case DisplayAs.EXTERNAL_AGENT:
-                        return (
-                            <TravelExploreIcon
-                                id={id}
-                                sx={{fontSize: AGENT_ICON_SIZE}}
-                            />
-                        )
-                    // This should be a supported type but we're not seeing it?
-                    case DisplayAs.LANGCHAIN_TOOL:
-                    case DisplayAs.CODED_TOOL:
-                        return (
-                            <HandymanIcon
-                                id={id}
-                                sx={{fontSize: AGENT_ICON_SIZE}}
-                            />
-                        )
-                    case DisplayAs.LLM_AGENT:
-                    default:
-                        return (
-                            <AutoAwesomeIcon
-                                id={id}
-                                sx={{fontSize: AGENT_ICON_SIZE}}
-                            />
-                        )
-                }
-            }
+            // This should be a supported type but we're not seeing it?
+            case DisplayAs.LANGCHAIN_TOOL:
+            case DisplayAs.CODED_TOOL:
+                return (
+                    <HandymanIcon
+                        id={id}
+                        sx={{fontSize: AGENT_ICON_SIZE}}
+                    />
+                )
+            case DisplayAs.LLM_AGENT:
+            default:
+                return (
+                    <AutoAwesomeIcon
+                        id={id}
+                        sx={{fontSize: AGENT_ICON_SIZE}}
+                    />
+                )
         }
     }
 
@@ -213,7 +220,7 @@ export const AgentNode: FC<NodeProps<RFNode<AgentNodeProps>>> = (props: NodeProp
 
     const [isHovered, setIsHovered] = useState(false)
 
-    // Wrap the agent name with zero-width spaces to give the browser hints where to wrap.
+    // Insert zero-width spaces into the agent name to give the browser hints where to wrap.
     const wrappedAgentName = agentName
         // Allow wrap after underscore
         .replaceAll("_", `_${ZERO_WIDTH_SPACE}`)

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/AgentNetworkTreeItem.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/AgentNetworkTreeItem.tsx
@@ -100,13 +100,26 @@ export const AgentNetworkTreeItem: FC<AgentNetworkNodeProps> = ({
 
     const iconNameSuggestion = item.iconSuggestion
 
-    let muiIconElement = null
+    let muiIconElement
 
-    if (iconNameSuggestion && MuiIcons[iconNameSuggestion as keyof typeof MuiIcons]) {
-        const IconComponent = MuiIcons[iconNameSuggestion as keyof typeof MuiIcons]
-        muiIconElement = <IconComponent sx={{fontSize: "1rem"}} />
-    } else if (iconNameSuggestion) {
-        console.warn(`Icon "${iconNameSuggestion}" not found in MUI icons library.`)
+    // If the item is a child (i.e., a network), we want to render an icon next to it.
+    if (isChild) {
+        if (iconNameSuggestion) {
+            if (MuiIcons[iconNameSuggestion as keyof typeof MuiIcons]) {
+                // If the icon name suggestion is valid, use it to render the icon
+                const IconComponent = MuiIcons[iconNameSuggestion as keyof typeof MuiIcons]
+                muiIconElement = <IconComponent sx={{fontSize: "1rem"}} />
+            } else {
+                // If the icon name suggestion is not valid, use a default icon
+                muiIconElement = <MuiIcons.Hub sx={{fontSize: "1rem"}} />
+            }
+        } else {
+            // If no icon name suggestion is provided, use a default icon
+            muiIconElement = <MuiIcons.Hub sx={{fontSize: "1rem"}} />
+        }
+    } else {
+        // Use folder icon for parent items (i.e., folders)
+        muiIconElement = <MuiIcons.Folder sx={{fontSize: "1rem"}} />
     }
 
     return (


### PR DESCRIPTION
See #255 for a demonstration of the issue. Now fixed: both networks and agent nodes have valid fallback icons. Also removed the annoying spammy error messages that were polluting the logs; we know LLMs hallucinate, and sometimes come up with invalid MUI icon names. No need to keep logging about it.

Also a minor but cool UI tweak: add "folder" icons to network categories:

Before  | After
:-------------------------:|:-------------------------:
<img width="310" height="470" alt="image" src="https://github.com/user-attachments/assets/500cec6d-eb70-4592-8774-9edafb204d3d" />|<img width="311" height="494" alt="image" src="https://github.com/user-attachments/assets/7362440c-a6ab-4558-8a74-624d03740ffe" />

ℹ️ Note: in this example the LLM had recommend (somewhat reasonably...) `SmartHome` as the icon for the `Basic/Smart Home` network. Alas, that isn't a valid MUI icon, so observe the "splat" (aka `Hub` icon) fallback in the screenshot.

