### PR TITLE
#428 Refactor "Settings" to remove duplication and consolidate styles

### DIFF
--- a/packages/dev-common/Configs/eslint.config.mjs
+++ b/packages/dev-common/Configs/eslint.config.mjs
@@ -222,7 +222,6 @@ export default defineConfig([
             "getter-return": "error",
             "grouped-accessor-pairs": ["error", "anyOrder", {enforceForTSTypes: true}],
             "max-depth": "error",
-            "newline-per-chained-call": "error",
             "no-alert": "error",
             "no-array-constructor": "error",
             "no-const-assign": "error",
@@ -565,8 +564,6 @@ export default defineConfig([
                     ignorePattern: "^import .*",
                 },
             ],
-
-            "newline-per-chained-call": "error",
 
             // Enforce double quotes (already handled by prettier) _and_ prevent backtick expressions with no
             // interpolation See: https://github.com/prettier/eslint-config-prettier "special rules" "quotes"

--- a/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
@@ -63,6 +63,26 @@ describe("SettingsDialog", () => {
         await screen.findByText("Settings")
     })
 
+    it("handles nullish logoSource", async () => {
+        useSettingsStore.getState().updateSettings({
+            branding: {
+                logoSource: null,
+            },
+        })
+
+        render(
+            <SettingsDialog
+                id="settings-dialog"
+                isOpen={true}
+            />
+        )
+
+        // Should render without crashing and show the "(None)" option as selected by default
+        const logoOptionsContainer = screen.getByRole("group", {name: "logo-selection"})
+        const noneButton = within(logoOptionsContainer).getByRole("button", {name: /None/u})
+        expect(noneButton).toHaveAttribute("aria-pressed", "true")
+    })
+
     it("triggers onClose when the dialog is closed", async () => {
         const onCloseMock = jest.fn()
         render(
@@ -333,6 +353,12 @@ describe("SettingsDialog", () => {
 
         // Now should be true
         expect(useSettingsStore.getState().settings.appearance.autoAgentIconColor).toBe(true)
+
+        // Click it again
+        await user.click(autoColorCheckbox)
+
+        // Should not have changed value
+        expect(useSettingsStore.getState().settings.appearance.autoAgentIconColor).toBe(true)
     })
 
     it("Allows toggling Zen mode", async () => {
@@ -465,7 +491,7 @@ describe("SettingsDialog", () => {
 
         expect(useSettingsStore.getState().settings.branding.logoSource).toEqual<LogoSource>("none")
 
-        const logoOptionsContainer = screen.getByLabelText("logo-options-container")
+        const logoOptionsContainer = screen.getByRole("group", {name: "logo-selection"}).closest("span").closest("div")
 
         const customerName = "Acme"
         await enterCustomerName(customerName)
@@ -631,8 +657,9 @@ describe("SettingsDialog", () => {
 
         await enterCustomerName("Acme", true)
 
-        const logoOptionsContainer = screen.getByLabelText("logo-options-container")
-        const errorTooltip = within(logoOptionsContainer).getByLabelText(/No Logo.dev token found/u)
+        const logoOptionsContainer = screen.getByRole("group", {name: "logo-selection"})
+
+        const errorTooltip = within(logoOptionsContainer).getByLabelText(/Cannot use Auto logo source/u)
 
         // Get span that wraps the button
         const autoButtonSpan = within(logoOptionsContainer).getByRole("button", {name: /Auto/u}).parentElement

--- a/packages/ui-common/__tests__/components/Settings/SettingsRow.test.tsx
+++ b/packages/ui-common/__tests__/components/Settings/SettingsRow.test.tsx
@@ -1,0 +1,75 @@
+import {render, screen} from "@testing-library/react"
+import {UserEvent, userEvent} from "@testing-library/user-event"
+
+import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
+import {useCheckmarkFade} from "../../../components/Settings/FadingCheckmark"
+import {SettingsRow} from "../../../components/Settings/SettingsRow"
+
+describe("SettingsRow", () => {
+    withStrictMocks()
+
+    it("Renders correctly", async () => {
+        const labelText = "Test Label"
+        const childrenText = "Test Children"
+        const checkmark: ReturnType<typeof useCheckmarkFade> = {
+            show: true,
+            trigger: jest.fn(),
+        }
+        const tooltip = "Test Tooltip"
+
+        render(
+            <SettingsRow
+                checkmark={checkmark}
+                label={labelText}
+                tooltip={tooltip}
+            >
+                {childrenText}
+            </SettingsRow>
+        )
+
+        expect(screen.getByText(labelText)).toBeInTheDocument()
+        expect(screen.getByText(childrenText)).toBeInTheDocument()
+
+        // Checkmark should be shown
+        screen.getByTestId("CheckIcon")
+
+        // Mouse over ⓘ to show tooltip
+        const user: UserEvent = userEvent.setup()
+        const infoIcon = screen.getByTestId("InfoOutlinedIcon")
+        await user.hover(infoIcon)
+
+        await screen.findByText(tooltip)
+    })
+
+    it("Handles missing values", async () => {
+        render(
+            <SettingsRow
+                disabled={true}
+                label=""
+                tooltip="Test Tooltip"
+            >
+                null
+            </SettingsRow>
+        )
+
+        const user: UserEvent = userEvent.setup()
+
+        // Mouse over ⓘ to show tooltip
+        const infoIcon = screen.getByTestId("InfoOutlinedIcon")
+        await user.hover(infoIcon)
+    })
+
+    it.each([{backgroundColor: "red"}, [{backgroundColor: "red"}]])("Handles SX value: %o", async (sx) => {
+        const {container} = render(
+            <SettingsRow
+                label="Test Label"
+                sx={sx}
+                tooltip="Test Tooltip"
+            >
+                Test Children
+            </SettingsRow>
+        )
+
+        expect(container.firstElementChild).toHaveStyle({backgroundColor: "rgb(255, 0, 0)"})
+    })
+})

--- a/packages/ui-common/components/Common/Navbar.tsx
+++ b/packages/ui-common/components/Common/Navbar.tsx
@@ -19,6 +19,7 @@ limitations under the License.
  */
 
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
+import Business from "@mui/icons-material/Business"
 import DarkModeIcon from "@mui/icons-material/DarkMode"
 import SettingsIcon from "@mui/icons-material/Settings"
 import Box from "@mui/material/Box"
@@ -180,6 +181,7 @@ export const Navbar = ({
                     <>
                         <CustomerLogo
                             customer={customer}
+                            fallbackIcon={Business}
                             iconSuggestion={iconSuggestion}
                             logoServiceToken={logoServiceToken}
                             logoSource={logoSource}

--- a/packages/ui-common/components/Logo/CustomerLogo.tsx
+++ b/packages/ui-common/components/Logo/CustomerLogo.tsx
@@ -1,6 +1,7 @@
 // Have to suppress this lint error to allow dynamic access of MUI icons
 // eslint-disable-next-line no-restricted-imports
 import * as MuiIcons from "@mui/icons-material"
+import {SvgIconProps} from "@mui/material/SvgIcon"
 import {FC} from "react"
 
 import {LogoSource} from "../../state/Settings"
@@ -8,6 +9,7 @@ import {LogoSource} from "../../state/Settings"
 //#region Types and Interfaces
 interface CustomerLogoProps {
     readonly customer: string
+    readonly fallbackIcon?: FC<SvgIconProps>
     readonly iconSuggestion?: string
     readonly logoServiceToken?: string
     readonly logoSource: LogoSource
@@ -19,28 +21,34 @@ export const LOGO_DEV_URL = "https://img.logo.dev/name"
 /**
  * Component to display the customer's logo based on the settings.
  * @param customer - Name of the customer, used for fetching the logo from logo.dev when logoSource is "auto"
+ * @param fallbackIcon - Optional MUI icon to use as a fallback if other approaches fail
  * @param iconSuggestion - Optional MUI icon name to use when logoSource is "generic"
  * @param logoServiceToken - Optional token for fetching the logo from logo.dev
  * @param logoSource - Source of the logo, determines how the logo is rendered ("none", "generic", or "auto")
  * @returns JSX element representing the customer's logo, MUI icon, or Cognizant fallback, or null if no logo
  * should be displayed or if the logo.dev token is missing/invalid.
  */
-export const CustomerLogo: FC<CustomerLogoProps> = ({customer, iconSuggestion, logoServiceToken, logoSource}) => {
+export const CustomerLogo: FC<CustomerLogoProps> = ({
+    customer,
+    fallbackIcon: FallbackIcon,
+    iconSuggestion,
+    logoServiceToken,
+    logoSource,
+}) => {
     const hasCustomer = customer?.trim()?.length > 0
+    const fallback = FallbackIcon ? <FallbackIcon sx={{fontSize: "2rem"}} /> : null
 
     // "generic": check if suggested MUI icon is valid
     switch (logoSource) {
         case "generic": {
             const MuiIcon = MuiIcons[iconSuggestion as keyof typeof MuiIcons]
-            if (MuiIcon) {
-                return <MuiIcon sx={{fontSize: "2rem"}} />
-            } else {
-                return null
-            }
+            const LogoIcon = MuiIcon ?? FallbackIcon
+
+            return LogoIcon ? <LogoIcon sx={{fontSize: "2rem"}} /> : null
         }
         case "auto": {
             if (!hasCustomer || !logoServiceToken || logoServiceToken.trim().length === 0) {
-                return null
+                return fallback
             }
 
             // "auto": use logo.dev service
@@ -59,6 +67,6 @@ export const CustomerLogo: FC<CustomerLogoProps> = ({customer, iconSuggestion, l
         }
         case "none":
         default:
-            return null
+            return fallback
     }
 }

--- a/packages/ui-common/components/Logo/CustomerLogo.tsx
+++ b/packages/ui-common/components/Logo/CustomerLogo.tsx
@@ -66,6 +66,7 @@ export const CustomerLogo: FC<CustomerLogoProps> = ({
             )
         }
         case "none":
+            return null
         default:
             return fallback
     }

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentConversations.ts
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentConversations.ts
@@ -41,7 +41,6 @@ export const isFinalMessage = (chatMessage: {
 export const createConversation = (agents: string[], text: string, type: ChatMessageType): AgentConversation => ({
     // Could use crypto.randomUUID, but it's only available under HTTPS, and don't want to use a different
     // solution for HTTP on localhost.
-    // eslint-disable-next-line newline-per-chained-call
     id: `conv_${Date.now()}${Math.random().toString(36).slice(2, 10)}`,
     agents: new Set(agents),
     startedAt: new Date(),

--- a/packages/ui-common/components/Settings/ApiKeyInput.tsx
+++ b/packages/ui-common/components/Settings/ApiKeyInput.tsx
@@ -126,6 +126,8 @@ export const ApiKeyInput: FC<ApiKeyInputProps> = ({
                         endAdornment: (
                             <InputAdornment position="end">
                                 <Tooltip title={showKey ? "Hide API key" : "Show API key"}>
+                                    {/*"span" required for tooltip when child is disabled. See:*/}
+                                    {/*https://github.com/mui/material-ui/issues/8416*/}
                                     <span>
                                         <IconButton
                                             aria-label="toggle key visibility"

--- a/packages/ui-common/components/Settings/InfoTip.tsx
+++ b/packages/ui-common/components/Settings/InfoTip.tsx
@@ -1,0 +1,23 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
+import Tooltip from "@mui/material/Tooltip"
+import {ReactNode} from "react"
+
+/**
+ * Simple wrapper around MUI's Tooltip that displays an info icon which, when hovered, shows the provided title.
+ * @param props Object containing the title to be displayed in the tooltip.
+ */
+export default function InfoTip(props: {title: ReactNode}) {
+    return (
+        <Tooltip title={props.title}>
+            <InfoOutlinedIcon
+                aria-label="setting information"
+                fontSize="small"
+                sx={{
+                    color: "primary.main",
+                    cursor: "help",
+                    fontSize: "0.9rem",
+                }}
+            />
+        </Tooltip>
+    )
+}

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -13,7 +13,8 @@ import Typography from "@mui/material/Typography"
 import {ComponentPropsWithoutRef, FC, MouseEvent as ReactMouseEvent, ReactNode, useEffect, useState} from "react"
 
 import {ApiKeyInput} from "./ApiKeyInput"
-import {FadingCheckmark, useCheckmarkFade} from "./FadingCheckmark"
+import {useCheckmarkFade} from "./FadingCheckmark"
+import InfoTip from "./InfoTip"
 import {SettingsRow} from "./SettingsRow"
 import {getBrandingSuggestions} from "../../controller/agent/Agent"
 import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../controller/llm/Providers"
@@ -65,7 +66,7 @@ const SubSectionBody = styled(Box)(({theme}) => ({
     alignContent: "center",
     display: "flex",
     flexDirection: "column",
-    gap: theme.spacing(2),
+    gap: theme.spacing(2.5),
     width: "100%",
 }))
 //#endregion: Styled Components
@@ -79,6 +80,7 @@ interface SettingsDialogProps {
 }
 
 interface LLMProviderInputConfig {
+    checkmark: ReturnType<typeof useCheckmarkFade>
     vendor: LLMProvider
     idSuffix: string
     logo: string
@@ -131,7 +133,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     const customer = useSettingsStore((state) => state.settings.branding.customer)
     const brandingCheckmark = useCheckmarkFade()
     const logoCheckmark = useCheckmarkFade()
-    const [customerInput, setCustomerInput] = useState<string>(customer)
+    const [customerInput, setCustomerInput] = useState<string>(customer ?? "")
     const [isBrandingApplying, setIsBrandingApplying] = useState<boolean>(false)
     const logoSource = useSettingsStore((state) => state.settings.branding.logoSource)
     const iconSuggestion = useSettingsStore((state) => state.settings.branding.iconSuggestion)
@@ -142,6 +144,8 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
 
     // API keys
     const apiKeys = useSettingsStore((state) => state.settings.apiKeys)
+    const openAIKeyCheckmark = useCheckmarkFade()
+    const anthropicKeyCheckmark = useCheckmarkFade()
 
     // Native names setting
     const useNativeNames = useSettingsStore((state) => state.settings.appearance.useNativeNames)
@@ -183,7 +187,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                 ...(Array.isArray(rangePalette) ? {rangePalette} : {}),
                 ...(newIconSuggestion
                     ? {
-                          newIconSuggestion,
+                          iconSuggestion: newIconSuggestion,
                           logoSource: logoServiceToken ? "auto" : "generic",
                       }
                     : {}),
@@ -199,6 +203,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
 
         // Trigger checkmarks for items we changed
         brandingCheckmark.trigger()
+        rangePaletteCheckmark.trigger()
 
         if (plasma) {
             plasmaColorCheckmark.trigger()
@@ -259,12 +264,13 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
         logoCheckmark.trigger()
     }
 
-    const persistKey = (vendor: LLMProvider, key: string) => {
+    const persistKey = (vendor: LLMProvider, key: string, checkmark: ReturnType<typeof useCheckmarkFade>) => {
         updateSettings({
             apiKeys: {
                 [vendor]: key,
             },
         })
+        checkmark.trigger()
     }
 
     // Effect to keep input in sync with state store
@@ -278,18 +284,20 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     // Config for API key inputs, so we can easily add new providers in the future by just adding to this array
     const apiKeyConfigs: LLMProviderInputConfig[] = [
         {
-            vendor: "OpenAI",
+            checkmark: openAIKeyCheckmark,
             idSuffix: "openai",
             logo: theme.palette.mode === "dark" ? "/OpenAI-white.png" : "/OpenAI-black.png",
             onTest: isOpenAIKeyValid,
             placeholder: "sk-...",
+            vendor: "OpenAI",
         },
         {
-            vendor: "Anthropic",
+            checkmark: anthropicKeyCheckmark,
             idSuffix: "anthropic",
             logo: "/claude.png",
             onTest: isAnthropicKeyValid,
             placeholder: "sk-ant-...",
+            vendor: "Anthropic",
         },
     ]
 
@@ -314,33 +322,47 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
 
     const getApiKeysSection = () => (
         <Section>
-            <SettingsSubsection title="API Keys">
-                <SubsectionTitle variant="subtitle1">Providers</SubsectionTitle>
-                <SubSectionBody>
-                    <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5}}>
-                        {apiKeyConfigs.map(({vendor, idSuffix, logo, onTest, placeholder}) => (
+            <Box sx={{display: "flex", alignItems: "center", gap: theme.spacing(2)}}>
+                <SettingsSectionTitle>API Keys</SettingsSectionTitle>
+                <InfoTip
+                    title={
+                        "API keys are used to access external services. Some networks may require an API key for " +
+                        "you to use them. Your keys will be saved in your browser local storage and sent to " +
+                        "services that require them. Do not use this option if you are on a shared or public computer."
+                    }
+                />
+            </Box>
+            <SubsectionTitle variant="subtitle1">Providers</SubsectionTitle>
+            <SubSectionBody>
+                <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5}}>
+                    {apiKeyConfigs.map(({checkmark, vendor, idSuffix, logo, onTest, placeholder}) => (
+                        <SettingsRow
+                            checkmark={checkmark}
+                            key={`${id}-${idSuffix}`}
+                            label=""
+                            tooltip={`API key for ${vendor}.`}
+                        >
                             <ApiKeyInput
-                                key={idSuffix}
-                                forgetKey={() => persistKey(vendor, "")}
+                                forgetKey={() => persistKey(vendor, "", checkmark)}
                                 id={`${id}-${idSuffix}`}
                                 logo={logo}
-                                onSave={(key) => persistKey(vendor, key)}
+                                onSave={(key) => persistKey(vendor, key, checkmark)}
                                 onTest={onTest}
                                 persistedValue={apiKeys[vendor]}
                                 placeholder={placeholder}
                                 vendor={vendor}
                             />
-                        ))}
-                    </Box>
-                </SubSectionBody>
-            </SettingsSubsection>
+                        </SettingsRow>
+                    ))}
+                </Box>
+            </SubSectionBody>
         </Section>
     )
 
     const getBehaviorSection = () => (
         <Section>
             <SettingsSectionTitle>Behavior</SettingsSectionTitle>
-            <SettingsSubsection title="Behavior">
+            <SettingsSubsection title="Zen mode">
                 <SettingsRow
                     label='Enable "Zen" mode:'
                     checkmark={enableZenModeCheckmark}
@@ -389,7 +411,6 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                         }
                     }}
                     size="small"
-                    sx={{mx: 2}}
                     value={useNativeNames ? "native" : "beautified"}
                 >
                     <ToggleButton value="native">Native</ToggleButton>
@@ -438,7 +459,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                             void handleBrandingApply()
                         }
                     }}
-                    value={customerInput ?? ""}
+                    value={customerInput}
                     placeholder="Company or organization name"
                     size="small"
                     sx={{width: "100%"}}
@@ -469,74 +490,79 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                 tooltip={
                     "Choose a logo to display in the top-left corner of the network. " +
                     '"None" will display no logo, "Generic" will display a simple generic logo, and "Auto" will ' +
-                    "attempt to find a suitable logo based on the customer name using an external service (requires " +
-                    "a Logo.dev token). Logo is only displayed when customer branding is applied."
+                    "attempt to find a suitable logo based on the customer name using an external service (if " +
+                    "configured on the server). Logo is only displayed when customer branding is applied."
                 }
             >
-                <ToggleButtonGroup
-                    aria-label="logo-selection"
-                    disabled={!customer}
-                    exclusive={true}
-                    onChange={(_, value) => {
-                        if (value !== null) {
-                            updateSettings({
-                                branding: {
-                                    logoSource: value,
-                                },
-                            })
-                            logoCheckmark.trigger()
-                        }
-                    }}
-                    size="small"
-                    sx={{marginRight: "1rem"}}
-                    value={logoSource || "none"}
-                >
-                    <Tooltip title={customer && "No logo will be displayed"}>
-                        {/*"span" required for tooltip when child is disabled. See:*/}
-                        {/*https://github.com/mui/material-ui/issues/8416*/}
-                        <span style={{cursor: customer ? "pointer" : "not-allowed"}}>
-                            <ToggleButton value="none">None</ToggleButton>
-                        </span>
-                    </Tooltip>
-                    <Tooltip title={customer && "Display a simple, anonymous generic logo based on a generic brand"}>
-                        {/*"span" required for tooltip when child is disabled. See:*/}
-                        {/*https://github.com/mui/material-ui/issues/8416*/}
-                        <span style={{cursor: customer ? "pointer" : "not-allowed"}}>
-                            <ToggleButton value="generic">Generic</ToggleButton>
-                        </span>
-                    </Tooltip>
-                    <Tooltip
-                        title={
-                            customer &&
-                            (logoServiceToken
-                                ? "Use a service to attempt to automatically find a suitable " +
-                                  "logo based on the customer name."
-                                : "No Logo.dev token found, cannot use Auto logo source")
-                        }
-                    >
-                        {/*"span" required for tooltip when child is disabled. See:*/}
-                        {/*https://github.com/mui/material-ui/issues/8416*/}
-                        <span
-                            style={{
-                                cursor: customer && logoServiceToken ? "pointer" : "not-allowed",
+                <Tooltip title={customer ? undefined : "Set a customer name to enable logo options"}>
+                    {/*"span" required for tooltip when child is disabled. See:*/}
+                    {/*https://github.com/mui/material-ui/issues/8416*/}
+                    <span>
+                        <ToggleButtonGroup
+                            aria-label="logo-selection"
+                            disabled={!customer}
+                            exclusive={true}
+                            onChange={(_, value) => {
+                                if (value !== null) {
+                                    updateSettings({
+                                        branding: {
+                                            logoSource: value,
+                                        },
+                                    })
+                                    logoCheckmark.trigger()
+                                }
                             }}
+                            size="small"
+                            sx={{cursor: customer && logoServiceToken ? "pointer" : "not-allowed", marginRight: "1rem"}}
+                            value={logoSource || "none"}
                         >
-                            <ToggleButton
-                                disabled={!logoServiceToken}
-                                value="auto"
+                            <Tooltip title={customer && "No logo will be displayed"}>
+                                {/*"span" required for tooltip when child is disabled. See:*/}
+                                {/*https://github.com/mui/material-ui/issues/8416*/}
+                                <span>
+                                    <ToggleButton value="none">None</ToggleButton>
+                                </span>
+                            </Tooltip>
+                            <Tooltip
+                                title={customer && "Display a simple, anonymous generic logo based on a generic brand"}
                             >
-                                Auto
-                            </ToggleButton>
-                        </span>
-                    </Tooltip>
-                </ToggleButtonGroup>
+                                {/*"span" required for tooltip when child is disabled. See:*/}
+                                {/*https://github.com/mui/material-ui/issues/8416*/}
+                                <span>
+                                    <ToggleButton value="generic">Generic</ToggleButton>
+                                </span>
+                            </Tooltip>
+                            <Tooltip
+                                title={
+                                    customer
+                                        ? logoServiceToken
+                                            ? "Use a service to attempt to automatically find a suitable logo based " +
+                                              "on the customer name."
+                                            : "Logo service not configured on the server. Cannot use Auto logo source"
+                                        : undefined
+                                }
+                            >
+                                {/*"span" required for tooltip when child is disabled. See:*/}
+                                {/*https://github.com/mui/material-ui/issues/8416*/}
+                                <span>
+                                    <ToggleButton
+                                        disabled={!logoServiceToken}
+                                        value="auto"
+                                    >
+                                        Auto
+                                    </ToggleButton>
+                                </span>
+                            </Tooltip>
+                        </ToggleButtonGroup>
+                    </span>
+                </Tooltip>
                 <FormLabel>Preview:</FormLabel>
                 <Box>
                     {logoSource === "auto" || logoSource === "generic" ? (
                         <CustomerLogo
-                            customer={customer}
+                            customer={customer ?? ""}
                             fallbackIcon={Business}
-                            iconSuggestion={iconSuggestion}
+                            iconSuggestion={iconSuggestion ?? undefined}
                             logoServiceToken={logoServiceToken}
                             logoSource={logoSource}
                         />
@@ -550,9 +576,12 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
 
     const getNetworkDisplaySubsection = () => (
         <SettingsSubsection title="Network display">
-            <FormLabel sx={{marginBottom: 2}}>Palette (heatmap and depth):</FormLabel>
-            <Box sx={{display: "flex", alignItems: "center", gap: 2}}>
-                <Tooltip title={customer ? "Palette is locked when branding is applied" : ""}>
+            <SettingsRow
+                checkmark={rangePaletteCheckmark}
+                label="Palette:"
+                tooltip="Choose the color palette to use for heatmaps and depth display in the network. "
+            >
+                <Tooltip title={customer ? "Palette is determined by customer branding and cannot be changed" : ""}>
                     {/*"span" required for tooltip when child is disabled. See:*/}
                     {/*https://github.com/mui/material-ui/issues/8416*/}
                     <span>
@@ -618,118 +647,119 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                         </ToggleButtonGroup>
                     </span>
                 </Tooltip>
-                <FadingCheckmark show={rangePaletteCheckmark.show} />
-            </Box>
+            </SettingsRow>
         </SettingsSubsection>
     )
 
     const getNetworkAnimationSubsection = () => (
         <SettingsSubsection title="Network animation">
-            <Box sx={{display: "flex", alignItems: "center", gap: 2}}>
-                <FormLabel>Plasma animation color:</FormLabel>
-                <Tooltip title={customer ? "Plasma color is locked when branding is applied" : ""}>
-                    <input
-                        aria-label="plasma-color-picker"
+            <SettingsRow
+                checkmark={plasmaColorCheckmark}
+                label="Plasma animation color:"
+                tooltip={
+                    customer
+                        ? "Plasma color is locked when branding is applied"
+                        : "Select the color for the plasma animation."
+                }
+            >
+                <input
+                    aria-label="plasma-color-picker"
+                    disabled={Boolean(customer)}
+                    onChange={(e) => {
+                        updateSettings({
+                            appearance: {
+                                plasmaColor: e.target.value,
+                            },
+                        })
+                        plasmaColorCheckmark.trigger()
+                    }}
+                    style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
+                    type="color"
+                    value={plasmaColor}
+                />
+            </SettingsRow>
+            <SettingsRow
+                checkmark={agentNodeColorCheckmark}
+                label="Agent node color:"
+                tooltip={
+                    customer
+                        ? "Agent node color is locked when branding is applied"
+                        : "Select the color for the agent node animation."
+                }
+            >
+                <input
+                    aria-label="agent-node-color-picker"
+                    disabled={Boolean(customer)}
+                    onChange={(e) => {
+                        updateSettings({
+                            appearance: {
+                                agentNodeColor: e.target.value,
+                            },
+                        })
+                        agentNodeColorCheckmark.trigger()
+                    }}
+                    style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
+                    type="color"
+                    value={agentNodeColor}
+                />
+            </SettingsRow>
+            <SettingsRow
+                checkmark={agentIconColorCheckmark}
+                label="Agent icon color:"
+                tooltip={
+                    customer
+                        ? "Agent icon color is locked when branding is applied"
+                        : "Select the color for the agent icon animation."
+                }
+            >
+                {/*"span" required for tooltip when child is disabled. See:*/}
+                {/*https://github.com/mui/material-ui/issues/8416*/}
+                <span>
+                    <ToggleButtonGroup
                         disabled={Boolean(customer)}
-                        onChange={(e) => {
-                            updateSettings({
-                                appearance: {
-                                    plasmaColor: e.target.value,
-                                },
-                            })
-                            plasmaColorCheckmark.trigger()
+                        exclusive
+                        value={autoAgentIconColor ? "auto" : "custom"}
+                        onChange={(_, value) => {
+                            if (value !== null) {
+                                updateSettings({
+                                    appearance: {
+                                        autoAgentIconColor: value === "auto",
+                                    },
+                                })
+                                agentIconColorCheckmark.trigger()
+                            }
                         }}
-                        style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
-                        type="color"
-                        value={plasmaColor}
-                    />
-                </Tooltip>
-                <FadingCheckmark show={plasmaColorCheckmark.show} />
-            </Box>
-            <Box sx={{display: "flex", alignItems: "center", gap: 2, marginTop: "1rem"}}>
-                <FormLabel>Agent node color:</FormLabel>
-                <Tooltip title={customer ? "Agent node color is locked when branding is applied" : ""}>
-                    <input
-                        aria-label="agent-node-color-picker"
-                        disabled={Boolean(customer)}
-                        onChange={(e) => {
-                            updateSettings({
-                                appearance: {
-                                    agentNodeColor: e.target.value,
-                                },
-                            })
-                            agentNodeColorCheckmark.trigger()
+                        size="small"
+                        style={{
+                            cursor: customer ? "not-allowed" : "pointer",
+                            opacity: customer ? 0.5 : 1,
                         }}
-                        style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
-                        type="color"
-                        value={agentNodeColor}
-                    />
-                </Tooltip>
-                <FadingCheckmark show={agentNodeColorCheckmark.show} />
-            </Box>
-            <Box sx={{display: "flex", alignItems: "center", gap: 2, marginTop: "1rem"}}>
-                <FormLabel>Agent icon color:</FormLabel>
-                <Tooltip title={customer ? "Agent icon color is locked when branding is applied" : ""}>
-                    {/*"span" required for tooltip when child is disabled. See:*/}
-                    {/*https://github.com/mui/material-ui/issues/8416*/}
-                    <span>
-                        <ToggleButtonGroup
-                            disabled={Boolean(customer)}
-                            exclusive
-                            value={autoAgentIconColor ? "auto" : "custom"}
-                            onChange={(_, value) => {
-                                if (value !== null) {
-                                    updateSettings({
-                                        appearance: {
-                                            autoAgentIconColor: value === "auto",
-                                        },
-                                    })
-                                    agentIconColorCheckmark.trigger()
-                                }
-                            }}
-                            size="small"
-                            style={{
-                                cursor: customer ? "not-allowed" : "pointer",
-                                opacity: customer ? 0.5 : 1,
-                            }}
+                    >
+                        <ToggleButton
+                            data-testid="auto-agent-icon-color-button"
+                            value="auto"
                         >
-                            <ToggleButton
-                                data-testid="auto-agent-icon-color-button"
-                                value="auto"
-                            >
-                                Auto
-                            </ToggleButton>
-                            <ToggleButton value="custom">Custom</ToggleButton>
-                        </ToggleButtonGroup>
-                    </span>
-                </Tooltip>
-                <Tooltip
-                    title={
-                        customer
-                            ? "Agent icon color is locked when branding is applied"
-                            : autoAgentIconColor
-                              ? "Disabled when Auto is selected"
-                              : ""
-                    }
-                >
-                    <input
-                        aria-label="agent-icon-color-picker"
-                        disabled={Boolean(customer) || autoAgentIconColor}
-                        onChange={(e) => {
-                            updateSettings({
-                                appearance: {
-                                    agentIconColor: e.target.value,
-                                },
-                            })
-                            agentIconColorCheckmark.trigger()
-                        }}
-                        style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
-                        type="color"
-                        value={agentIconColor}
-                    />
-                </Tooltip>
-                <FadingCheckmark show={agentIconColorCheckmark.show} />
-            </Box>
+                            Auto
+                        </ToggleButton>
+                        <ToggleButton value="custom">Custom</ToggleButton>
+                    </ToggleButtonGroup>
+                </span>
+                <input
+                    aria-label="agent-icon-color-picker"
+                    disabled={Boolean(customer) || autoAgentIconColor}
+                    onChange={(e) => {
+                        updateSettings({
+                            appearance: {
+                                agentIconColor: e.target.value,
+                            },
+                        })
+                        agentIconColorCheckmark.trigger()
+                    }}
+                    style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
+                    type="color"
+                    value={agentIconColor}
+                />
+            </SettingsRow>
         </SettingsSubsection>
     )
 

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -9,10 +9,11 @@ import ToggleButton from "@mui/material/ToggleButton"
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
-import {ComponentPropsWithoutRef, FC, MouseEvent as ReactMouseEvent, useEffect, useState} from "react"
+import {ComponentPropsWithoutRef, FC, MouseEvent as ReactMouseEvent, ReactNode, useEffect, useState} from "react"
 
 import {ApiKeyInput} from "./ApiKeyInput"
 import {FadingCheckmark, useCheckmarkFade} from "./FadingCheckmark"
+import {SettingsRow} from "./SettingsRow"
 import {getBrandingSuggestions} from "../../controller/agent/Agent"
 import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../controller/llm/Providers"
 import {BrandingSuggestions} from "../../controller/Types/Branding"
@@ -83,7 +84,20 @@ interface LLMProviderInputConfig {
     onTest: (key: string) => Promise<boolean>
     placeholder: string
 }
+
+interface SettingsSubsectionProps {
+    readonly title: string
+    readonly children: ReactNode
+}
 //#endregion: Types and Interfaces
+
+// eslint-disable-next-line react/no-multi-comp -- only relevant to this module.
+const SettingsSubsection: FC<SettingsSubsectionProps> = ({title, children}) => (
+    <SubSection>
+        <SubsectionTitle variant="subtitle1">{title}</SubsectionTitle>
+        <SubSectionBody>{children}</SubSectionBody>
+    </SubSection>
+)
 
 // eslint-disable-next-line react/no-multi-comp -- styled component shim is only used in this module
 export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoServiceToken, onClose}) => {
@@ -148,78 +162,53 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     }
 
     const updateBranding = (brandingSuggestions: BrandingSuggestions) => {
-        updateSettings({
+        const {
+            plasma,
+            nodeColor,
+            primary,
+            secondary,
+            background,
+            rangePalette,
+            iconSuggestion: newIconSuggestion,
+        } = brandingSuggestions
+
+        // Update persisted settings with new branding suggestions
+        const updates: Parameters<typeof updateSettings>[0] = {
             branding: {
                 customer: customerInput,
+                ...(primary ? {primary} : {}),
+                ...(secondary ? {secondary} : {}),
+                ...(background ? {background} : {}),
+                ...(Array.isArray(rangePalette) ? {rangePalette} : {}),
+                ...(newIconSuggestion
+                    ? {
+                          newIconSuggestion,
+                          logoSource: logoServiceToken ? "auto" : "generic",
+                      }
+                    : {}),
             },
-        })
-
-        updateSettings({
             appearance: {
                 rangePalette: "brand",
+                ...(plasma ? {plasmaColor: plasma} : {}),
+                ...(nodeColor ? {agentNodeColor: nodeColor} : {}),
             },
-        })
+        }
 
-        if (brandingSuggestions["plasma"]) {
-            updateSettings({
-                appearance: {
-                    plasmaColor: brandingSuggestions["plasma"],
-                },
-            })
+        updateSettings(updates)
+
+        // Trigger checkmarks for items we changed
+        brandingCheckmark.trigger()
+
+        if (plasma) {
             plasmaColorCheckmark.trigger()
         }
 
-        if (brandingSuggestions["nodeColor"]) {
-            updateSettings({
-                appearance: {
-                    agentNodeColor: brandingSuggestions["nodeColor"],
-                },
-            })
+        if (nodeColor) {
             agentNodeColorCheckmark.trigger()
         }
 
-        // primary
-        if (brandingSuggestions["primary"]) {
-            updateSettings({
-                branding: {
-                    primary: brandingSuggestions["primary"],
-                },
-            })
-        }
-
-        // secondary
-        if (brandingSuggestions["secondary"]) {
-            updateSettings({
-                branding: {
-                    secondary: brandingSuggestions["secondary"],
-                },
-            })
-        }
-
-        // background
-        if (brandingSuggestions["background"]) {
-            updateSettings({
-                branding: {
-                    background: brandingSuggestions["background"],
-                },
-            })
-        }
-
-        if (Array.isArray(brandingSuggestions["rangePalette"])) {
-            updateSettings({
-                branding: {
-                    rangePalette: brandingSuggestions["rangePalette"],
-                },
-            })
-        }
-
-        if (brandingSuggestions["iconSuggestion"]) {
-            updateSettings({
-                branding: {
-                    iconSuggestion: brandingSuggestions["iconSuggestion"],
-                    logoSource: logoServiceToken ? "auto" : "generic",
-                },
-            })
+        if (newIconSuggestion) {
+            logoCheckmark.trigger()
         }
     }
 
@@ -233,7 +222,6 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
             const brandingSuggestions = await getBrandingSuggestions(customerInput)
             if (brandingSuggestions) {
                 updateBranding(brandingSuggestions)
-                brandingCheckmark.trigger()
             }
         } catch (e) {
             console.error(`Failed to fetch branding suggestions for customer "${customerInput}"`, e)
@@ -249,12 +237,25 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     }
 
     const handleBrandingClear = () => {
+        // Clear branding settings
         updateSettings({
             appearance: {
+                agentIconColor: DEFAULT_SETTINGS.appearance.agentIconColor,
+                agentNodeColor: DEFAULT_SETTINGS.appearance.agentNodeColor,
+                autoAgentIconColor: DEFAULT_SETTINGS.appearance.autoAgentIconColor,
+                plasmaColor: DEFAULT_SETTINGS.appearance.plasmaColor,
                 rangePalette: DEFAULT_SETTINGS.appearance.rangePalette,
             },
             branding: {...DEFAULT_SETTINGS.branding},
         })
+
+        // Trigger checkmarks for all the settings that are affected by branding
+        agentIconColorCheckmark.trigger()
+        agentNodeColorCheckmark.trigger()
+        plasmaColorCheckmark.trigger()
+        rangePaletteCheckmark.trigger()
+        brandingCheckmark.trigger()
+        logoCheckmark.trigger()
     }
 
     const persistKey = (vendor: LLMProvider, key: string) => {
@@ -312,8 +313,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
 
     const getApiKeysSection = () => (
         <Section>
-            <SettingsSectionTitle>API Keys</SettingsSectionTitle>
-            <SubSection>
+            <SettingsSubsection title="API Keys">
                 <SubsectionTitle variant="subtitle1">Providers</SubsectionTitle>
                 <SubSectionBody>
                     <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5}}>
@@ -332,423 +332,403 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                         ))}
                     </Box>
                 </SubSectionBody>
-            </SubSection>
+            </SettingsSubsection>
         </Section>
     )
 
     const getBehaviorSection = () => (
         <Section>
             <SettingsSectionTitle>Behavior</SettingsSectionTitle>
-            <SubSection>
-                <SubsectionTitle variant="subtitle1">Zen mode</SubsectionTitle>
-                <SubSectionBody>
-                    <Box sx={{display: "flex", alignItems: "center", gap: 0.5}}>
-                        <FormLabel>Enable &quot;Zen&quot; mode:</FormLabel>
-                        <Tooltip
-                            title={
-                                "Hides most of the UI during agent network animations, " +
-                                "providing a more immersive experience."
-                            }
-                        >
-                            <Checkbox
-                                checked={enableZenMode}
-                                data-testid="zen-mode-checkbox"
-                                onChange={(_, checked) => {
-                                    updateSettings({behavior: {enableZenMode: checked}})
-                                    enableZenModeCheckmark.trigger()
-                                }}
-                                sx={{p: 0.0}}
-                            />
-                        </Tooltip>
-                        <FadingCheckmark show={enableZenModeCheckmark.show} />
-                    </Box>
-                </SubSectionBody>
-            </SubSection>
+            <SettingsSubsection title="Behavior">
+                <SettingsRow
+                    label='Enable "Zen" mode:'
+                    checkmark={enableZenModeCheckmark}
+                    tooltip={
+                        "Hides most of the UI during agent network animations providing a more immersive " +
+                        "experience."
+                    }
+                >
+                    <Checkbox
+                        checked={enableZenMode}
+                        data-testid="zen-mode-checkbox"
+                        onChange={(_, checked) => {
+                            updateSettings({behavior: {enableZenMode: checked}})
+                            enableZenModeCheckmark.trigger()
+                        }}
+                        sx={{p: 0.0}}
+                    />
+                </SettingsRow>
+            </SettingsSubsection>
         </Section>
     )
 
     const getNamingSubsection = () => (
-        <SubSection>
-            <SubsectionTitle variant="subtitle1">Agent names</SubsectionTitle>
-            <SubSectionBody>
-                <Box sx={{display: "flex", alignItems: "center", gap: 0.5}}>
-                    <FormLabel>Display as:</FormLabel>
-                    <ToggleButtonGroup
-                        aria-label="agent-name-format-selection"
-                        exclusive={true}
-                        onChange={(_, value) => {
-                            if (value !== null) {
-                                updateSettings({
-                                    appearance: {
-                                        useNativeNames: value === "native",
-                                    },
-                                })
-                                nativeNamesCheckmark.trigger()
-                            }
-                        }}
-                        size="small"
-                        sx={{mx: 2}}
-                        value={useNativeNames ? "native" : "beautified"}
-                    >
-                        <ToggleButton value="native">Native</ToggleButton>
-                        <ToggleButton value="beautified">Beautified</ToggleButton>
-                    </ToggleButtonGroup>
-                    <FormLabel>Preview: </FormLabel>
-                    <FormLabel
-                        sx={{
-                            marginBottom: 0,
-                            border: "1px solid",
-                            borderRadius: 1,
-                            backgroundColor: "background.paper",
-                            ml: 0.5,
-                            px: 1,
-                            py: 0.25,
-                            lineHeight: 0,
-                            fontSize: "0.7rem",
-                            maxWidth: "100%",
-                        }}
-                    >
-                        <pre>
-                            {`category/some_agent_name → ${
-                                useNativeNames ? "category/some_agent_name [unchanged]" : "Category Some Agent Name"
-                            }`}
-                        </pre>
-                    </FormLabel>
-                    <FadingCheckmark show={nativeNamesCheckmark.show} />
-                </Box>
-            </SubSectionBody>
-        </SubSection>
+        <SettingsSubsection title="Agent names">
+            <SettingsRow
+                label="Display as:"
+                checkmark={nativeNamesCheckmark}
+                tooltip={
+                    "Choose how agent names are displayed in the network. " +
+                    '"Native" shows the original agent name as provided by the system, while "Beautified" applies ' +
+                    "formatting to make names more human-readable. This setting does not affect the actual names of " +
+                    "agents, only how they are displayed in the UI."
+                }
+            >
+                <ToggleButtonGroup
+                    aria-label="agent-name-format-selection"
+                    exclusive={true}
+                    onChange={(_, value) => {
+                        if (value !== null) {
+                            updateSettings({
+                                appearance: {
+                                    useNativeNames: value === "native",
+                                },
+                            })
+                            nativeNamesCheckmark.trigger()
+                        }
+                    }}
+                    size="small"
+                    sx={{mx: 2}}
+                    value={useNativeNames ? "native" : "beautified"}
+                >
+                    <ToggleButton value="native">Native</ToggleButton>
+                    <ToggleButton value="beautified">Beautified</ToggleButton>
+                </ToggleButtonGroup>
+                <FormLabel>Preview: </FormLabel>
+                <FormLabel
+                    sx={{
+                        marginBottom: 0,
+                        border: "1px solid",
+                        borderRadius: 1,
+                        backgroundColor: "background.paper",
+                        ml: 0.5,
+                        px: 1,
+                        py: 0.25,
+                        lineHeight: 0,
+                        fontSize: "0.7rem",
+                        maxWidth: "100%",
+                    }}
+                >
+                    <pre>
+                        {`category/some_agent_name → ${
+                            useNativeNames ? "category/some_agent_name [unchanged]" : "Category Some Agent Name"
+                        }`}
+                    </pre>
+                </FormLabel>
+            </SettingsRow>
+        </SettingsSubsection>
     )
 
     const getBrandingSubsection = () => (
-        <SubSection>
-            <SubsectionTitle variant="subtitle1">Branding</SubsectionTitle>
-            <SubSectionBody>
-                <Box
-                    sx={{
-                        alignItems: "center",
-                        display: "flex",
-                        flexDirection: "row",
-                        gap: 2,
-                    }}
-                >
-                    <FormLabel>Customer:</FormLabel>
-                    <TextField
-                        aria-label="branding-input"
-                        onChange={(e) => setCustomerInput(e.target.value)}
-                        onKeyDown={(e) => {
-                            if (e.key === "Enter" && customerInput?.trim().length > 0) {
-                                void handleBrandingApply()
-                            }
-                        }}
-                        value={customerInput ?? ""}
-                        placeholder="Company or organization name"
-                        size="small"
-                        sx={{width: "100%"}}
-                        variant="outlined"
-                    />
-                    <Button
-                        disabled={
-                            customerInput?.trim().length === 0 || isBrandingApplying || customerInput === customer
+        <SettingsSubsection title="Branding">
+            <SettingsRow
+                checkmark={brandingCheckmark}
+                label="Customer:"
+                tooltip={
+                    "Set a customer or organization name to automatically apply a custom color palette and " +
+                    "logo to the network"
+                }
+            >
+                <TextField
+                    aria-label="branding-input"
+                    onChange={(e) => setCustomerInput(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter" && customerInput?.trim().length > 0) {
+                            void handleBrandingApply()
                         }
-                        variant="contained"
-                        size="small"
-                        onClick={handleBrandingApply}
-                        loading={isBrandingApplying}
-                    >
-                        Apply
-                    </Button>
-                    <Button
-                        disabled={!customer || isBrandingApplying}
-                        variant="contained"
-                        size="small"
-                        onClick={handleBrandingClear}
-                        loading={isBrandingApplying}
-                    >
-                        Clear
-                    </Button>
-                    <FadingCheckmark show={brandingCheckmark.show} />
-                </Box>
-
-                <Box
-                    aria-label="logo-options-container"
-                    sx={{display: "flex", alignItems: "center"}}
+                    }}
+                    value={customerInput ?? ""}
+                    placeholder="Company or organization name"
+                    size="small"
+                    sx={{width: "100%"}}
+                    variant="outlined"
+                />
+                <Button
+                    disabled={customerInput?.trim().length === 0 || isBrandingApplying || customerInput === customer}
+                    variant="contained"
+                    size="small"
+                    onClick={handleBrandingApply}
+                    loading={isBrandingApplying}
                 >
-                    <Box
-                        sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 2,
-                            marginBottom: "1rem",
-                            width: "100%",
-                        }}
-                    >
-                        <FormLabel>Logo:</FormLabel>
-                        <Tooltip title={customer ? null : "Set a customer name to enable logo options"}>
-                            <span>
-                                <ToggleButtonGroup
-                                    aria-label="logo-selection"
-                                    disabled={!customer}
-                                    exclusive={true}
-                                    onChange={(_, value) => {
-                                        if (value !== null) {
-                                            updateSettings({
-                                                branding: {
-                                                    logoSource: value,
-                                                },
-                                            })
-                                            logoCheckmark.trigger()
-                                        }
-                                    }}
-                                    size="small"
-                                    sx={{marginRight: "1rem"}}
-                                    value={logoSource || "none"}
-                                >
-                                    <Tooltip title={customer && "No logo will be displayed"}>
-                                        <span style={{cursor: customer ? "pointer" : "not-allowed"}}>
-                                            <ToggleButton value="none">None</ToggleButton>
-                                        </span>
-                                    </Tooltip>
-                                    <Tooltip
-                                        title={
-                                            customer &&
-                                            "Display a simple, anonymous generic logo based on a generic brand"
-                                        }
-                                    >
-                                        <span style={{cursor: customer ? "pointer" : "not-allowed"}}>
-                                            <ToggleButton value="generic">Generic</ToggleButton>
-                                        </span>
-                                    </Tooltip>
-                                    <Tooltip
-                                        title={
-                                            customer &&
-                                            (logoServiceToken
-                                                ? "Use a service to attempt to automatically find a suitable " +
-                                                  "logo based on the customer name."
-                                                : "No Logo.dev token found, cannot use Auto logo source")
-                                        }
-                                    >
-                                        <span
-                                            style={{
-                                                cursor: customer && logoServiceToken ? "pointer" : "not-allowed",
-                                            }}
-                                        >
-                                            <ToggleButton
-                                                disabled={!logoServiceToken}
-                                                value="auto"
-                                            >
-                                                Auto
-                                            </ToggleButton>
-                                        </span>
-                                    </Tooltip>
-                                </ToggleButtonGroup>
-                            </span>
-                        </Tooltip>
-                        <FormLabel>Preview:</FormLabel>
-                        <Box>
-                            {logoSource === "auto" || logoSource === "generic" ? (
-                                <CustomerLogo
-                                    logoServiceToken={logoServiceToken}
-                                    customer={customer}
-                                    logoSource={logoSource}
-                                    iconSuggestion={iconSuggestion}
-                                />
-                            ) : (
-                                "(None)"
-                            )}
-                        </Box>
-                        <FadingCheckmark show={logoCheckmark.show} />
-                    </Box>
-                </Box>
-            </SubSectionBody>
-        </SubSection>
-    )
-
-    const getNetworkDisplaySubsection = () => (
-        <SubSection>
-            <SubsectionTitle variant="subtitle1">Network display</SubsectionTitle>
-            <SubSectionBody>
-                <FormLabel sx={{marginBottom: 2}}>Palette (heatmap and depth):</FormLabel>
-                <Box sx={{display: "flex", alignItems: "center", gap: 2}}>
-                    <Tooltip title={customer ? "Palette is locked when branding is applied" : ""}>
-                        <span>
-                            <ToggleButtonGroup
-                                aria-label="depth-heatmap-palette-selection"
-                                disabled={Boolean(customer)}
-                                exclusive={true}
-                                onChange={handlePaletteChange}
-                                size="small"
-                                sx={{
-                                    cursor: customer ? "not-allowed" : "pointer",
-                                    opacity: customer ? 0.5 : 1,
-                                }}
-                                value={paletteKey}
-                            >
-                                {paletteKeys.map((key) => {
-                                    const palette = availablePalettes[key as keyof typeof availablePalettes]
-                                    if (!palette || !Array.isArray(palette)) return null
-
-                                    const paletteArray: string[] = palette
-
-                                    return (
-                                        <ToggleButton
-                                            aria-label={`${key}-palette-button`}
-                                            key={key}
-                                            value={key}
-                                        >
-                                            <Box
-                                                sx={{
-                                                    display: "flex",
-                                                    flexDirection: "column",
-                                                    gap: 0.5,
-                                                    alignItems: "center",
-                                                }}
-                                            >
-                                                <Typography
-                                                    variant="caption"
-                                                    sx={{textTransform: "capitalize"}}
-                                                >
-                                                    {key}
-                                                </Typography>
-                                                <Box sx={{display: "flex", gap: 0.5}}>
-                                                    {Array.from({length: 5}, (_, i) => {
-                                                        const paletteLength = paletteArray.length
-                                                        const index = Math.floor((i * paletteLength) / 5)
-                                                        return paletteArray[index]
-                                                    }).map((color) => (
-                                                        <Box
-                                                            key={color}
-                                                            sx={{
-                                                                width: "0.75rem",
-                                                                height: "0.75rem",
-                                                                backgroundColor: color,
-                                                                border: "1px solid",
-                                                            }}
-                                                        />
-                                                    ))}
-                                                </Box>
-                                            </Box>
-                                        </ToggleButton>
-                                    )
-                                })}
-                            </ToggleButtonGroup>
+                    Apply
+                </Button>
+                <Button
+                    disabled={!customer || isBrandingApplying}
+                    variant="contained"
+                    size="small"
+                    onClick={handleBrandingClear}
+                    loading={isBrandingApplying}
+                >
+                    Clear
+                </Button>
+            </SettingsRow>
+            <SettingsRow
+                checkmark={logoCheckmark}
+                label="Logo:"
+                tooltip={
+                    "Choose a logo to display in the top-left corner of the network. " +
+                    '"None" will display no logo, "Generic" will display a simple generic logo, and "Auto" will ' +
+                    "attempt to find a suitable logo based on the customer name using an external service (requires " +
+                    "a Logo.dev token). Logo is only displayed when customer branding is applied."
+                }
+            >
+                <ToggleButtonGroup
+                    aria-label="logo-selection"
+                    disabled={!customer}
+                    exclusive={true}
+                    onChange={(_, value) => {
+                        if (value !== null) {
+                            updateSettings({
+                                branding: {
+                                    logoSource: value,
+                                },
+                            })
+                            logoCheckmark.trigger()
+                        }
+                    }}
+                    size="small"
+                    sx={{marginRight: "1rem"}}
+                    value={logoSource || "none"}
+                >
+                    <Tooltip title={customer && "No logo will be displayed"}>
+                        {/*"span" required for tooltip when child is disabled. See:*/}
+                        {/*https://github.com/mui/material-ui/issues/8416*/}
+                        <span style={{cursor: customer ? "pointer" : "not-allowed"}}>
+                            <ToggleButton value="none">None</ToggleButton>
                         </span>
                     </Tooltip>
-                    <FadingCheckmark show={rangePaletteCheckmark.show} />
-                </Box>
-            </SubSectionBody>
-        </SubSection>
-    )
-
-    const getNetworkAnimationSubsection = () => (
-        <SubSection>
-            <SubsectionTitle variant="subtitle1">Network animation</SubsectionTitle>
-            <SubSectionBody>
-                <Box sx={{display: "flex", alignItems: "center", gap: 2}}>
-                    <FormLabel>Plasma animation color:</FormLabel>
-                    <Tooltip title={customer ? "Plasma color is locked when branding is applied" : ""}>
-                        <input
-                            aria-label="plasma-color-picker"
-                            disabled={Boolean(customer)}
-                            onChange={(e) => {
-                                updateSettings({
-                                    appearance: {
-                                        plasmaColor: e.target.value,
-                                    },
-                                })
-                                plasmaColorCheckmark.trigger()
-                            }}
-                            style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
-                            type="color"
-                            value={plasmaColor}
-                        />
-                    </Tooltip>
-                    <FadingCheckmark show={plasmaColorCheckmark.show} />
-                </Box>
-                <Box sx={{display: "flex", alignItems: "center", gap: 2, marginTop: "1rem"}}>
-                    <FormLabel>Agent node color:</FormLabel>
-                    <Tooltip title={customer ? "Agent node color is locked when branding is applied" : ""}>
-                        <input
-                            aria-label="agent-node-color-picker"
-                            disabled={Boolean(customer)}
-                            onChange={(e) => {
-                                updateSettings({
-                                    appearance: {
-                                        agentNodeColor: e.target.value,
-                                    },
-                                })
-                                agentNodeColorCheckmark.trigger()
-                            }}
-                            style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
-                            type="color"
-                            value={agentNodeColor}
-                        />
-                    </Tooltip>
-                    <FadingCheckmark show={agentNodeColorCheckmark.show} />
-                </Box>
-                <Box sx={{display: "flex", alignItems: "center", gap: 2, marginTop: "1rem"}}>
-                    <FormLabel>Agent icon color:</FormLabel>
-                    <Tooltip title={customer ? "Agent icon color is locked when branding is applied" : ""}>
-                        <span>
-                            <ToggleButtonGroup
-                                disabled={Boolean(customer)}
-                                exclusive
-                                value={autoAgentIconColor ? "auto" : "custom"}
-                                onChange={(_, value) => {
-                                    if (value !== null) {
-                                        updateSettings({
-                                            appearance: {
-                                                autoAgentIconColor: value === "auto",
-                                            },
-                                        })
-                                        agentIconColorCheckmark.trigger()
-                                    }
-                                }}
-                                size="small"
-                                style={{
-                                    cursor: customer ? "not-allowed" : "pointer",
-                                    opacity: customer ? 0.5 : 1,
-                                }}
-                            >
-                                <ToggleButton
-                                    data-testid="auto-agent-icon-color-button"
-                                    value="auto"
-                                >
-                                    Auto
-                                </ToggleButton>
-                                <ToggleButton value="custom">Custom</ToggleButton>
-                            </ToggleButtonGroup>
+                    <Tooltip title={customer && "Display a simple, anonymous generic logo based on a generic brand"}>
+                        {/*"span" required for tooltip when child is disabled. See:*/}
+                        {/*https://github.com/mui/material-ui/issues/8416*/}
+                        <span style={{cursor: customer ? "pointer" : "not-allowed"}}>
+                            <ToggleButton value="generic">Generic</ToggleButton>
                         </span>
                     </Tooltip>
                     <Tooltip
                         title={
-                            customer
-                                ? "Agent icon color is locked when branding is applied"
-                                : autoAgentIconColor
-                                  ? "Disabled when Auto is selected"
-                                  : ""
+                            customer &&
+                            (logoServiceToken
+                                ? "Use a service to attempt to automatically find a suitable " +
+                                  "logo based on the customer name."
+                                : "No Logo.dev token found, cannot use Auto logo source")
                         }
                     >
-                        <input
-                            aria-label="agent-icon-color-picker"
-                            disabled={Boolean(customer) || autoAgentIconColor}
-                            onChange={(e) => {
-                                updateSettings({
-                                    appearance: {
-                                        agentIconColor: e.target.value,
-                                    },
-                                })
-                                agentIconColorCheckmark.trigger()
+                        {/*"span" required for tooltip when child is disabled. See:*/}
+                        {/*https://github.com/mui/material-ui/issues/8416*/}
+                        <span
+                            style={{
+                                cursor: customer && logoServiceToken ? "pointer" : "not-allowed",
                             }}
-                            style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
-                            type="color"
-                            value={agentIconColor}
-                        />
+                        >
+                            <ToggleButton
+                                disabled={!logoServiceToken}
+                                value="auto"
+                            >
+                                Auto
+                            </ToggleButton>
+                        </span>
                     </Tooltip>
-                    <FadingCheckmark show={agentIconColorCheckmark.show} />
+                </ToggleButtonGroup>
+                <FormLabel>Preview:</FormLabel>
+                <Box>
+                    {logoSource === "auto" || logoSource === "generic" ? (
+                        <CustomerLogo
+                            logoServiceToken={logoServiceToken}
+                            customer={customer}
+                            logoSource={logoSource}
+                            iconSuggestion={iconSuggestion}
+                        />
+                    ) : (
+                        "(None)"
+                    )}
                 </Box>
-            </SubSectionBody>
-        </SubSection>
+            </SettingsRow>
+        </SettingsSubsection>
+    )
+
+    const getNetworkDisplaySubsection = () => (
+        <SettingsSubsection title="Network display">
+            <FormLabel sx={{marginBottom: 2}}>Palette (heatmap and depth):</FormLabel>
+            <Box sx={{display: "flex", alignItems: "center", gap: 2}}>
+                <Tooltip title={customer ? "Palette is locked when branding is applied" : ""}>
+                    {/*"span" required for tooltip when child is disabled. See:*/}
+                    {/*https://github.com/mui/material-ui/issues/8416*/}
+                    <span>
+                        <ToggleButtonGroup
+                            aria-label="depth-heatmap-palette-selection"
+                            disabled={Boolean(customer)}
+                            exclusive={true}
+                            onChange={handlePaletteChange}
+                            size="small"
+                            sx={{
+                                cursor: customer ? "not-allowed" : "pointer",
+                                opacity: customer ? 0.5 : 1,
+                            }}
+                            value={paletteKey}
+                        >
+                            {paletteKeys.map((key) => {
+                                const palette = availablePalettes[key as keyof typeof availablePalettes]
+                                if (!palette || !Array.isArray(palette)) return null
+
+                                const paletteArray: string[] = palette
+
+                                return (
+                                    <ToggleButton
+                                        aria-label={`${key}-palette-button`}
+                                        key={key}
+                                        value={key}
+                                    >
+                                        <Box
+                                            sx={{
+                                                display: "flex",
+                                                flexDirection: "column",
+                                                gap: 0.5,
+                                                alignItems: "center",
+                                            }}
+                                        >
+                                            <Typography
+                                                variant="caption"
+                                                sx={{textTransform: "capitalize"}}
+                                            >
+                                                {key}
+                                            </Typography>
+                                            <Box sx={{display: "flex", gap: 0.5}}>
+                                                {Array.from({length: 5}, (_, i) => {
+                                                    const paletteLength = paletteArray.length
+                                                    const index = Math.floor((i * paletteLength) / 5)
+                                                    return paletteArray[index]
+                                                }).map((color) => (
+                                                    <Box
+                                                        key={color}
+                                                        sx={{
+                                                            width: "0.75rem",
+                                                            height: "0.75rem",
+                                                            backgroundColor: color,
+                                                            border: "1px solid",
+                                                        }}
+                                                    />
+                                                ))}
+                                            </Box>
+                                        </Box>
+                                    </ToggleButton>
+                                )
+                            })}
+                        </ToggleButtonGroup>
+                    </span>
+                </Tooltip>
+                <FadingCheckmark show={rangePaletteCheckmark.show} />
+            </Box>
+        </SettingsSubsection>
+    )
+
+    const getNetworkAnimationSubsection = () => (
+        <SettingsSubsection title="Network animation">
+            <Box sx={{display: "flex", alignItems: "center", gap: 2}}>
+                <FormLabel>Plasma animation color:</FormLabel>
+                <Tooltip title={customer ? "Plasma color is locked when branding is applied" : ""}>
+                    <input
+                        aria-label="plasma-color-picker"
+                        disabled={Boolean(customer)}
+                        onChange={(e) => {
+                            updateSettings({
+                                appearance: {
+                                    plasmaColor: e.target.value,
+                                },
+                            })
+                            plasmaColorCheckmark.trigger()
+                        }}
+                        style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
+                        type="color"
+                        value={plasmaColor}
+                    />
+                </Tooltip>
+                <FadingCheckmark show={plasmaColorCheckmark.show} />
+            </Box>
+            <Box sx={{display: "flex", alignItems: "center", gap: 2, marginTop: "1rem"}}>
+                <FormLabel>Agent node color:</FormLabel>
+                <Tooltip title={customer ? "Agent node color is locked when branding is applied" : ""}>
+                    <input
+                        aria-label="agent-node-color-picker"
+                        disabled={Boolean(customer)}
+                        onChange={(e) => {
+                            updateSettings({
+                                appearance: {
+                                    agentNodeColor: e.target.value,
+                                },
+                            })
+                            agentNodeColorCheckmark.trigger()
+                        }}
+                        style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
+                        type="color"
+                        value={agentNodeColor}
+                    />
+                </Tooltip>
+                <FadingCheckmark show={agentNodeColorCheckmark.show} />
+            </Box>
+            <Box sx={{display: "flex", alignItems: "center", gap: 2, marginTop: "1rem"}}>
+                <FormLabel>Agent icon color:</FormLabel>
+                <Tooltip title={customer ? "Agent icon color is locked when branding is applied" : ""}>
+                    {/*"span" required for tooltip when child is disabled. See:*/}
+                    {/*https://github.com/mui/material-ui/issues/8416*/}
+                    <span>
+                        <ToggleButtonGroup
+                            disabled={Boolean(customer)}
+                            exclusive
+                            value={autoAgentIconColor ? "auto" : "custom"}
+                            onChange={(_, value) => {
+                                if (value !== null) {
+                                    updateSettings({
+                                        appearance: {
+                                            autoAgentIconColor: value === "auto",
+                                        },
+                                    })
+                                    agentIconColorCheckmark.trigger()
+                                }
+                            }}
+                            size="small"
+                            style={{
+                                cursor: customer ? "not-allowed" : "pointer",
+                                opacity: customer ? 0.5 : 1,
+                            }}
+                        >
+                            <ToggleButton
+                                data-testid="auto-agent-icon-color-button"
+                                value="auto"
+                            >
+                                Auto
+                            </ToggleButton>
+                            <ToggleButton value="custom">Custom</ToggleButton>
+                        </ToggleButtonGroup>
+                    </span>
+                </Tooltip>
+                <Tooltip
+                    title={
+                        customer
+                            ? "Agent icon color is locked when branding is applied"
+                            : autoAgentIconColor
+                              ? "Disabled when Auto is selected"
+                              : ""
+                    }
+                >
+                    <input
+                        aria-label="agent-icon-color-picker"
+                        disabled={Boolean(customer) || autoAgentIconColor}
+                        onChange={(e) => {
+                            updateSettings({
+                                appearance: {
+                                    agentIconColor: e.target.value,
+                                },
+                            })
+                            agentIconColorCheckmark.trigger()
+                        }}
+                        style={{cursor: customer ? "not-allowed" : "pointer", opacity: customer ? 0.5 : 1}}
+                        type="color"
+                        value={agentIconColor}
+                    />
+                </Tooltip>
+                <FadingCheckmark show={agentIconColorCheckmark.show} />
+            </Box>
+        </SettingsSubsection>
     )
 
     const getAppearanceSection = () => (
@@ -778,12 +758,6 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
         </SubSection>
     )
 
-    /* Dev note:
-    Before you go removing the "useless" spans in the code that wrap MUI elements: they are required because
-    MUI's disabled state on certain components sets pointer-events: none, which prevents tooltips from working.
-    Wrapping in a span allows the tooltip to still function while the inner component is disabled.
-    See: https://github.com/mui/material-ui/issues/8416
-    */
     return (
         // Always use default theme for settings dialog so user can always see to reset. It's possible that with
         // certain custom themes the dialog would be unreadable.

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -1,3 +1,4 @@
+import Business from "@mui/icons-material/Business"
 import RestoreIcon from "@mui/icons-material/SettingsBackupRestore"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
@@ -533,10 +534,11 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                 <Box>
                     {logoSource === "auto" || logoSource === "generic" ? (
                         <CustomerLogo
-                            logoServiceToken={logoServiceToken}
                             customer={customer}
-                            logoSource={logoSource}
+                            fallbackIcon={Business}
                             iconSuggestion={iconSuggestion}
+                            logoServiceToken={logoServiceToken}
+                            logoSource={logoSource}
                         />
                     ) : (
                         "(None)"

--- a/packages/ui-common/components/Settings/SettingsRow.tsx
+++ b/packages/ui-common/components/Settings/SettingsRow.tsx
@@ -1,0 +1,63 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
+import Box from "@mui/material/Box"
+import FormLabel from "@mui/material/FormLabel"
+import {SxProps, Theme} from "@mui/material/styles"
+import Tooltip from "@mui/material/Tooltip"
+import {FC, ReactNode} from "react"
+
+import {FadingCheckmark, useCheckmarkFade} from "./FadingCheckmark"
+
+interface SettingsRowProps {
+    readonly label: ReactNode
+    readonly children: ReactNode
+    readonly checkmark?: ReturnType<typeof useCheckmarkFade>
+    readonly tooltip: ReactNode
+    readonly disabled?: boolean
+    readonly sx?: SxProps<Theme>
+}
+
+export const SettingsRow: FC<SettingsRowProps> = ({label, children, checkmark, tooltip, disabled = false, sx}) => (
+    <Box
+        sx={[
+            {
+                display: "flex",
+                alignItems: "center",
+                gap: 1.25,
+                opacity: disabled ? 0.5 : 1,
+            },
+            ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+    >
+        <Box
+            sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+            }}
+        >
+            <FormLabel>{label}</FormLabel>
+        </Box>
+
+        <Box
+            sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+            }}
+        >
+            {children}
+            {checkmark ? <FadingCheckmark show={checkmark.show} /> : null}
+        </Box>
+        <Tooltip title={tooltip}>
+            <InfoOutlinedIcon
+                aria-label="setting information"
+                fontSize="small"
+                sx={{
+                    color: "text.secondary",
+                    cursor: "help",
+                    fontSize: "0.9rem",
+                }}
+            />
+        </Tooltip>
+    </Box>
+)

--- a/packages/ui-common/components/Settings/SettingsRow.tsx
+++ b/packages/ui-common/components/Settings/SettingsRow.tsx
@@ -1,63 +1,74 @@
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
 import Box from "@mui/material/Box"
 import FormLabel from "@mui/material/FormLabel"
-import {SxProps, Theme} from "@mui/material/styles"
-import Tooltip from "@mui/material/Tooltip"
+import {SxProps, Theme, useTheme} from "@mui/material/styles"
 import {FC, ReactNode} from "react"
 
 import {FadingCheckmark, useCheckmarkFade} from "./FadingCheckmark"
+import InfoTip from "./InfoTip"
 
 interface SettingsRowProps {
-    readonly label: ReactNode
-    readonly children: ReactNode
     readonly checkmark?: ReturnType<typeof useCheckmarkFade>
-    readonly tooltip: ReactNode
+    readonly children: ReactNode
     readonly disabled?: boolean
+    readonly label: ReactNode
+    readonly labelWidth?: string | number
     readonly sx?: SxProps<Theme>
+    readonly tooltip: ReactNode
 }
 
-export const SettingsRow: FC<SettingsRowProps> = ({label, children, checkmark, tooltip, disabled = false, sx}) => (
-    <Box
-        sx={[
-            {
-                display: "flex",
-                alignItems: "center",
-                gap: 1.25,
-                opacity: disabled ? 0.5 : 1,
-            },
-            ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
-    >
-        <Box
-            sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.5,
-            }}
-        >
-            <FormLabel>{label}</FormLabel>
-        </Box>
+export const SettingsRow: FC<SettingsRowProps> = ({
+    checkmark,
+    children,
+    disabled = false,
+    label,
+    labelWidth = "8rem",
+    sx,
+    tooltip,
+}) => {
+    const theme = useTheme()
 
+    return (
         <Box
-            sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.5,
-            }}
+            sx={[
+                {
+                    alignItems: "center",
+                    display: "flex",
+                    flexDirection: "row",
+                    gap: theme.spacing(2),
+                    opacity: disabled ? 0.5 : 1,
+                    width: "100%",
+                },
+                ...(sx ? (Array.isArray(sx) ? sx : [sx]) : []),
+            ]}
         >
-            {children}
-            {checkmark ? <FadingCheckmark show={checkmark.show} /> : null}
-        </Box>
-        <Tooltip title={tooltip}>
-            <InfoOutlinedIcon
-                aria-label="setting information"
-                fontSize="small"
+            {label ? (
+                <Box
+                    sx={{
+                        alignItems: "center",
+                        display: "flex",
+                        flexBasis: labelWidth,
+                        flexShrink: 0,
+                    }}
+                >
+                    <FormLabel>{label}</FormLabel>
+                </Box>
+            ) : null}
+
+            <Box
                 sx={{
-                    color: "text.secondary",
-                    cursor: "help",
-                    fontSize: "0.9rem",
+                    alignItems: "center",
+                    display: "flex",
+                    flex: 1,
+                    gap: theme.spacing(2),
+                    minWidth: 0,
                 }}
-            />
-        </Tooltip>
-    </Box>
-)
+            >
+                {children}
+                {checkmark ? <FadingCheckmark show={checkmark.show} /> : null}
+            </Box>
+            <Box sx={{flexShrink: 0}}>
+                <InfoTip title={tooltip} />
+            </Box>
+        </Box>
+    )
+}

--- a/packages/ui-common/components/Settings/SettingsRow.tsx
+++ b/packages/ui-common/components/Settings/SettingsRow.tsx
@@ -16,6 +16,9 @@ interface SettingsRowProps {
     readonly tooltip: ReactNode
 }
 
+/**
+ * Lightweight component to encapsulate a row in the Settings page.
+ */
 export const SettingsRow: FC<SettingsRowProps> = ({
     checkmark,
     children,
@@ -38,6 +41,7 @@ export const SettingsRow: FC<SettingsRowProps> = ({
                     opacity: disabled ? 0.5 : 1,
                     width: "100%",
                 },
+                // Can't spread sx directly because it can be an array or object
                 ...(sx ? (Array.isArray(sx) ? sx : [sx]) : []),
             ]}
         >


### PR DESCRIPTION
# Overview
Complete overhaul of Settings dialog, both visually and in the code. The copy-pasta code is now _gone_, something I've wanted to do since day 1 of writing this code, and we now use reusable components and styles for the various Settings sections, making it _much_ easier and less verbose to add new configuration settings.

The dialog itself is also overhauled visually, and is now more pleasing and symmetrical.

# Details
1) Items now line up properly (horizontal alignment). Items take up the whole row, with...
2) ...ⓘ info tips everywhere, right justified, while still retaining "here's why this button is disabled" tips on individual controls
3) Code is refactored into components, using new modular `SettingsRow` for each section.
4) Copy-pasted styles and sections are _gone_.


# Screenshots
Before  | After
:-------------------------:|:-------------------------:
<img width="1185" height="1199" alt="image" src="https://github.com/user-attachments/assets/bb257143-4ced-4447-96f3-29a3fb305942" />|<img width="1280" height="1135" alt="image" src="https://github.com/user-attachments/assets/e7827e5a-c954-4f5a-b3da-a6cdb1165e16" />
