### PR TITLE
Fix build failure caused by duelling @mui/system versions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,7 +8,7 @@ catalogs:
         "@langchain/core": "1.1.17"
         "@mui/icons-material": "9.0.1"
         "@mui/material": "9.0.1"
-        "@mui/system": "9.0.1"
+        "@mui/system": "9.1.2"
         "@mui/x-tree-view": "9.1.0"
         "@testing-library/dom": "10.4.1"
         "@testing-library/react": "16.3.0"

--- a/packages/ui-common/package.json
+++ b/packages/ui-common/package.json
@@ -12,10 +12,6 @@
     "dependencies": {
         "@dagrejs/dagre": "1.0.4",
         "@langchain/core": "catalog:default",
-        "@mui/icons-material": "catalog:default",
-        "@mui/material": "catalog:default",
-        "@mui/system": "catalog:default",
-        "@mui/x-tree-view": "catalog:default",
         "@xyflow/react": "catalog:default",
         "http-status": "catalog:default",
         "lodash-es": "catalog:default",
@@ -30,6 +26,10 @@
         "zustand": "4.5.7"
     },
     "devDependencies": {
+        "@mui/icons-material": "catalog:default",
+        "@mui/material": "catalog:default",
+        "@mui/system": "catalog:default",
+        "@mui/x-tree-view": "catalog:default",
         "@testing-library/dom": "catalog:default",
         "@testing-library/react": "catalog:default",
         "@testing-library/user-event": "catalog:default",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,7 +1495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^9.0.1, @mui/private-theming@npm:^9.1.1":
+"@mui/private-theming@npm:^9.1.1":
   version: 9.1.1
   resolution: "@mui/private-theming@npm:9.1.1"
   dependencies:
@@ -1512,7 +1512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/styled-engine@npm:^9.0.0, @mui/styled-engine@npm:^9.1.1":
+"@mui/styled-engine@npm:^9.1.1":
   version: 9.1.1
   resolution: "@mui/styled-engine@npm:9.1.1"
   dependencies:
@@ -1535,35 +1535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:9.0.1":
-  version: 9.0.1
-  resolution: "@mui/system@npm:9.0.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.29.2"
-    "@mui/private-theming": "npm:^9.0.1"
-    "@mui/styled-engine": "npm:^9.0.0"
-    "@mui/types": "npm:^9.0.0"
-    "@mui/utils": "npm:^9.0.1"
-    clsx: "npm:^2.1.1"
-    csstype: "npm:^3.2.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10c0/f6adf7494f85aeea306f43a67a420abc4302ce2a19994b78a4d7cc51db61c134e6a513231bee61faa5a573eb1501dc70accc6dba4ca4cb1557d96a5ebfffc482
-  languageName: node
-  linkType: hard
-
-"@mui/system@npm:^9.0.1":
+"@mui/system@npm:9.1.2, @mui/system@npm:^9.0.1":
   version: 9.1.2
   resolution: "@mui/system@npm:9.1.2"
   dependencies:


### PR DESCRIPTION
For posterity, the issue was that we were installing two different copies of `@mui/system` due to dependency resolution issues. We were getting away with it before because the versions were all resolving down to the same one, `9.0.1` in `yarn.lock`, but we were living on borrowed time because the actual internal dependency of `@mui/material` was always pointing to `@mui/system` version `9.1.2`, despite what we specified in our catalog:

```
direct workspace/package dependency: @mui/system@9.0.1
transitive from @mui/material@9.0.1: @mui/system@9.1.2
```

We were getting away with it by the skin of our teeth because of `yarn.lock`, but as soon as I regen'd that file as part of the Vitest updates, all hell broke loose.

Our yarn catalog was calling for `9.0.1` but in fact at build time we were resolving to `9.1.2` transitively via `@mui/material`. I wish we could just not have `@mui/system` as a dependency at all and just let the other MUI libraries pull it in transitively, but if we don't specify it, yarn complains that `@mui/x-tree-view` requires it, so we're stuck.

The solution was to modify the version in the catalog so it reflects the same version that we are actually resolving to at build time. This is not an upgrade, but a realignment of the catalog to reflect what has been happening in reality.

My explanation above wasn't that great; I asked Copilot to do better:

> @mui/material@9.0.1 depends on @mui/system@^9.0.1, and after the lockfile changed, Yarn re-resolved that range from 9.0.1 to 9.1.2, while ui-common was still directly providing @mui/system@9.0.1; that created two MUI System type identities, which only surfaced during declaration emit in build:lib.
Updating the catalog so the direct @mui/system provision also resolves to 9.1.2 removed the duplicate version/type split: the repo now uses a single @mui/system version, matching what MUI Material was already choosing transitively.

We can consider adding the build step to our `test` goals for CI; it would catch weird edge cases like this, for the cost of a little extra time on every build. But only 11 seconds currently:

```
❯ time yarn build:lib 
✨ openapi-typescript 7.8.0
🚀 https://neuro-san-dev.decisionai.ml/api/v1/docs → ./generated/neuro-san/NeuroSanClient.ts [463.5ms]
yarn build:lib  11.08s user 1.48s system 157% cpu 7.963 total
```

On the other hand, it is super rare that something passes all our CI checks then fails at `yarn build:lib` time. Not impossible, as we see here, but hugely unlikely. Similar to Docker build failures: very rare that something sneaks past our CI and causes issues at Docker build time, but not unheard-of. However, Docker builds take a long time -- O(several minutes) -- so I wouldn't want to add that tax to every build.

Also move MUI deps from deps to devDeps as recommended by Copilot.