### PR TITLE
#472 Fix error message during tests

### DIFF
--- a/packages/ui-common/__tests__/components/Common/Navbar.test.tsx
+++ b/packages/ui-common/__tests__/components/Common/Navbar.test.tsx
@@ -99,7 +99,7 @@ describe("Navbar", () => {
     })
 
     it("should redirect to email client when confirmation is clicked", async () => {
-        vi.spyOn(BrowserNavigation, "navigateToUrl")
+        vi.spyOn(BrowserNavigation, "navigateToUrl").mockImplementation(vi.fn())
 
         renderNavbar()
 

--- a/packages/ui-common/utils/BrowserNavigation.ts
+++ b/packages/ui-common/utils/BrowserNavigation.ts
@@ -18,6 +18,8 @@ limitations under the License.
  * Navigate to the specified URL by setting window.location.href
  * @param url The URL to navigate to
  */
+// See: https://github.com/jsdom/jsdom/issues/2112
+/* istanbul ignore next -- JSDom doesn't support simulated navigation */
 export const navigateToUrl = (url: string): void => {
     window.location.href = url
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,8 +32,8 @@ export default defineConfig({
         environment: "jsdom",
         exclude: ["**/node_modules/**", "**/dist/**", "**/.next/**", "**/coverage/**"],
         globals: true,
-        // Let maxWorkers default to the number of CPU cores in CI, but set 8 for local development (best by test)
         include: ["apps/**/__tests__/**/*.test.{ts,tsx}", "packages/**/__tests__/**/*.test.{ts,tsx}"],
+        // Let maxWorkers default to the number of CPU cores in CI, but set 8 for local development (best by test)
         maxWorkers: process.env["CI"] === "true" ? undefined : (process.env["VITEST_MAX_WORKERS"] ?? 8),
         // Have to manually specify GitHub Actions reporter when configuring reporters manually.
         // See: https://vitest.dev/guide/reporters.html#github-actions-reporter


### PR DESCRIPTION
Fixes this error that was showing up during unit test runs:

`Not implemented: navigation to another Document`

Emitted by JSDom, which doesn't support browser navigation (and refuses to pretend it does).

Reference: https://github.com/jsdom/jsdom/issues/2112