### PR TITLE
#406,#457,#458 Use session storage for API Keys for safety

### DIFF
--- a/__tests__/common/strictMocks.ts
+++ b/__tests__/common/strictMocks.ts
@@ -40,6 +40,7 @@ export const withStrictMocks = (options: StrictMockOptions = {}) => {
         }
 
         localStorage.clear()
+        sessionStorage.clear()
 
         // Reset IndexedDB mock store
         globalThis.indexedDB = new IDBFactory()

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -1457,7 +1457,14 @@ describe("MultiAgentAccelerator", () => {
             BYOK.parse((await getAgentFunction(null, null, null)).function?.sly_data_schema)
 
             // Add an existing API key to the store. This represents the key that the user has supplied
-            useSettingsStore.getState().updateSettings({apiKeys: {Anthropic: "anthropic-key"}})
+            useSettingsStore.getState().updateSettings({
+                apiKeys: {
+                    Anthropic: {
+                        expiresAt: Number.MAX_SAFE_INTEGER,
+                        value: "anthropic-key",
+                    },
+                },
+            })
 
             renderMultiAgentAcceleratorPage()
 

--- a/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
@@ -15,6 +15,9 @@ vi.mock("../../../components/Common/notification")
 
 const TEST_API_KEY = "test-api-key-123"
 
+// Pseudo expiration time
+const NEVER = Number.MAX_SAFE_INTEGER
+
 const BRANDING_SUGGESTIONS_RESPONSE: BrandingSuggestions = {
     background: "#AA0022",
     iconSuggestion: "Add",
@@ -349,7 +352,7 @@ describe("SettingsDialog", () => {
             useSettingsStore.getState().updateSettings({
                 apiKeys: {
                     OpenAI: {
-                        expiresAt: Number.MAX_SAFE_INTEGER, // "never expires""
+                        expiresAt: NEVER,
                         value: TEST_API_KEY,
                     },
                 },
@@ -388,7 +391,7 @@ describe("SettingsDialog", () => {
             useSettingsStore.getState().updateSettings({
                 apiKeys: {
                     OpenAI: {
-                        expiresAt: Number.MAX_SAFE_INTEGER, // "never expires""
+                        expiresAt: NEVER,
                         value: TEST_API_KEY,
                     },
                 },

--- a/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/Settings/SettingsDialog.test.tsx
@@ -8,7 +8,7 @@ import {NotificationType, sendNotification} from "../../../components/Common/not
 import {SettingsDialog} from "../../../components/Settings/SettingsDialog"
 import {BrandingSuggestions} from "../../../controller/Types/Branding"
 import {useEnvironmentStore} from "../../../state/Environment"
-import {DEFAULT_SETTINGS, LogoSource, useSettingsStore} from "../../../state/Settings"
+import {DEFAULT_SETTINGS, getApiKey, LogoSource, useSettingsStore} from "../../../state/Settings"
 
 // Mock notification system
 vi.mock("../../../components/Common/notification")
@@ -300,7 +300,7 @@ describe("SettingsDialog", () => {
 
             await user.click(saveButton)
 
-            expect(useSettingsStore.getState().settings.apiKeys.OpenAI).toBe(testApiKey)
+            expect(getApiKey(useSettingsStore.getState().settings.apiKeys, "OpenAI")).toBe(testApiKey)
         })
 
         it("allows user to test API keys", async () => {
@@ -348,7 +348,10 @@ describe("SettingsDialog", () => {
             // set an existing key value
             useSettingsStore.getState().updateSettings({
                 apiKeys: {
-                    OpenAI: TEST_API_KEY,
+                    OpenAI: {
+                        expiresAt: Number.MAX_SAFE_INTEGER, // "never expires""
+                        value: TEST_API_KEY,
+                    },
                 },
             })
 
@@ -369,7 +372,7 @@ describe("SettingsDialog", () => {
             await user.click(cancelButton)
 
             // Key should still be there
-            expect(useSettingsStore.getState().settings.apiKeys.OpenAI).toBe(TEST_API_KEY)
+            expect(getApiKey(useSettingsStore.getState().settings.apiKeys, "OpenAI")).toBe(TEST_API_KEY)
 
             // Now click it again but this time confirm
             await user.click(forgetButton)
@@ -377,14 +380,17 @@ describe("SettingsDialog", () => {
             const confirmButton = screen.getByText("Yes, forget key")
             await user.click(confirmButton)
 
-            expect(useSettingsStore.getState().settings.apiKeys.OpenAI).toBeFalsy()
+            expect(getApiKey(useSettingsStore.getState().settings.apiKeys, "OpenAI")).toBeFalsy()
         })
 
         it("allows a user to show/hide keys", async () => {
             // set an existing key value
             useSettingsStore.getState().updateSettings({
                 apiKeys: {
-                    OpenAI: TEST_API_KEY,
+                    OpenAI: {
+                        expiresAt: Number.MAX_SAFE_INTEGER, // "never expires""
+                        value: TEST_API_KEY,
+                    },
                 },
             })
 

--- a/packages/ui-common/__tests__/unit/State/Settings.test.ts
+++ b/packages/ui-common/__tests__/unit/State/Settings.test.ts
@@ -1,0 +1,126 @@
+// Include mock for IndexedDB
+import "fake-indexeddb/auto"
+
+import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
+import {
+    APP_SETTINGS_STORAGE_KEY,
+    DEFAULT_SETTINGS,
+    getApiKey,
+    SESSION_API_KEYS_STORAGE_KEY,
+    useSettingsStore,
+} from "../../../state/Settings"
+
+describe("Settings", () => {
+    withStrictMocks()
+
+    beforeEach(() => {
+        useSettingsStore.getState().resetSettings()
+    })
+
+    const reloadSettingsStore = async () => {
+        // Reset modules to ensure the store is re-imported and reads from sessionStorage
+        vi.resetModules()
+
+        // Re-import the store after resetting modules to ensure it reads from sessionStorage again
+        const {useSettingsStore: freshUseSettingsStore} = await import("../../../state/Settings")
+
+        // The expired API key should be purged on rehydration, so the store should not have any API keys
+        expect(freshUseSettingsStore.getState().settings.apiKeys).toEqual({})
+    }
+
+    describe("ApiKeys", () => {
+        it("should filter out expired keys", async () => {
+            const openAIKeyValue = "valid-key"
+            useSettingsStore.getState().updateSettings({
+                apiKeys: {
+                    OpenAI: {
+                        value: openAIKeyValue,
+                        expiresAt: Number.MAX_SAFE_INTEGER, // "never" expires
+                    },
+                    Anthropic: {
+                        value: "expired-key",
+                        expiresAt: Date.now() - 1000, // expired 1 second ago
+                    },
+                },
+            })
+
+            const apiKeys = useSettingsStore.getState().settings.apiKeys
+            expect(Object.keys(apiKeys).length).toBe(2)
+
+            expect(getApiKey(apiKeys, "OpenAI")).toBe(openAIKeyValue)
+            expect(getApiKey(apiKeys, "Anthropic")).toBeUndefined()
+        })
+
+        it("should purge legacy keys persisted in localStorage on hydrate", async () => {
+            localStorage.setItem(
+                APP_SETTINGS_STORAGE_KEY,
+                JSON.stringify({
+                    state: {settings: {apiKeys: {OpenAI: {value: "legacy-key"}}}},
+                })
+            )
+
+            await reloadSettingsStore()
+
+            // The persisted state in localStorage should also not have any API keys
+            const persisted = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? "{}")
+            expect(persisted.state.settings.apiKeys).toBeUndefined()
+        })
+
+        it("Purges expired keys on rehydration", async () => {
+            const expiredKey = {
+                value: "expired-key",
+                expiresAt: Date.now() - 1000, // expired 1 second ago
+            }
+
+            // Store an expired key in sessionStorage
+            sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify({OpenAI: expiredKey}))
+
+            await reloadSettingsStore()
+
+            // The persisted state in sessionStorage should also not have any API keys
+            const persistedSession = JSON.parse(sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}")
+            expect(persistedSession).toEqual({})
+        })
+
+        it("persists API keys only in sessionStorage", () => {
+            const openAIKeyValue = "valid-key"
+            useSettingsStore.getState().updateSettings({
+                apiKeys: {
+                    OpenAI: {
+                        value: openAIKeyValue,
+                        expiresAt: Number.MAX_SAFE_INTEGER, // "never" expires
+                    },
+                },
+            })
+
+            const storedApiKeys = JSON.parse(sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}")
+            expect(storedApiKeys.OpenAI.value).toBe(openAIKeyValue)
+
+            const persisted = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? "{}")
+            expect(persisted.state.settings.apiKeys).toBeUndefined()
+        })
+    })
+
+    describe("Settings persistence", () => {
+        it("persists non-API key settings in localStorage", () => {
+            const agentIconColor = "#112233"
+            useSettingsStore.getState().updateSettings({
+                appearance: {
+                    agentIconColor,
+                },
+            })
+
+            const persisted = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? "{}")
+            expect(persisted.state.settings.appearance.agentIconColor).toBe(agentIconColor)
+        })
+
+        it("handles persisted empty settings gracefully", async () => {
+            localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({state: {settings: null}}))
+
+            await reloadSettingsStore()
+
+            const settings = useSettingsStore.getState().settings
+            expect(settings).toEqual(DEFAULT_SETTINGS)
+        })
+    })
+})

--- a/packages/ui-common/__tests__/unit/State/Settings.test.ts
+++ b/packages/ui-common/__tests__/unit/State/Settings.test.ts
@@ -1,6 +1,3 @@
-// Include mock for IndexedDB
-import "fake-indexeddb/auto"
-
 import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
 import {
     APP_SETTINGS_STORAGE_KEY,

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -61,7 +61,6 @@ import {AgentIconSuggestions} from "../../controller/Types/AgentIconSuggestions"
 import {NetworkIconSuggestions} from "../../controller/Types/NetworkIconSuggestions"
 import {AgentInfo, ConnectivityInfo, ConnectivityResponse} from "../../generated/neuro-san/NeuroSanClient"
 import {useAgentChatHistoryStore} from "../../state/ChatHistory"
-import {ByokKeyField, LLM_PROVIDER_API_KEY_FIELD, LLMProvider, useSettingsStore} from "../../state/Settings"
 import {TemporaryNetwork, useTempNetworksStore} from "../../state/TemporaryNetworks"
 import {TourPromptState, useTourStore} from "../../state/Tour"
 import {getZIndex} from "../../utils/zIndexLayers"
@@ -74,6 +73,7 @@ import {MUIAlert} from "../Common/MUIAlert"
 import {MUIDialog} from "../Common/MUIDialog"
 import {closeNotification, NotificationType, sendNotification} from "../Common/notification"
 import {BYOK} from "./Schema/SlyData"
+import {ByokKeyField, getApiKey, LLM_PROVIDER_API_KEY_FIELD, LLMProvider, useSettingsStore} from "../../state/Settings"
 
 export interface MultiAgentAcceleratorProps {
     readonly username: string
@@ -263,7 +263,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
             [...supportedByokProviders]
                 .map((provider): [ByokKeyField, string | undefined] => [
                     LLM_PROVIDER_API_KEY_FIELD[provider],
-                    apiKeys[provider],
+                    getApiKey(apiKeys, provider),
                 ])
                 .filter((entry: [ByokKeyField, string | undefined]): entry is [ByokKeyField, string] =>
                     Boolean(entry[1])
@@ -759,7 +759,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
 
     const getMissingApiKeys = (): ReadonlySet<LLMProvider> => {
         // Calculate intersection of what we have (apiKeys) and what is required (providerKeysRequired)
-        const intersection = new Set([...supportedByokProviders].filter((x) => apiKeys[x]))
+        const intersection = new Set([...supportedByokProviders].filter((provider) => getApiKey(apiKeys, provider)))
         return intersection.size === 0 ? supportedByokProviders : new Set()
     }
 

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -33,7 +33,14 @@ import {getBrandingSuggestions, testConnection, TestConnectionResult} from "../.
 import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../controller/llm/Providers"
 import {BrandingSuggestions} from "../../controller/Types/Branding"
 import {useEnvironmentStore} from "../../state/Environment"
-import {DEFAULT_SETTINGS, LLMProvider, PaletteKey, useSettingsStore} from "../../state/Settings"
+import {
+    API_KEYS_TTL_MS,
+    DEFAULT_SETTINGS,
+    getApiKey,
+    LLMProvider,
+    PaletteKey,
+    useSettingsStore,
+} from "../../state/Settings"
 import {PALETTES} from "../../Theme/Palettes"
 import {ConfirmationModal} from "../Common/ConfirmationModal"
 import {MUIDialog} from "../Common/MUIDialog"
@@ -334,10 +341,25 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
         logoCheckmark.trigger()
     }
 
-    const persistKey = (vendor: LLMProvider, key: string, checkmark: ReturnType<typeof useCheckmarkFade>) => {
+    /**
+     * Used for both saving and removing keys.
+     * @param vendor Vendor for this key: see the list in LLMProvider type
+     * @param key Value of the key
+     * @param checkmark Checkmark to trigger on save
+     * @param now Timestamp for "now"
+     */
+    const persistKey = (
+        vendor: LLMProvider,
+        key: string,
+        checkmark: ReturnType<typeof useCheckmarkFade>,
+        now: number
+    ) => {
         updateSettings({
             apiKeys: {
-                [vendor]: key,
+                [vendor]: {
+                    value: key,
+                    expiresAt: key ? now + API_KEYS_TTL_MS : 0,
+                },
             },
         })
         checkmark.trigger()
@@ -531,9 +553,10 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
             <Box sx={{display: "flex", alignItems: "center", gap: theme.spacing(1)}}>
                 <SettingsSectionTitle>API Keys</SettingsSectionTitle>
                 <Tooltip
-                    title="API keys are stored in your browser's memory for the duration of your session only and are
-                    only sent to the Neuro SAN service for use with the associated LLM provider. Your keys are never
-                    sent to any other servers or services and are not stored on our servers.
+                    title="API keys are stored locally in your browser's memory for the duration of your session only
+                    and are only sent to the Neuro SAN service for use with the associated LLM provider when you use
+                    this application to interact with networks.
+                    Your keys are never sent to any other servers or services and are not stored on our servers.
                     When you close this tab or your browser, your keys will be permanently cleared from memory and
                     you will need to enter them again to use services that require them."
                 >
@@ -576,12 +599,12 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                             tooltip={`API key for ${vendor}.`}
                         >
                             <ApiKeyInput
-                                forgetKey={() => persistKey(vendor, "", checkmark)}
+                                forgetKey={() => persistKey(vendor, "", checkmark, 0)}
                                 id={`${id}-${idSuffix}`}
                                 logo={logo}
-                                onSave={(key) => persistKey(vendor, key, checkmark)}
+                                onSave={(key) => persistKey(vendor, key, checkmark, Date.now())}
                                 onTest={onTest}
-                                persistedValue={apiKeys[vendor]}
+                                persistedValue={getApiKey(apiKeys, vendor) ?? ""}
                                 placeholder={placeholder}
                                 vendor={vendor}
                             />
@@ -1036,7 +1059,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
     )
 
     return (
-        // Always use default theme for settings dialog so user can always see to reset. It's possible that with
+        // Always use the default theme for settings dialog so user can always see to reset. It's possible that with
         // certain custom themes the dialog would be unreadable.
         <ThemeProvider theme={settingsTheme}>
             {resetToDefaultSettingsOpen ? getConfirmationModal() : null}

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -604,7 +604,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
                                 logo={logo}
                                 onSave={(key) => persistKey(vendor, key, checkmark, Date.now())}
                                 onTest={onTest}
-                                persistedValue={getApiKey(apiKeys, vendor) ?? ""}
+                                persistedValue={getApiKey(apiKeys, vendor)}
                                 placeholder={placeholder}
                                 vendor={vendor}
                             />

--- a/packages/ui-common/components/Settings/SettingsDialog.tsx
+++ b/packages/ui-common/components/Settings/SettingsDialog.tsx
@@ -28,7 +28,6 @@ import {
 
 import {ApiKeyInput} from "./ApiKeyInput"
 import {useCheckmarkFade} from "./FadingCheckmark"
-import InfoTip from "./InfoTip"
 import {SettingsRow} from "./SettingsRow"
 import {getBrandingSuggestions, testConnection, TestConnectionResult} from "../../controller/agent/Agent"
 import {isAnthropicKeyValid, isOpenAIKeyValid} from "../../controller/llm/Providers"
@@ -529,15 +528,43 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({id, isOpen, logoService
 
     const getApiKeysSection = () => (
         <Section>
-            <Box sx={{display: "flex", alignItems: "center", gap: theme.spacing(2)}}>
+            <Box sx={{display: "flex", alignItems: "center", gap: theme.spacing(1)}}>
                 <SettingsSectionTitle>API Keys</SettingsSectionTitle>
-                <InfoTip
-                    title={
-                        "API keys are used to access external services. Some networks may require an API key for " +
-                        "you to use them. Your keys will be saved in your browser local storage and sent to " +
-                        "services that require them. Do not use this option if you are on a shared or public computer."
-                    }
-                />
+                <Tooltip
+                    title="API keys are stored in your browser's memory for the duration of your session only and are
+                    only sent to the Neuro SAN service for use with the associated LLM provider. Your keys are never
+                    sent to any other servers or services and are not stored on our servers.
+                    When you close this tab or your browser, your keys will be permanently cleared from memory and
+                    you will need to enter them again to use services that require them."
+                >
+                    <Typography
+                        sx={{
+                            alignSelf: "flex-start",
+                            color: "var(--bs-secondary)",
+                            cursor: "help",
+                            fontSize: "0.7rem",
+                            lineHeight: 1,
+                            mt: 0.5,
+                        }}
+                        variant="caption"
+                    >
+                        <Box
+                            component="span"
+                            sx={{mr: 0.5}}
+                        >
+                            ⓘ
+                        </Box>
+                        <Box
+                            component="span"
+                            sx={{
+                                borderBottom: "1px dashed",
+                                pb: 0.25,
+                            }}
+                        >
+                            How are my keys stored and used?
+                        </Box>
+                    </Typography>
+                </Tooltip>
             </Box>
             <SettingsSubsection title="LLM Providers">
                 <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5}}>

--- a/packages/ui-common/state/Settings.ts
+++ b/packages/ui-common/state/Settings.ts
@@ -112,6 +112,25 @@ export const DEFAULT_SETTINGS: Settings = {
         neuroSanUrl: null,
     },
 }
+const APP_SETTINGS_STORAGE_KEY = "app-settings"
+const SESSION_API_KEYS_STORAGE_KEY = "app-settings-api-keys"
+
+/**
+ * Purges any persisted API keys from localStorage. This cleans up from previous versions of the cdoe.
+ */
+const purgePersistedApiKeys = () => {
+    // Protect against non-browser, SSR, test environments etc.
+    if (typeof sessionStorage === "undefined") {
+        return
+    }
+
+    const persisted = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? "{}")
+
+    if (persisted.state?.settings) {
+        delete persisted.state.settings.apiKeys
+        localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(persisted))
+    }
+}
 
 /**
  * The hook that lets apps use the store
@@ -121,18 +140,52 @@ export const useSettingsStore = create<SettingsStore>()(
         (set) => ({
             settings: DEFAULT_SETTINGS,
             updateSettings: (updates) =>
-                set((state) => ({
-                    settings: merge({}, state.settings, updates),
-                })),
+                set((state) => {
+                    const nextSettings = merge({}, state.settings, updates)
+
+                    // Side effect: persist API keys in sessionStorage, unlike other Settings items which are persisted
+                    // to localStorage (zustand default)
+                    if (updates.apiKeys && typeof sessionStorage !== "undefined") {
+                        sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify(nextSettings.apiKeys))
+                    }
+
+                    return {
+                        settings: nextSettings,
+                    }
+                }),
             resetSettings: () => set({settings: DEFAULT_SETTINGS}),
         }),
         {
-            name: "app-settings",
+            name: APP_SETTINGS_STORAGE_KEY,
+
+            // We don't want to persist API keys in localStorage, so we remove them before saving the state.
+            partialize: (state) => {
+                const {apiKeys: _apiKeys, ...settingsWithoutApiKeys} = state.settings
+
+                return {
+                    ...state,
+                    settings: settingsWithoutApiKeys,
+                }
+            },
+
             merge: (persistedState, currentState) => {
+                // This is the hook that runs when the store is rehydrated from localStorage.
+                // We use it to purge any persisted API keys from previous versions of the code.
+                purgePersistedApiKeys()
+
                 // Merge persisted settings with defaults to fill in any missing fields
+                const sessionApiKeys =
+                    typeof sessionStorage === "undefined"
+                        ? {}
+                        : JSON.parse(sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}")
+
+                const persistedSettings = (persistedState as Partial<SettingsStore>).settings ?? {}
+
                 return {
                     ...currentState,
-                    settings: merge({}, DEFAULT_SETTINGS, (persistedState as SettingsStore).settings),
+                    settings: merge({}, DEFAULT_SETTINGS, persistedSettings, {
+                        apiKeys: sessionApiKeys,
+                    }),
                 }
             },
         }

--- a/packages/ui-common/state/Settings.ts
+++ b/packages/ui-common/state/Settings.ts
@@ -19,6 +19,8 @@ import {persist} from "zustand/middleware"
 
 import {PALETTES} from "../Theme/Palettes"
 
+//#region Interfaces and Types
+
 /**
  * A utility type that makes all properties in T deeply optional, since TypeScript's built-in Partial<T>
  * only makes the top-level properties optional.
@@ -31,17 +33,21 @@ type DeepPartial<T> = {
 }
 
 export type LLMProvider = "OpenAI" | "Anthropic"
-export type LogoSource = "none" | "generic" | "auto"
 
-// Mapping of LLM providers to their corresponding API key field names in the settings store.
-export const LLM_PROVIDER_API_KEY_FIELD = {
-    OpenAI: "openai_api_key",
-    Anthropic: "anthropic_api_key",
-} as const satisfies Record<LLMProvider, string>
+export type LogoSource = "none" | "generic" | "auto"
 
 // Type representing the API key field name for a given LLM provider, derived from the mapping above.
 // Not to be confused: API "key" vs. the "key" in the map.
 export type ByokKeyField = (typeof LLM_PROVIDER_API_KEY_FIELD)[LLMProvider]
+
+interface ApiKeyEntry {
+    readonly value: string
+    readonly expiresAt: number
+}
+
+type ApiKeys = Partial<Record<LLMProvider, ApiKeyEntry>>
+
+export type PaletteKey = keyof typeof PALETTES | "brand"
 
 /**
  * User preference settings
@@ -67,7 +73,7 @@ interface Settings {
     readonly behavior: {
         readonly enableZenMode: boolean
     }
-    readonly apiKeys: Partial<Record<LLMProvider, string>>
+    readonly apiKeys: ApiKeys
     readonly externalServices: {
         neuroSanUrl: string | null
     }
@@ -81,6 +87,16 @@ interface SettingsStore {
     readonly updateSettings: (updates: DeepPartial<Settings>) => void
     readonly resetSettings: () => void
 }
+
+//#endregion Interfaces and Types
+
+//#region Constants
+
+// Mapping of LLM providers to their corresponding API key field names in the settings store.
+export const LLM_PROVIDER_API_KEY_FIELD = {
+    OpenAI: "openai_api_key",
+    Anthropic: "anthropic_api_key",
+} as const satisfies Record<LLMProvider, string>
 
 /**
  * Default settings, used on first load and on reset
@@ -112,14 +128,25 @@ export const DEFAULT_SETTINGS: Settings = {
         neuroSanUrl: null,
     },
 }
+
+// Name for key where main app settings are saved
 const APP_SETTINGS_STORAGE_KEY = "app-settings"
+
+// Name for key where API keys are saved in sessionStorage.
 const SESSION_API_KEYS_STORAGE_KEY = "app-settings-api-keys"
+
+// TTL for API keys in sessionStorage. After this time, the keys will be cleared from sessionStorage.
+// This is a backstop for cases where users rarely close their browser or tabs
+export const API_KEYS_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+//#endregion Constants
 
 /**
  * Purges any persisted API keys from localStorage. This cleans up from previous versions of the cdoe.
+ * Once we are "reasonably sure" that no users are on old versions, we can remove this function.
  */
 const purgePersistedApiKeys = () => {
-    // Protect against non-browser, SSR, test environments etc.
+    // Protect against non-browser, SSR, test environments, etc.
     if (typeof sessionStorage === "undefined") {
         return
     }
@@ -130,6 +157,20 @@ const purgePersistedApiKeys = () => {
         delete persisted.state.settings.apiKeys
         localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(persisted))
     }
+}
+
+/**
+ * Returns the API key for the given provider if it exists and is not expired, otherwise returns undefined.
+ * This helper should be used to retrieve API keys from the settings store, rather than accessing the store directly,
+ * to ensure that expired keys are not returned.
+ * @param apiKeys Set of API keys stored in the settings store
+ * @param provider The LLM provider for which to retrieve the API key
+ */
+export const getApiKey = (apiKeys: ApiKeys, provider: LLMProvider) => {
+    const now = Date.now()
+    const entry = apiKeys[provider]
+
+    return entry && entry.expiresAt > now ? entry.value : undefined
 }
 
 /**
@@ -145,6 +186,7 @@ export const useSettingsStore = create<SettingsStore>()(
 
                     // Side effect: persist API keys in sessionStorage, unlike other Settings items which are persisted
                     // to localStorage (zustand default)
+                    // Timestamp the API keys so we can purge them after a TTL.
                     if (updates.apiKeys && typeof sessionStorage !== "undefined") {
                         sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify(nextSettings.apiKeys))
                     }
@@ -173,14 +215,28 @@ export const useSettingsStore = create<SettingsStore>()(
                 // We use it to purge any persisted API keys from previous versions of the code.
                 purgePersistedApiKeys()
 
-                // Merge persisted settings with defaults to fill in any missing fields
-                const sessionApiKeys =
-                    typeof sessionStorage === "undefined"
-                        ? {}
-                        : JSON.parse(sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}")
+                const sessionApiKeys = (() => {
+                    if (typeof sessionStorage === "undefined") {
+                        return {}
+                    }
+
+                    const now = Date.now()
+                    const storedApiKeys = JSON.parse(
+                        sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}"
+                    ) as ApiKeys
+
+                    const validApiKeys = Object.fromEntries(
+                        Object.entries(storedApiKeys).filter(([, entry]) => entry.expiresAt > now)
+                    ) as ApiKeys
+
+                    sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify(validApiKeys))
+
+                    return validApiKeys
+                })()
 
                 const persistedSettings = (persistedState as Partial<SettingsStore>).settings ?? {}
 
+                // Merge persisted settings with defaults to fill in any missing fields
                 return {
                     ...currentState,
                     settings: merge({}, DEFAULT_SETTINGS, persistedSettings, {
@@ -191,8 +247,6 @@ export const useSettingsStore = create<SettingsStore>()(
         }
     )
 )
-
-export type PaletteKey = keyof typeof PALETTES | "brand"
 
 /**
  * Custom hook to get the current color palette based on user settings.

--- a/packages/ui-common/state/Settings.ts
+++ b/packages/ui-common/state/Settings.ts
@@ -137,7 +137,7 @@ export const SESSION_API_KEYS_STORAGE_KEY = "app-settings-api-keys"
 
 // TTL for API keys in sessionStorage. After this time, the keys will be cleared from sessionStorage.
 // This is a backstop for cases where users rarely close their browser or tabs
-export const API_KEYS_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+export const API_KEYS_TTL_MS = 2 * 24 * 60 * 60 * 1000 // 2 days
 
 //#endregion Constants
 

--- a/packages/ui-common/state/Settings.ts
+++ b/packages/ui-common/state/Settings.ts
@@ -203,7 +203,10 @@ export const useSettingsStore = create<SettingsStore>()(
                         settings: nextSettings,
                     }
                 }),
-            resetSettings: () => set({settings: DEFAULT_SETTINGS}),
+            resetSettings: () => {
+                sessionStorage.removeItem(SESSION_API_KEYS_STORAGE_KEY)
+                set({settings: DEFAULT_SETTINGS})
+            },
         }),
         {
             name: APP_SETTINGS_STORAGE_KEY,

--- a/packages/ui-common/state/Settings.ts
+++ b/packages/ui-common/state/Settings.ts
@@ -130,10 +130,10 @@ export const DEFAULT_SETTINGS: Settings = {
 }
 
 // Name for key where main app settings are saved
-const APP_SETTINGS_STORAGE_KEY = "app-settings"
+export const APP_SETTINGS_STORAGE_KEY = "app-settings"
 
 // Name for key where API keys are saved in sessionStorage.
-const SESSION_API_KEYS_STORAGE_KEY = "app-settings-api-keys"
+export const SESSION_API_KEYS_STORAGE_KEY = "app-settings-api-keys"
 
 // TTL for API keys in sessionStorage. After this time, the keys will be cleared from sessionStorage.
 // This is a backstop for cases where users rarely close their browser or tabs
@@ -141,16 +141,18 @@ export const API_KEYS_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
 //#endregion Constants
 
+const hasPersistedSettings = (state: unknown): state is {settings: DeepPartial<Settings>} =>
+    typeof state === "object" &&
+    state !== null &&
+    "settings" in state &&
+    typeof state.settings === "object" &&
+    state.settings !== null
+
 /**
  * Purges any persisted API keys from localStorage. This cleans up from previous versions of the cdoe.
  * Once we are "reasonably sure" that no users are on old versions, we can remove this function.
  */
 const purgePersistedApiKeys = () => {
-    // Protect against non-browser, SSR, test environments, etc.
-    if (typeof sessionStorage === "undefined") {
-        return
-    }
-
     const persisted = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? "{}")
 
     if (persisted.state?.settings) {
@@ -160,6 +162,13 @@ const purgePersistedApiKeys = () => {
 }
 
 /**
+ * Function to determine if an API key entry is valid (i.e., exists and is not expired).
+ * @param entry The API key entry to validate
+ * @returns True if the entry exists and is not expired, false otherwise
+ */
+const isApiKeyValid = (entry?: ApiKeyEntry): boolean => Boolean(entry) && entry.expiresAt > Date.now()
+
+/**
  * Returns the API key for the given provider if it exists and is not expired, otherwise returns undefined.
  * This helper should be used to retrieve API keys from the settings store, rather than accessing the store directly,
  * to ensure that expired keys are not returned.
@@ -167,10 +176,9 @@ const purgePersistedApiKeys = () => {
  * @param provider The LLM provider for which to retrieve the API key
  */
 export const getApiKey = (apiKeys: ApiKeys, provider: LLMProvider) => {
-    const now = Date.now()
     const entry = apiKeys[provider]
 
-    return entry && entry.expiresAt > now ? entry.value : undefined
+    return isApiKeyValid(entry) ? entry.value : undefined
 }
 
 /**
@@ -187,7 +195,7 @@ export const useSettingsStore = create<SettingsStore>()(
                     // Side effect: persist API keys in sessionStorage, unlike other Settings items which are persisted
                     // to localStorage (zustand default)
                     // Timestamp the API keys so we can purge them after a TTL.
-                    if (updates.apiKeys && typeof sessionStorage !== "undefined") {
+                    if (updates.apiKeys) {
                         sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify(nextSettings.apiKeys))
                     }
 
@@ -215,33 +223,27 @@ export const useSettingsStore = create<SettingsStore>()(
                 // We use it to purge any persisted API keys from previous versions of the code.
                 purgePersistedApiKeys()
 
-                const sessionApiKeys = (() => {
-                    if (typeof sessionStorage === "undefined") {
-                        return {}
-                    }
+                // Now we can read the API keys from sessionStorage and filter out any expired keys.
+                const storedApiKeys = JSON.parse(
+                    sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}"
+                ) as ApiKeys
 
-                    const now = Date.now()
-                    const storedApiKeys = JSON.parse(
-                        sessionStorage.getItem(SESSION_API_KEYS_STORAGE_KEY) ?? "{}"
-                    ) as ApiKeys
+                const sessionApiKeys = Object.fromEntries(
+                    Object.entries(storedApiKeys).filter(([, entry]) => isApiKeyValid(entry))
+                )
 
-                    const validApiKeys = Object.fromEntries(
-                        Object.entries(storedApiKeys).filter(([, entry]) => entry.expiresAt > now)
-                    ) as ApiKeys
+                sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify(sessionApiKeys))
 
-                    sessionStorage.setItem(SESSION_API_KEYS_STORAGE_KEY, JSON.stringify(validApiKeys))
+                const persistedSettings = hasPersistedSettings(persistedState) ? persistedState.settings : {}
 
-                    return validApiKeys
-                })()
-
-                const persistedSettings = (persistedState as Partial<SettingsStore>).settings ?? {}
-
-                // Merge persisted settings with defaults to fill in any missing fields
+                // Merge persisted settings with defaults to fill in any missing fields,
+                // then explicitly replace apiKeys with sessionStorage-backed keys.
                 return {
                     ...currentState,
-                    settings: merge({}, DEFAULT_SETTINGS, persistedSettings, {
+                    settings: {
+                        ...merge({}, DEFAULT_SETTINGS, persistedSettings),
                         apiKeys: sessionApiKeys,
-                    }),
+                    },
                 }
             },
         }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -103,
-                branches: -154,
-                functions: -25,
-                lines: -74,
+                statements: -106,
+                branches: -160,
+                functions: -26,
+                lines: -77,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -106,
-                branches: -160,
-                functions: -26,
-                lines: -77,
+                statements: -103,
+                branches: -155,
+                functions: -25,
+                lines: -74,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests


### PR DESCRIPTION
With this PR, entered API keys are only saved in ephemeral [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage), which lasts only as long as the browser process or tab (whichever is closed first).

Also side effect, purges any persisted in localStorage (which is where we used to save them).

<img width="891" height="862" alt="image" src="https://github.com/user-attachments/assets/bc05899a-4604-4412-a726-f849a8ab6c75" />

