### PR TITLE
#465 Show Neuro SAN Studio version in status tip

### DIFF
--- a/packages/ui-common/README.md
+++ b/packages/ui-common/README.md
@@ -160,9 +160,9 @@ async function checkServer() {
     const result = await testConnection("https://api.example.com")
 
     if (result.success) {
-        console.log(`Connected! Version: ${result.version}`)
+        console.log(`Connected!`)
     } else {
-        console.error(`Connection failed: ${result.status}`)
+        console.error(`Connection failed: ${result.statusText}`)
     }
 }
 ```

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -59,7 +59,6 @@ import {
     getAgentNetworks,
     getConnectivity,
     sendNetworkDesignerRequest,
-    testConnection,
 } from "../../../controller/agent/Agent"
 import {getNetworkIconSuggestions} from "../../../controller/agent/IconSuggestions"
 import {NetworkIconSuggestions} from "../../../controller/Types/NetworkIconSuggestions"
@@ -269,7 +268,6 @@ describe("MultiAgentAccelerator", () => {
 
         vi.mocked(getAgentNetworks).mockResolvedValue(LIST_NETWORKS_RESPONSE)
         vi.mocked(getConnectivity).mockResolvedValue(MOCK_CONNECTIVITY_INFO)
-        vi.mocked(testConnection).mockResolvedValue({success: true, status: "ok", version: "1.0.0"})
         vi.mocked(sendNetworkDesignerRequest)
 
         user = userEvent.setup()

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
@@ -196,7 +196,7 @@ describe("SideBar", () => {
         await user.hover(statusLight)
         const statusTooltip = await screen.findByRole("tooltip", {name: "Neuro-san server status"})
         within(statusTooltip).getByText(TEST_VERSION)
-        within(statusTooltip).getByText("ok")
+        within(statusTooltip).getByText("online")
         within(statusTooltip).getByText(DEFAULT_EXAMPLE_URL)
 
         // Now mock testConnection to return failure and re-render the component

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/Sidebar/Sidebar.test.tsx
@@ -150,10 +150,13 @@ describe("SideBar", () => {
         user = userEvent.setup()
         const testConnectionMock = vi.mocked(testConnection)
         testConnectionMock.mockResolvedValue({
+            healthCheckResponse: {
+                status: "ok",
+                versions: {"neuro-san": TEST_VERSION},
+            },
             httpStatus: httpStatus.OK,
-            status: "ok",
+            statusText: "ok",
             success: true,
-            version: TEST_VERSION,
         } satisfies TestConnectionResult)
 
         // Reset settings store
@@ -193,7 +196,7 @@ describe("SideBar", () => {
         await user.hover(statusLight)
         const statusTooltip = await screen.findByRole("tooltip", {name: "Neuro-san server status"})
         within(statusTooltip).getByText(TEST_VERSION)
-        within(statusTooltip).getByText(/online/u)
+        within(statusTooltip).getByText("ok")
         within(statusTooltip).getByText(DEFAULT_EXAMPLE_URL)
 
         // Now mock testConnection to return failure and re-render the component
@@ -202,7 +205,7 @@ describe("SideBar", () => {
         const testConnectionMock = vi.mocked(testConnection)
         testConnectionMock.mockResolvedValue({
             success: false,
-            status: statusMessage,
+            statusText: statusMessage,
             httpStatus: httpStatus.IM_A_TEAPOT,
         } satisfies TestConnectionResult)
 
@@ -221,9 +224,8 @@ describe("SideBar", () => {
         // Tooltip should now show the error status
         const updatedStatusTooltip = await screen.findByRole("tooltip", {name: "Neuro-san server status"})
         within(updatedStatusTooltip).getByText(statusMessage)
-        within(updatedStatusTooltip).getByText("offline")
-        // version and URL should be "unknown"
-        expect(within(updatedStatusTooltip).getAllByText("unknown")).toHaveLength(2)
+        // versions x 2, URL and "service" should be "unknown"
+        expect(within(updatedStatusTooltip).getAllByText("unknown")).toHaveLength(4)
         within(updatedStatusTooltip).getByText(new RegExp(String(httpStatus.IM_A_TEAPOT), "u"))
 
         testConnectionMock.mockClear()
@@ -231,7 +233,7 @@ describe("SideBar", () => {
         // Now with an unknown http status (mainly for branch coverage)
         testConnectionMock.mockResolvedValue({
             success: false,
-            status: statusMessage,
+            statusText: statusMessage,
             httpStatus: httpStatus.IM_A_TEAPOT + 1,
         } satisfies TestConnectionResult)
 
@@ -255,34 +257,10 @@ describe("SideBar", () => {
         )
         const unknownStatusTooltip = await screen.findByRole("tooltip", {name: "Neuro-san server status"})
         within(unknownStatusTooltip).getByText(statusMessage)
-        within(unknownStatusTooltip).getByText("offline")
-        within(unknownStatusTooltip).getByText("unknown")
+
+        // 2 versions "unknown" + 1 "service" "unknown" = 3 unknowns
+        expect(within(unknownStatusTooltip).getAllByText("unknown")).toHaveLength(3)
         within(unknownStatusTooltip).getByText(new RegExp(`${String(httpStatus.IM_A_TEAPOT + 1)}.*Unknown status`, "u"))
-    })
-
-    it.each([
-        {
-            caseName: "Error object",
-            exception: new Error("Simulated testConnection error"),
-            expectedMessage: "Simulated testConnection error",
-        },
-        {
-            caseName: "string",
-            exception: "Simulated string error",
-            expectedMessage: "Simulated string error",
-        },
-    ])("handles errors from testConnection when $caseName is thrown", async ({exception, expectedMessage}) => {
-        const testConnectionMock = vi.mocked(testConnection)
-
-        testConnectionMock.mockRejectedValue(exception)
-
-        renderSidebarComponent({})
-
-        const statusLight = await screen.findByTestId(`${DEFAULT_PROPS.id}-agent-network-status-light`)
-        await user.hover(statusLight)
-
-        const tooltip = await screen.findByRole("tooltip", {name: "Neuro-san server status"})
-        within(tooltip).getByText(expectedMessage)
     })
 
     it("Should display suggested network icons correctly", async () => {

--- a/packages/ui-common/__tests__/unit/Controller/agent/Agent.test.ts
+++ b/packages/ui-common/__tests__/unit/Controller/agent/Agent.test.ts
@@ -22,6 +22,7 @@ import {
     getAgentFunction,
     getAgentNetworks,
     getConnectivity,
+    HealthCheckResponse,
     sendChatQuery,
     sendNetworkDesignerRequest,
     testConnection,
@@ -49,14 +50,23 @@ describe("Controller/Agent/testConnection", () => {
     withStrictMocks()
 
     it("Should handle a successful testConnection result", async () => {
-        global.fetch = mockFetch({status: "healthy", versions: {"neuro-san": "1.2.3"}})
+        const neuroSanVersion = "1.2.3"
+        const neuroSanStudioVersion = "4.5.6"
+
+        global.fetch = mockFetch({
+            versions: {"neuro-san": neuroSanVersion, "neuro-san-studio": neuroSanStudioVersion},
+            service: "Neuro SAN studio service",
+            status: "ok",
+        } satisfies HealthCheckResponse)
+
         const result: TestConnectionResult = await testConnection("www.example.com")
         expect(result.success).toBe(true)
-        expect(result.version).toBe("1.2.3")
+        expect(result.healthCheckResponse.versions["neuro-san"]).toBe(neuroSanVersion)
+        expect(result.healthCheckResponse.versions["neuro-san-studio"]).toBe(neuroSanStudioVersion)
     })
 
     it("Should handle an unsuccessful testConnection result", async () => {
-        global.fetch = mockFetch({status: "unhealthy"})
+        global.fetch = mockFetch({status: "unhealthy"} satisfies HealthCheckResponse, false)
         const result: TestConnectionResult = await testConnection("www.example.com")
         expect(result.success).toBe(false)
 

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
@@ -26,7 +26,7 @@ import {FC, useEffect, useState} from "react"
 
 import {AgentNetworkNodeProps, AgentNetworkTreeItem} from "./AgentNetworkTreeItem"
 import {buildTreeViewItems, findTreeItemById} from "./TreeBuilder"
-import {testConnection} from "../../../controller/agent/Agent"
+import {testConnection, TestConnectionResult} from "../../../controller/agent/Agent"
 import {NetworkIconSuggestions} from "../../../controller/Types/NetworkIconSuggestions"
 import {AgentInfo} from "../../../generated/neuro-san/NeuroSanClient"
 import {useSettingsStore} from "../../../state/Settings"
@@ -138,7 +138,6 @@ const ServerStatusTooltip = styled(({className, ...props}: TooltipProps) => (
 
 //#region: Types
 
-type CONNECTION_STATUS = "online" | "offline" | "unknown"
 export interface SidebarProps {
     readonly id: string
     readonly isAwaitingLlm: boolean
@@ -177,37 +176,21 @@ export const Sidebar: FC<SidebarProps> = ({
     // Display option for agent/network names
     const useNativeNames = useSettingsStore((state) => state.settings.appearance.useNativeNames)
 
-    const [neuroSanServerStatus, setNeuroSanServerStatus] = useState<{
-        error?: string
-        httpStatus?: number
-        onlineStatus: CONNECTION_STATUS
-        version: string | null
-    }>({onlineStatus: "unknown", version: null})
+    const [neuroSanServerStatus, setNeuroSanServerStatus] = useState<TestConnectionResult | null>(null)
 
     useEffect(() => {
+        // Track whether the current request is still valid. If the component unmounts or the URL changes,
+        // we want to ignore any results from previous requests.
         let isCurrentRequest = true
 
         const checkStatus = async () => {
-            try {
-                const result = await testConnection(neuroSanServerURL)
+            const result = await testConnection(neuroSanServerURL)
 
-                if (!isCurrentRequest) {
-                    return
-                }
-
-                setNeuroSanServerStatus(
-                    result.success
-                        ? {onlineStatus: "online", version: result.version}
-                        : {error: result.status, httpStatus: result.httpStatus, onlineStatus: "offline", version: null}
-                )
-            } catch (error) {
-                if (!isCurrentRequest) {
-                    return
-                }
-
-                const errorString = error instanceof Error ? error.message : String(error)
-                setNeuroSanServerStatus({error: errorString, onlineStatus: "offline", version: null})
+            if (!isCurrentRequest) {
+                return
             }
+
+            setNeuroSanServerStatus(result)
         }
 
         void checkStatus()
@@ -291,12 +274,12 @@ export const Sidebar: FC<SidebarProps> = ({
     }, [newlyAddedTemporaryNetworks])
 
     const toStatusColor = () => {
-        switch (neuroSanServerStatus.onlineStatus) {
-            case "online":
+        switch (neuroSanServerStatus?.success) {
+            case true:
                 return "green"
-            case "offline":
+            case false:
                 return "red"
-            case "unknown":
+            case undefined:
             default:
                 return "unknown"
         }
@@ -312,26 +295,39 @@ export const Sidebar: FC<SidebarProps> = ({
             title={
                 <Box sx={{display: "flex", flexDirection: "column", gap: 0.5}}>
                     <Typography variant="body2">
-                        <strong>Status:</strong> {neuroSanServerStatus.onlineStatus}
-                    </Typography>
-                    <Typography variant="body2">
-                        <strong>Version:</strong> {neuroSanServerStatus.version ?? "unknown"}
+                        <strong>Status:</strong> {neuroSanServerStatus?.statusText}
                     </Typography>
                     <Typography variant="body2">
                         <strong>URL:</strong> {neuroSanServerURL || "unknown"}
                     </Typography>
-                    {neuroSanServerStatus.error && (
+                    <Typography variant="body2">
+                        <strong>Service:</strong> {neuroSanServerStatus?.healthCheckResponse?.service || "unknown"}
+                    </Typography>
+                    <Typography
+                        sx={{fontWeight: "bold"}}
+                        variant="body2"
+                    >
+                        Versions:
+                    </Typography>
+                    <Box sx={{ml: 1}}>
+                        <Typography variant="body2">
+                            <strong>Neuro SAN:</strong>{" "}
+                            {neuroSanServerStatus?.healthCheckResponse?.versions?.["neuro-san"] ?? "unknown"}
+                        </Typography>
+                        <Typography variant="body2">
+                            <strong>Neuro SAN Studio:</strong>{" "}
+                            {neuroSanServerStatus?.healthCheckResponse?.versions?.["neuro-san-studio"] ?? "unknown"}
+                        </Typography>
+                    </Box>
+                    {!neuroSanServerStatus?.success && neuroSanServerStatus?.httpStatus && (
                         <>
-                            <Typography variant="body2">
-                                <strong>Error:</strong> {neuroSanServerStatus.error}
-                            </Typography>
-                            {neuroSanServerStatus.httpStatus && (
+                            {
                                 <Typography variant="body2">
                                     <strong>HTTP status:</strong>{" "}
                                     {/* eslint-disable-next-line max-len -- feels unnatural to break it */}
                                     {`${neuroSanServerStatus.httpStatus} (${httpStatus[neuroSanServerStatus.httpStatus] ?? "Unknown status"})`}
                                 </Typography>
-                            )}
+                            }
                         </>
                     )}
                 </Box>

--- a/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Sidebar/Sidebar.tsx
@@ -285,6 +285,8 @@ export const Sidebar: FC<SidebarProps> = ({
         }
     }
 
+    const mapStatus = (statusText: string | undefined) => (statusText === "ok" ? "online" : (statusText ?? "unknown"))
+
     const getStatusLight = () => (
         <ServerStatusTooltip
             slotProps={{
@@ -295,7 +297,7 @@ export const Sidebar: FC<SidebarProps> = ({
             title={
                 <Box sx={{display: "flex", flexDirection: "column", gap: 0.5}}>
                     <Typography variant="body2">
-                        <strong>Status:</strong> {neuroSanServerStatus?.statusText}
+                        <strong>Status:</strong> {mapStatus(neuroSanServerStatus?.statusText)}
                     </Typography>
                     <Typography variant="body2">
                         <strong>URL:</strong> {neuroSanServerURL || "unknown"}

--- a/packages/ui-common/controller/agent/Agent.ts
+++ b/packages/ui-common/controller/agent/Agent.ts
@@ -61,11 +61,22 @@ const insertTargetAgent = (agent: string, path: string) => {
     return path.replace("{agent_name}", agentTmp)
 }
 
-export interface TestConnectionResult {
-    readonly httpStatus?: number
+// Response from Neuro SAN "/" root endpoint healthcheck
+export interface HealthCheckResponse {
+    readonly service?: string
     readonly status?: string
+    readonly versions?: {
+        readonly "neuro-san-studio"?: string
+        readonly "neuro-san"?: string
+    }
+}
+
+// Response from testConnection() function.
+export interface TestConnectionResult {
+    readonly healthCheckResponse?: HealthCheckResponse
+    readonly httpStatus?: number
+    readonly statusText?: string
     readonly success: boolean
-    readonly version?: string
 }
 
 /**
@@ -81,25 +92,30 @@ export const testConnection = async (url: string): Promise<TestConnectionResult>
         const response = await fetch(url, {signal: controller.signal})
         if (!response.ok) {
             return {
-                success: false,
                 httpStatus: response.status,
-                status: response.statusText,
+                statusText: response.statusText,
+                success: false,
             }
         }
 
         const jsonResponse = await response.json()
-        // eslint-disable-next-line no-shadow
-        const status = jsonResponse?.status
 
-        // Different versions of the server return different status values, so we need to check for both.
-        const success = status === "healthy" || status === "ok"
+        const statusText = jsonResponse?.status
 
-        // For now, just capture the Neuro-san version since that's all the server returns. More can be added later.
-        const version = jsonResponse?.versions?.["neuro-san"]
-        return {httpStatus: response.status, success, status, version}
+        const success = statusText === "ok"
+
+        return {
+            healthCheckResponse: jsonResponse,
+            httpStatus: response.status,
+            statusText,
+            success,
+        }
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error)
-        return {success: false, status: errorMessage}
+        return {
+            statusText: errorMessage,
+            success: false,
+        }
     } finally {
         clearTimeout(timeout)
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -104,
-                branches: -155,
+                statements: -103,
+                branches: -154,
                 functions: -25,
-                lines: -75,
+                lines: -74,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests
@@ -34,7 +34,7 @@ export default defineConfig({
         globals: true,
         include: ["apps/**/__tests__/**/*.test.{ts,tsx}", "packages/**/__tests__/**/*.test.{ts,tsx}"],
         // Let maxWorkers default to the number of CPU cores in CI, but set 8 for local development (best by test)
-        maxWorkers: process.env["CI"] === "true" ? undefined : (process.env["VITEST_MAX_WORKERS"] ?? 8),
+        // maxWorkers: process.env["CI"] === "true" ? undefined : (process.env["VITEST_MAX_WORKERS"] ?? 8),
         // Have to manually specify GitHub Actions reporter when configuring reporters manually.
         // See: https://vitest.dev/guide/reporters.html#github-actions-reporter
         reporters: process.env["GITHUB_ACTIONS"] === "true" ? ["minimal", "github-actions"] : ["minimal"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         globals: true,
         include: ["apps/**/__tests__/**/*.test.{ts,tsx}", "packages/**/__tests__/**/*.test.{ts,tsx}"],
         // Let maxWorkers default to the number of CPU cores in CI, but set 8 for local development (best by test)
-        // maxWorkers: process.env["CI"] === "true" ? undefined : (process.env["VITEST_MAX_WORKERS"] ?? 8),
+        maxWorkers: process.env["CI"] === "true" ? undefined : (process.env["VITEST_MAX_WORKERS"] ?? 8),
         // Have to manually specify GitHub Actions reporter when configuring reporters manually.
         // See: https://vitest.dev/guide/reporters.html#github-actions-reporter
         reporters: process.env["GITHUB_ACTIONS"] === "true" ? ["minimal", "github-actions"] : ["minimal"],


### PR DESCRIPTION
Consumes the newly-added Neuro SAN Studio version information and displays it in the status tip. Also add service name in the tooltip, because we get it from the endpoint so why not.
<br />

Before  | After
:-------------------------:|:-------------------------:
<img width="496" height="380" alt="image" src="https://github.com/user-attachments/assets/5b016f84-8d95-4d62-abf1-47bcad1f76cd" />|<img width="506" height="384" alt="image" src="https://github.com/user-attachments/assets/87073bb2-7999-4289-b8d3-91605926a837" />

Note that now any error text while polling the server is displayed in the `Status` field; if all is well it displays `online`.

Error scenario:
<br />
<img width="503" height="438" alt="image" src="https://github.com/user-attachments/assets/3be46807-b532-4856-a7a1-45afe8987bc3" />
