### PR TITLE
#340 Add DeepWiki badge/link to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 <p align="center">
-    <a href="https://deepwiki.com/cognizant-ai-lab/neuro-san-ui">
+    <a href="https://deepwiki.com/cognizant-ai-lab/neuro-san-ui" rel="noopener noreferrer" target="_blank">
         <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki: neuro-san-ui" />
     </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+<p align="center">
+    <a href="https://deepwiki.com/cognizant-ai-lab/neuro-san-ui">
+        <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki: neuro-san-ui" />
+    </a>
+</p>
+
 # Overview
 
 This is the repository for the Neuro SAN UI, which is the user interface for the Neuro SAN product. It contains


### PR DESCRIPTION
Adds a "DeepWiki" badge to the repository README. Note: I separately added this repository to DeepWiki for full indexing, and it has completed so we should be good to go.

<img width="1208" height="982" alt="image" src="https://github.com/user-attachments/assets/a0f2a479-9369-4261-b7a9-de8554f95f23" />
