### PR TITLE
Install corepack in Dockerfile for Node 26.

### DIFF
--- a/apps/main/Dockerfile
+++ b/apps/main/Dockerfile
@@ -43,7 +43,9 @@ COPY packages/ui-common ./packages/ui-common
 COPY apps/main/package.json ./apps/main/package.json
 
 # Install all dependencies (including devDependencies) and build ui-common
+# Node 26 no longer bundles corepack, so install it before enabling.
 RUN --mount=type=cache,target=/root/.cache/yarn \
+    npm install -g corepack@latest && \
     corepack enable && \
     corepack install && \
     yarn install --immutable && \
@@ -72,6 +74,7 @@ COPY yarn.lock ./
 COPY --from=deps /app/packages/ui-common ./packages/ui-common
 
 RUN --mount=type=cache,target=/root/.cache/yarn \
+    npm install -g corepack@latest && \
     corepack enable && \
     corepack install && \
     yarn install --immutable

--- a/apps/main/Dockerfile
+++ b/apps/main/Dockerfile
@@ -44,8 +44,8 @@ COPY apps/main/package.json ./apps/main/package.json
 
 # Install all dependencies (including devDependencies) and build ui-common
 # Node 26 no longer bundles corepack, so install it before enabling.
-RUN --mount=type=cache,target=/root/.cache/yarn \
-    npm install -g corepack@latest && \
+RUN --mount=type=cache,target=/root/.cache/yarn --mount=type=cache,target=/root/.npm \
+    npm install -g corepack@0.35.0 && \
     corepack enable && \
     corepack install && \
     yarn install --immutable && \
@@ -73,8 +73,8 @@ COPY yarn.lock ./
 # Copy the full ui-common package from deps (includes source + built dist)
 COPY --from=deps /app/packages/ui-common ./packages/ui-common
 
-RUN --mount=type=cache,target=/root/.cache/yarn \
-    npm install -g corepack@latest && \
+RUN --mount=type=cache,target=/root/.cache/yarn --mount=type=cache,target=/root/.npm \
+    npm install -g corepack@0.35.0 && \
     corepack enable && \
     corepack install && \
     yarn install --immutable


### PR DESCRIPTION
## Fix Docker build broken by Node 22 → 26 upgrade (corepack unbundled)

### Problem

After the Node 22 → 26 bump (#485), the Docker build fails at the dependency-install step with exit code 127 (command not found):

```
Dockerfile:46
>>> RUN --mount=type=cache,target=/root/.cache/yarn \
>>>     corepack enable && \
...
ERROR: process "/bin/sh -c corepack enable && ..." did not complete successfully: exit code: 127
```

### Root cause

Node.js unbundled corepack, so the `node:26-trixie-slim` image ships with **neither corepack nor yarn** — only npm. The Node 22 image bundled both, which is why the same `corepack enable` line worked before the version bump.

Per the Node.js docs: **corepack ships by default in Node.js 24 and earlier, and is no longer distributed starting with Node.js 25** ("Corepack will no longer be distributed starting with Node.js v25"). The Node.js TSC voted to stop bundling it; from v25 on it must be installed via `npm install -g corepack`.

Verified against the images directly:

| Image | corepack | yarn |
|---|---|---|
| `node:22-bookworm-slim` | ✅ 0.34.6 | ✅ 1.22.22 |
| `node:26-trixie-slim` | ❌ missing | ❌ missing |

This is unrelated to the test failure fixed separately (#489).

### Fix

Install corepack via npm before enabling it, in both the `deps` and `builder` stages of `apps/main/Dockerfile`:

```dockerfile
npm install -g corepack@latest && \
corepack enable && \
corepack install && \
...
```

### References

- [Node.js TSC Votes to Stop Distributing Corepack — Socket.dev](https://socket.dev/blog/node-js-tsc-votes-to-stop-distributing-corepack)
- [nodejs/corepack #722 — "Node 25 will not ship corepack by default"](https://github.com/nodejs/corepack/issues/722)
- [nodejs/corepack #783 — README needs fixing now that corepack is not bundled](https://github.com/nodejs/corepack/issues/783)
