### PR TITLE
#308 #386 Add Neuro SAN Studio repo callouts in various places

### DIFF
--- a/apps/main/__tests__/pages/IndexPage.test.tsx
+++ b/apps/main/__tests__/pages/IndexPage.test.tsx
@@ -77,6 +77,13 @@ describe("Index Page", () => {
         await screen.findByText("Flowsource")
         await screen.findByText("Skygrade")
         await screen.findByText("Cognizant Ignition")
+        const title = await screen.findByText(/Star us on GitHub/u)
+        expect(title).toBeVisible()
+
+        const link = title.closest("a")
+
+        expect(link).toBeVisible()
+        expect(link).toHaveAttribute("href", "https://github.com/cognizant-ai-lab/neuro-san-studio")
     })
 
     it("opens the email dialog when 'Contact Us' is clicked", async () => {

--- a/apps/main/pages/_app.tsx
+++ b/apps/main/pages/_app.tsx
@@ -298,43 +298,40 @@ export const NeuroSanUI: FC<ExtendedAppProps> = ({Component, pageProps}): ReactJ
         )
     } else {
         body = (
-            <>
-                <CssBaseline />
-                <NullableSessionProvider>
-                    <ErrorBoundary id="error_boundary">
-                        <NavbarWrapper
-                            id="nav-bar"
-                            logo={LOGO}
-                            logoServiceToken={logoServiceToken}
-                            query={query}
-                            pathname={pathname}
-                            authenticationType={authenticationType}
-                            signOut={handleSignOut}
-                            supportEmailAddress={supportEmailAddress}
-                        />
-                        <Container
-                            id="body-container"
-                            maxWidth={false}
-                            sx={{
-                                border: `solid 1px ${theme.palette.grey[300]}`,
-                                display: "flex",
-                                flex: 1,
-                                flexDirection: "column",
-                                minHeight: "90%",
-                            }}
-                        >
-                            {includeBreadcrumbs && <NeuroAIBreadcrumbs pathname={pathname} />}
-                            {getAppComponent()}
-                        </Container>
-                        <Footer
-                            supportEmailAddress={supportEmailAddress}
-                            logoLinkUrl="https://www.cognizant.com/"
-                            logoUrl="/cognizant-logo-white.svg"
-                            sx={{borderTop: "none", marginTop: 0}}
-                        />
-                    </ErrorBoundary>
-                </NullableSessionProvider>
-            </>
+            <NullableSessionProvider>
+                <ErrorBoundary id="error_boundary">
+                    <NavbarWrapper
+                        id="nav-bar"
+                        logo={LOGO}
+                        logoServiceToken={logoServiceToken}
+                        query={query}
+                        pathname={pathname}
+                        authenticationType={authenticationType}
+                        signOut={handleSignOut}
+                        supportEmailAddress={supportEmailAddress}
+                    />
+                    <Container
+                        id="body-container"
+                        maxWidth={false}
+                        sx={{
+                            border: `solid 1px ${theme.palette.grey[300]}`,
+                            display: "flex",
+                            flex: 1,
+                            flexDirection: "column",
+                            minHeight: "90%",
+                        }}
+                    >
+                        {includeBreadcrumbs && <NeuroAIBreadcrumbs pathname={pathname} />}
+                        {getAppComponent()}
+                    </Container>
+                    <Footer
+                        supportEmailAddress={supportEmailAddress}
+                        logoLinkUrl="https://www.cognizant.com/"
+                        logoUrl="/cognizant-logo-white.svg"
+                        sx={{borderTop: "none", marginTop: 0}}
+                    />
+                </ErrorBoundary>
+            </NullableSessionProvider>
         )
     }
 
@@ -358,6 +355,7 @@ export const NeuroSanUI: FC<ExtendedAppProps> = ({Component, pageProps}): ReactJ
                     theme={theme}
                     noSsr={true}
                 >
+                    <CssBaseline />
                     {body}
                     <SnackbarProvider
                         Components={{

--- a/apps/main/pages/index.tsx
+++ b/apps/main/pages/index.tsx
@@ -22,6 +22,7 @@ import {useRouter} from "next/router"
 import {FC, JSX as ReactJSX} from "react"
 
 import {Footer} from "../../../packages/ui-common/components/Common/Footer"
+import {NeuroSanStudioCallout} from "../../../packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout"
 import {LOGO} from "../../../packages/ui-common/const"
 import {useEnvironmentStore} from "../../../packages/ui-common/state/Environment"
 import {CustomPageProps} from "../Types/Types"
@@ -179,7 +180,7 @@ export const Index: FC & CustomPageProps = Object.assign(
                                 <NavbarMiddleSection id="nav-bar-middle" />
                             </>
                         </Navbar>
-                        <div id="main-div">
+                        <Box id="main-div">
                             <HeaderLineOne id="header-line">
                                 <div
                                     id="headline-eyebrow"
@@ -220,7 +221,10 @@ export const Index: FC & CustomPageProps = Object.assign(
                                     </a>
                                 </Link>
                             </NeuroAIToolsContainer>
-                        </div>
+                            <Box sx={{my: 8, width: 360}}>
+                                <NeuroSanStudioCallout />
+                            </Box>
+                        </Box>
                     </BodyContent>
                     <Footer
                         supportEmailAddress={supportEmailAddress}

--- a/apps/main/styles/globals.css
+++ b/apps/main/styles/globals.css
@@ -77,8 +77,6 @@ limitations under the License.
     --bs-border-radius-xl: 1rem;
     --bs-border-radius-2xl: 2rem;
     --bs-border-radius-pill: 50rem;
-    --bs-link-color: var(--bs-secondary);
-    --bs-link-hover-color: var(--bs-primary);
     --bs-code-color: var(--bs-red);
     --bs-highlight-bg: var(--bs-white);
     --bs-button-bg: var(--bs-accent3-medium);
@@ -184,17 +182,6 @@ h5 {
 .small,
 small {
     font-size: 0.75rem;
-}
-
-a {
-    color: var(--bs-link-color);
-    font-weight: bold;
-    transition: all 0.3s ease;
-    text-decoration: none;
-
-    &:hover {
-        color: var(--bs-link-hover-color);
-    }
 }
 
 input {

--- a/apps/main/theme.ts
+++ b/apps/main/theme.ts
@@ -81,6 +81,20 @@ const DEFAULT_PALETTE = {
 export const createAppTheme = (primary: string, secondary: string, background: string) =>
     createTheme({
         components: {
+            MuiCssBaseline: {
+                styleOverrides: {
+                    // Custom link formatting: migrated from globals.css
+                    a: {
+                        color: cssVar("--bs-secondary"),
+                        fontWeight: "bold",
+                        transition: "all 0.3s ease",
+                        textDecoration: "none",
+                        "&:hover": {
+                            color: cssVar("--bs-primary"),
+                        },
+                    },
+                },
+            },
             MuiButton: {
                 styleOverrides: {
                     root: ({ownerState}) => ({

--- a/build_scripts/CommitCheck.sh
+++ b/build_scripts/CommitCheck.sh
@@ -50,4 +50,4 @@ run_check "tsc" yarn tsc
 run_check "knip" yarn knip
 run_check "prettier" yarn check-format
 run_check "eslint" yarn lint --max-warnings 0
-run_check "test" yarn test
+run_check "test" yarn test --coverage

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import {HumanMessage} from "@langchain/core/messages"
-import {act, render, screen, waitFor, within} from "@testing-library/react"
+import {act, render, screen, waitFor, waitForElementToBeRemoved, within} from "@testing-library/react"
 import {userEvent} from "@testing-library/user-event"
 import {SnackbarProvider} from "notistack"
 import {Children, isValidElement, ReactNode, Ref} from "react"
@@ -45,6 +45,7 @@ import {
     AgentNetworkDefinitionEntry,
     EXPIRED_NETWORKS_CHECK_INTERVAL_MS,
     GRACE_PERIOD_MS,
+    NEURO_SAN_CALLOUT_DELAY_MS,
     SHOW_TOUR_DELAY_MS,
     TEMPORARY_NETWORK_FOLDER,
     TRIGGER_APP_TOUR_EVENT_NAME,
@@ -67,6 +68,7 @@ import {
     ConnectivityInfo,
     FunctionResponse,
 } from "../../../generated/neuro-san/NeuroSanClient"
+import {AnnouncementId, useAnnouncementsStore} from "../../../state/Announcements"
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
 import {ByokKeyField, LLM_PROVIDER_API_KEY_FIELD, useSettingsStore} from "../../../state/Settings"
 import {TemporaryNetwork, useTempNetworksStore} from "../../../state/TemporaryNetworks"
@@ -275,6 +277,7 @@ describe("MultiAgentAccelerator", () => {
         useAgentChatHistoryStore.setState({history: {}})
         useSettingsStore.getState().resetSettings()
         useTourStore.getState().reset()
+        useAnnouncementsStore.getState().reset()
     })
 
     describe("Basic Rendering", () => {
@@ -1314,6 +1317,45 @@ describe("MultiAgentAccelerator", () => {
                 const lastCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1]
                 expect(lastCall[0]).toBeNull()
             })
+        })
+    })
+
+    describe("Announcement Handling", () => {
+        it("Should display the Neuro SAN Studio callout on a user's first visit", async () => {
+            const localUser = userEvent.setup({
+                advanceTimers: vi.advanceTimersByTime,
+            })
+
+            vi.useFakeTimers({now: Date.now()})
+            renderMultiAgentAcceleratorPage()
+
+            // Haven't shown announcement yet
+            expect(useAnnouncementsStore.getState().hasShown(AnnouncementId.NeuroSanStudioGithubStar)).toBe(false)
+
+            // Advance time to trigger the callout. Add 1000 to give Slide animation time to complete
+            act(() => {
+                vi.advanceTimersByTime(NEURO_SAN_CALLOUT_DELAY_MS + 1000)
+            })
+
+            // Verify the callout is displayed
+            const title = await screen.findByText(/Star us on GitHub/u)
+            expect(title).toBeVisible()
+
+            const link = title.closest("a")
+
+            expect(link).toBeVisible()
+            expect(link).toHaveAttribute("href", "https://github.com/cognizant-ai-lab/neuro-san-studio")
+
+            // Now dismiss it
+            const closeButton = screen.getByLabelText(/Close Neuro SAN Studio callout/iu)
+
+            expect(closeButton).toBeVisible()
+            await localUser.click(closeButton)
+
+            await waitForElementToBeRemoved(() => screen.queryByText(/Star us on GitHub/u))
+
+            // Should have updated the announcements store to indicate announcement dismissed
+            expect(useAnnouncementsStore.getState().hasShown(AnnouncementId.NeuroSanStudioGithubStar)).toBe(true)
         })
     })
 

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -277,341 +277,430 @@ describe("MultiAgentAccelerator", () => {
         useTourStore.getState().reset()
     })
 
-    it("should render the component and change the network when item is clicked in the sidebar", async () => {
-        renderMultiAgentAcceleratorPage()
+    describe("Basic Rendering", () => {
+        it("should render the component and change the network when item is clicked in the sidebar", async () => {
+            renderMultiAgentAcceleratorPage()
 
-        // click to expand networks
-        const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
-        await user.click(header)
+            // click to expand networks
+            const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
+            await user.click(header)
 
-        // Ensure Math Guy (default network) element is rendered.
-        await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY)
+            // Ensure Math Guy (default network) element is rendered.
+            await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY)
 
-        // Find sidebar. Will fail if <> 1 found
-        await screen.findByText("Agent Networks")
+            // Find sidebar. Will fail if <> 1 found
+            await screen.findByText("Agent Networks")
 
-        // Ensure Music Nerd is initially shown once. Will fail if <> 1 found
-        const musicNerdItem = await screen.findByText(TEST_AGENT_MUSIC_NERD_DISPLAY)
+            // Ensure Music Nerd is initially shown once. Will fail if <> 1 found
+            const musicNerdItem = await screen.findByText(TEST_AGENT_MUSIC_NERD_DISPLAY)
 
-        // Click Music Nerd sidebar item
-        await user.click(musicNerdItem)
+            // Click Music Nerd sidebar item
+            await user.click(musicNerdItem)
 
-        // Music Nerd is selected now. Make sure we see it.
-        await screen.findByText(TEST_AGENT_MUSIC_NERD_DISPLAY)
+            // Music Nerd is selected now. Make sure we see it.
+            await screen.findByText(TEST_AGENT_MUSIC_NERD_DISPLAY)
 
-        // Make sure the page rendered ChatCommon with expected props
-        expect(chatCommonMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                currentUser: MOCK_USER,
-                selectedNetwork: `${TEST_AGENTS_FOLDER}/${TEST_AGENT_MUSIC_NERD}`,
-                neuroSanURL: NEURO_SAN_SERVER_URL,
-                sampleQueries: MOCK_CONNECTIVITY_INFO.metadata["sample_queries"],
-            })
-        )
-    })
-
-    it("should render the component correctly with 'native names' option on or off", async () => {
-        useSettingsStore.getState().updateSettings({appearance: {useNativeNames: false}})
-        renderMultiAgentAcceleratorPage()
-
-        // click to expand networks
-        const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
-        await user.click(header)
-
-        // Ensure Math Guy (default network) element is rendered.
-        screen.getByText(TEST_AGENT_MATH_GUY_DISPLAY)
-
-        // Now toggle the setting to use native names
-        act(() => {
-            useSettingsStore.getState().updateSettings({appearance: {useNativeNames: true}})
-        })
-
-        // Now the native agent names should be shown instead of the cleaned up display names
-        screen.getByText(TEST_AGENTS_FOLDER)
-        screen.getByText(TEST_AGENT_MATH_GUY)
-    })
-
-    it("should handle a network with no sample queries", async () => {
-        vi.mocked(getConnectivity).mockResolvedValue({
-            ...MOCK_CONNECTIVITY_INFO,
-            metadata: {},
-        })
-        renderMultiAgentAcceleratorPage()
-
-        // Expand networks
-        const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
-        await user.click(header)
-
-        // Select a network to trigger getConnectivity
-        const network = await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY)
-        await user.click(network)
-
-        // Make sure the page rendered ChatCommon with expected props
-        expect(chatCommonMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sampleQueries: [],
-            })
-        )
-    })
-
-    it("should display error toast when an error occurs for getAgentNetworks", async () => {
-        const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
-        // Mock getAgentNetworks to reject with an error
-        vi.mocked(getAgentNetworks).mockRejectedValue(new Error("Failed to fetch agent networks"))
-
-        renderMultiAgentAcceleratorPage()
-
-        // Assert the console.debug call
-        await waitFor(() => {
-            expect(debugSpy).toHaveBeenCalledWith(
-                expect.stringMatching(new RegExp(`Unable to get list of Agent Networks.*${NEURO_SAN_SERVER_URL}`, "u"))
+            // Make sure the page rendered ChatCommon with expected props
+            expect(chatCommonMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    currentUser: MOCK_USER,
+                    selectedNetwork: `${TEST_AGENTS_FOLDER}/${TEST_AGENT_MUSIC_NERD}`,
+                    neuroSanURL: NEURO_SAN_SERVER_URL,
+                    sampleQueries: MOCK_CONNECTIVITY_INFO.metadata["sample_queries"],
+                })
             )
         })
+
+        it("should render the component correctly with 'native names' option on or off", async () => {
+            useSettingsStore.getState().updateSettings({appearance: {useNativeNames: false}})
+            renderMultiAgentAcceleratorPage()
+
+            // click to expand networks
+            const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
+            await user.click(header)
+
+            // Ensure Math Guy (default network) element is rendered.
+            screen.getByText(TEST_AGENT_MATH_GUY_DISPLAY)
+
+            // Now toggle the setting to use native names
+            act(() => {
+                useSettingsStore.getState().updateSettings({appearance: {useNativeNames: true}})
+            })
+
+            // Now the native agent names should be shown instead of the cleaned up display names
+            screen.getByText(TEST_AGENTS_FOLDER)
+            screen.getByText(TEST_AGENT_MATH_GUY)
+        })
+
+        it("should handle a network with no sample queries", async () => {
+            vi.mocked(getConnectivity).mockResolvedValue({
+                ...MOCK_CONNECTIVITY_INFO,
+                metadata: {},
+            })
+            renderMultiAgentAcceleratorPage()
+
+            // Expand networks
+            const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
+            await user.click(header)
+
+            // Select a network to trigger getConnectivity
+            const network = await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY)
+            await user.click(network)
+
+            // Make sure the page rendered ChatCommon with expected props
+            expect(chatCommonMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sampleQueries: [],
+                })
+            )
+        })
+
+        it("Should pass along network icon suggestions to the sidebar", async () => {
+            const iconSuggestions = {
+                copy_cat: "Copy",
+                date_time_provider: "DateTime",
+            } satisfies NetworkIconSuggestions
+
+            vi.mocked(getNetworkIconSuggestions).mockResolvedValue(iconSuggestions)
+
+            renderMultiAgentAcceleratorPage()
+
+            await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
+
+            await waitFor(() => expect(networkIconSuggestionsMock).toHaveBeenCalledWith(iconSuggestions))
+        })
     })
 
-    it("should display error toast when an error occurs for getConnectivity", async () => {
-        const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
-        // Mock getAgentNetworks to reject with an error
-        vi.mocked(getConnectivity).mockRejectedValue(new Error("Failed to fetch connectivity"))
+    describe("Error Handling", () => {
+        it("should display error toast when an error occurs for getAgentNetworks", async () => {
+            const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
+            // Mock getAgentNetworks to reject with an error
+            vi.mocked(getAgentNetworks).mockRejectedValue(new Error("Failed to fetch agent networks"))
 
-        renderMultiAgentAcceleratorPage()
+            renderMultiAgentAcceleratorPage()
 
-        // Expand networks
-        const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
-        await user.click(header)
-
-        // Select a network to trigger getConnectivity
-        const network = await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY)
-        await user.click(network)
-
-        // Assert the console.error call
-        await waitFor(() => {
-            expect(debugSpy).toHaveBeenCalledWith(
-                expect.stringMatching(
-                    new RegExp(
-                        "Unable to get agent list.*" +
-                            `${TEST_AGENTS_FOLDER_DISPLAY} ${TEST_AGENT_MATH_GUY_DISPLAY}.*${NEURO_SAN_SERVER_URL}.*`,
-                        "u"
+            // Assert the console.debug call
+            await waitFor(() => {
+                expect(debugSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(
+                        new RegExp(`Unable to get list of Agent Networks.*${NEURO_SAN_SERVER_URL}`, "u")
                     )
                 )
-            )
+            })
+        })
+
+        it("should display error toast when an error occurs for getConnectivity", async () => {
+            const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
+            // Mock getAgentNetworks to reject with an error
+            vi.mocked(getConnectivity).mockRejectedValue(new Error("Failed to fetch connectivity"))
+
+            renderMultiAgentAcceleratorPage()
+
+            // Expand networks
+            const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
+            await user.click(header)
+
+            // Select a network to trigger getConnectivity
+            const network = await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY)
+            await user.click(network)
+
+            // Assert the console.error call
+            await waitFor(() => {
+                expect(debugSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(
+                        new RegExp(
+                            "Unable to get agent list.*" +
+                                `${TEST_AGENTS_FOLDER_DISPLAY} ${TEST_AGENT_MATH_GUY_DISPLAY}` +
+                                `.*${NEURO_SAN_SERVER_URL}.*`,
+                            "u"
+                        )
+                    )
+                )
+            })
+        })
+
+        it("Should handle getNetworkIconSuggestions failure gracefully", async () => {
+            vi.mocked(getNetworkIconSuggestions).mockRejectedValue(new Error("Failed to fetch icon suggestions"))
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn())
+            renderMultiAgentAcceleratorPage()
+            await waitFor(() => {
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining("Unable to get network icon suggestions"),
+                    expect.any(Error)
+                )
+            })
         })
     })
 
-    it("should handle Zen mode animation correctly", async () => {
-        renderMultiAgentAcceleratorPage()
+    describe("Zen Mode", () => {
+        it("should handle Zen mode animation correctly", async () => {
+            renderMultiAgentAcceleratorPage()
 
-        await screen.findByText("Agent Networks")
+            await screen.findByText("Agent Networks")
 
-        // Left panel: Make sure sidebar is visible
-        await waitFor(() => {
+            // Left panel: Make sure sidebar is visible
+            await waitFor(() => {
+                expect(document.getElementById("multi-agent-accelerator-sidebar-sidebar")).toBeVisible()
+            })
+
+            // Center panel: Agent Flow
+            await waitFor(() => {
+                expect(document.getElementById("multi-agent-accelerator-agent-flow-container")).toBeVisible()
+            })
+
+            // Right panel: Chat window
+            expect(await screen.findByTestId("test-chat-common")).toBeVisible()
+
+            // Make sure Stop button is not in document
+            expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument()
+
+            // Force Zen mode by setting isAwaitingLlm to true
+            await act(async () => {
+                setIsAwaitingLlm(true)
+            })
+
+            // Stop button should be in document in Zen mode
+            await screen.findByLabelText("Stop")
+
+            // Left panel: should be hidden in Zen mode
+            await waitFor(() => {
+                expect(document.getElementById("multi-agent-accelerator-sidebar-sidebar")).not.toBeVisible()
+            })
+
+            // Center panel: Agent Flow. Should still be visible in Zen mode
+            await waitFor(() => {
+                expect(document.getElementById("multi-agent-accelerator-agent-flow-container")).toBeVisible()
+            })
+
+            // Right panel: Chat window should be hidden in Zen mode
+            expect(await screen.findByTestId("test-chat-common")).not.toBeVisible()
+        })
+
+        it("should correctly handle Zen mode being disabled", async () => {
+            // Disable Zen mode
+            useSettingsStore.getState().updateSettings({behavior: {enableZenMode: false}})
+
+            renderMultiAgentAcceleratorPage()
+
+            screen.getByText("Agent Networks")
+
+            await act(async () => {
+                setIsAwaitingLlm(true)
+            })
+
+            // Panels should all still be visible even with isAwaitingLlm true because Zen mode is disabled
+            // Left panel: should be hidden in Zen mode
             expect(document.getElementById("multi-agent-accelerator-sidebar-sidebar")).toBeVisible()
-        })
 
-        // Center panel: Agent Flow
-        await waitFor(() => {
+            // Center panel: Agent Flow. Should always be visible
             expect(document.getElementById("multi-agent-accelerator-agent-flow-container")).toBeVisible()
-        })
 
-        // Right panel: Chat window
-        expect(await screen.findByTestId("test-chat-common")).toBeVisible()
-
-        // Make sure Stop button is not in document
-        expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument()
-
-        // Force Zen mode by setting isAwaitingLlm to true
-        await act(async () => {
-            setIsAwaitingLlm(true)
-        })
-
-        // Stop button should be in document in Zen mode
-        await screen.findByLabelText("Stop")
-
-        // Left panel: should be hidden in Zen mode
-        await waitFor(() => {
-            expect(document.getElementById("multi-agent-accelerator-sidebar-sidebar")).not.toBeVisible()
-        })
-
-        // Center panel: Agent Flow. Should still be visible in Zen mode
-        await waitFor(() => {
-            expect(document.getElementById("multi-agent-accelerator-agent-flow-container")).toBeVisible()
-        })
-
-        // Right panel: Chat window should be hidden in Zen mode
-        expect(await screen.findByTestId("test-chat-common")).not.toBeVisible()
-    })
-
-    it("should correctly handle Zen mode being disabled", async () => {
-        // Disable Zen mode
-        useSettingsStore.getState().updateSettings({behavior: {enableZenMode: false}})
-
-        renderMultiAgentAcceleratorPage()
-
-        screen.getByText("Agent Networks")
-
-        await act(async () => {
-            setIsAwaitingLlm(true)
-        })
-
-        // Panels should all still be visible even with isAwaitingLlm true because Zen mode is disabled
-        // Left panel: should be hidden in Zen mode
-        expect(document.getElementById("multi-agent-accelerator-sidebar-sidebar")).toBeVisible()
-
-        // Center panel: Agent Flow. Should always be visible
-        expect(document.getElementById("multi-agent-accelerator-agent-flow-container")).toBeVisible()
-
-        // Right panel: Chat window should be hidden in Zen mode
-        expect(await screen.findByTestId("test-chat-common")).toBeVisible()
-    })
-
-    it("calls handleStopMock on Escape key when isAwaitingLlm is true", async () => {
-        renderMultiAgentAcceleratorPage()
-
-        await act(async () => {
-            setIsAwaitingLlm(true)
-        })
-
-        // Simulate Escape key
-        await userEvent.keyboard("{Escape}")
-
-        expect(handleStopMock).toHaveBeenCalledTimes(1)
-    })
-
-    it("ignores presses of keys other than Escape", async () => {
-        renderMultiAgentAcceleratorPage()
-
-        await act(async () => {
-            setIsAwaitingLlm(true)
-        })
-
-        // Simulate Escape key
-        await userEvent.keyboard("{Enter}")
-
-        expect(handleStopMock).not.toHaveBeenCalled()
-    })
-
-    it("Should clear the chat when the Add New Network button is clicked", async () => {
-        renderMultiAgentAcceleratorPage()
-        await screen.findByTestId("test-chat-common")
-
-        handleClearChatMock.mockClear()
-
-        const addButton = screen.getByRole("button", {name: "Add New Network"})
-        await userEvent.click(addButton)
-
-        expect(handleClearChatMock).toHaveBeenCalledTimes(1)
-    })
-
-    it("Should NOT clear the chat when a regular network is selected", async () => {
-        renderMultiAgentAcceleratorPage()
-        await screen.findByTestId("test-chat-common")
-
-        handleClearChatMock.mockClear()
-
-        await act(async () => {
-            setSelectedNetwork(`${TEST_AGENTS_FOLDER}/${TEST_AGENT_MATH_GUY}`)
-        })
-
-        expect(handleClearChatMock).not.toHaveBeenCalled()
-    })
-
-    it("should handle receiving an agent conversation chat message", async () => {
-        renderMultiAgentAcceleratorPage()
-
-        // Simulate receiving a chat message
-        const mockChunk = JSON.stringify(MATH_GUY_MESSAGE)
-
-        await act(async () => {
-            onChunkReceived(mockChunk)
-        })
-
-        expect(chatCommonMock).toHaveBeenCalled()
-
-        // Verify the conversations array contains the expected agent
-        const conversationCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1][0]
-        const hasAgent = conversationCall.some((conv: {agents: Set<string>}) =>
-            [...conv.agents].includes(TEST_AGENT_MATH_GUY)
-        )
-        expect(hasAgent).toBe(true)
-    })
-
-    it("should handle receiving a bad message", async () => {
-        // Make extractConversations return failure (null) for this one test to simulate a critical error
-        const agentConversations = await import("../../../components/MultiAgentAccelerator/AgentConversations")
-        vi.spyOn(agentConversations, "extractConversations").mockReturnValue(null)
-
-        renderMultiAgentAcceleratorPage()
-
-        // Simulate receiving a chat message
-        const mockChunk = JSON.stringify(MATH_GUY_MESSAGE)
-
-        await act(async () => {
-            onChunkReceived(mockChunk)
-        })
-
-        expect(chatCommonMock).toHaveBeenCalled()
-
-        // Verify the conversations array contains the expected agent
-        const calls = conversationMock.mock.calls
-
-        // Assert that conversationMock was always called with an empty array (no conversations)
-        // due to the failure in extractConversations
-        calls.forEach((call) => {
-            expect(call[0]).toEqual([])
+            // Right panel: Chat window should be hidden in Zen mode
+            expect(await screen.findByTestId("test-chat-common")).toBeVisible()
         })
     })
 
-    it("should handle receiving an end of conversation chat message", async () => {
-        renderMultiAgentAcceleratorPage()
+    describe("Chat Message Handling", () => {
+        it("should handle receiving an agent conversation chat message", async () => {
+            renderMultiAgentAcceleratorPage()
 
-        // Set up one active agent
-        const activeAgentChunk = JSON.stringify(MATH_GUY_MESSAGE)
-        await act(async () => {
-            onChunkReceived(activeAgentChunk)
+            // Simulate receiving a chat message
+            const mockChunk = JSON.stringify(MATH_GUY_MESSAGE)
+
+            await act(async () => {
+                onChunkReceived(mockChunk)
+            })
+
+            expect(chatCommonMock).toHaveBeenCalled()
+
+            // Verify the conversations array contains the expected agent
+            const conversationCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1][0]
+            const hasAgent = conversationCall.some((conv: {agents: Set<string>}) =>
+                [...conv.agents].includes(TEST_AGENT_MATH_GUY)
+            )
+            expect(hasAgent).toBe(true)
         })
 
-        // Verify the conversation mock was called
-        expect(conversationMock).toHaveBeenCalled()
+        it("should handle receiving a bad message", async () => {
+            // Make extractConversations return failure (null) for this one test to simulate a critical error
+            const agentConversations = await import("../../../components/MultiAgentAccelerator/AgentConversations")
+            vi.spyOn(agentConversations, "extractConversations").mockReturnValue(null)
 
-        // End of conversation message for unrelated agent
-        const endOfConversationDifferentAgent: ChatResponse = {
-            response: {
-                type: ChatMessageType.AGENT,
-                text: "This is a test message",
-                // One of "hints" for end of conversation is having a structure field containing total_tokens
-                structure: {total_tokens: 100},
-                origin: [{tool: "Definitely not math guy"}],
-            },
-        }
+            renderMultiAgentAcceleratorPage()
 
-        await act(async () => {
-            onChunkReceived(JSON.stringify(endOfConversationDifferentAgent))
+            // Simulate receiving a chat message
+            const mockChunk = JSON.stringify(MATH_GUY_MESSAGE)
+
+            await act(async () => {
+                onChunkReceived(mockChunk)
+            })
+
+            expect(chatCommonMock).toHaveBeenCalled()
+
+            // Verify the conversations array contains the expected agent
+            const calls = conversationMock.mock.calls
+
+            // Assert that conversationMock was always called with an empty array (no conversations)
+            // due to the failure in extractConversations
+            calls.forEach((call) => {
+                expect(call[0]).toEqual([])
+            })
         })
 
-        // Verify Math Guy is still in the conversations
-        expect(conversationMock).toHaveBeenCalled()
-        const latestCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1][0]
-        const hasMathGuy = latestCall.some((conv: {agents: Set<string>}) => conv.agents.has(TEST_AGENT_MATH_GUY))
-        expect(hasMathGuy).toBe(true)
+        it("should handle receiving an end of conversation chat message", async () => {
+            renderMultiAgentAcceleratorPage()
 
-        conversationMock.mockClear()
+            // Set up one active agent
+            const activeAgentChunk = JSON.stringify(MATH_GUY_MESSAGE)
+            await act(async () => {
+                onChunkReceived(activeAgentChunk)
+            })
 
-        // Now the end of conversation message for the active agent
-        const chatMessage: ChatResponse = {
-            response: {
-                type: ChatMessageType.AGENT,
-                text: "This is a test message",
-                structure: {total_tokens: 100},
-                origin: [{tool: TEST_AGENT_MATH_GUY}],
-            },
-        }
+            // Verify the conversation mock was called
+            expect(conversationMock).toHaveBeenCalled()
 
-        await act(async () => {
-            onChunkReceived(JSON.stringify(chatMessage))
+            // End of conversation message for unrelated agent
+            const endOfConversationDifferentAgent: ChatResponse = {
+                response: {
+                    type: ChatMessageType.AGENT,
+                    text: "This is a test message",
+                    // One of "hints" for end of conversation is having a structure field containing total_tokens
+                    structure: {total_tokens: 100},
+                    origin: [{tool: "Definitely not math guy"}],
+                },
+            }
+
+            await act(async () => {
+                onChunkReceived(JSON.stringify(endOfConversationDifferentAgent))
+            })
+
+            // Verify Math Guy is still in the conversations
+            expect(conversationMock).toHaveBeenCalled()
+            const latestCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1][0]
+            const hasMathGuy = latestCall.some((conv: {agents: Set<string>}) => conv.agents.has(TEST_AGENT_MATH_GUY))
+            expect(hasMathGuy).toBe(true)
+
+            conversationMock.mockClear()
+
+            // Now the end of conversation message for the active agent
+            const chatMessage: ChatResponse = {
+                response: {
+                    type: ChatMessageType.AGENT,
+                    text: "This is a test message",
+                    structure: {total_tokens: 100},
+                    origin: [{tool: TEST_AGENT_MATH_GUY}],
+                },
+            }
+
+            await act(async () => {
+                onChunkReceived(JSON.stringify(chatMessage))
+            })
+        })
+
+        it("Should handle receiving something that isn't a ChatMessage", async () => {
+            renderMultiAgentAcceleratorPage()
+            await act(async () => {
+                const result = onChunkReceived("I am not a ChatMessage")
+                expect(result).toEqual(true)
+            })
+        })
+    })
+
+    describe("Interaction Handling", () => {
+        it("calls handleStopMock on Escape key when isAwaitingLlm is true", async () => {
+            renderMultiAgentAcceleratorPage()
+
+            await act(async () => {
+                setIsAwaitingLlm(true)
+            })
+
+            // Simulate Escape key
+            await userEvent.keyboard("{Escape}")
+
+            expect(handleStopMock).toHaveBeenCalledTimes(1)
+        })
+
+        it("ignores presses of keys other than Escape", async () => {
+            renderMultiAgentAcceleratorPage()
+
+            await act(async () => {
+                setIsAwaitingLlm(true)
+            })
+
+            // Simulate Escape key
+            await userEvent.keyboard("{Enter}")
+
+            expect(handleStopMock).not.toHaveBeenCalled()
+        })
+
+        it("Should clear the chat when the Add New Network button is clicked", async () => {
+            renderMultiAgentAcceleratorPage()
+            await screen.findByTestId("test-chat-common")
+
+            handleClearChatMock.mockClear()
+
+            const addButton = screen.getByRole("button", {name: "Add New Network"})
+            await userEvent.click(addButton)
+
+            expect(handleClearChatMock).toHaveBeenCalledTimes(1)
+        })
+
+        it("Should NOT clear the chat when a regular network is selected", async () => {
+            renderMultiAgentAcceleratorPage()
+            await screen.findByTestId("test-chat-common")
+
+            handleClearChatMock.mockClear()
+
+            await act(async () => {
+                setSelectedNetwork(`${TEST_AGENTS_FOLDER}/${TEST_AGENT_MATH_GUY}`)
+            })
+
+            expect(handleClearChatMock).not.toHaveBeenCalled()
+        })
+
+        it("Should not allow user to select an expired temporary network", async () => {
+            const expiredTemporaryNetwork: TemporaryNetwork = {
+                ...TEMPORARY_NETWORK,
+                reservation: {
+                    ...TEMPORARY_NETWORK.reservation,
+                    expiration_time_in_seconds: Math.floor(Date.now() / 1000) - 60,
+                },
+            }
+
+            useTempNetworksStore.setState({tempNetworks: [expiredTemporaryNetwork]})
+
+            renderMultiAgentAcceleratorPage()
+
+            // Expand temporary networks section
+            const header = await screen.findByText(cleanUpAgentName(TEMPORARY_NETWORK_FOLDER))
+            await user.click(header)
+
+            const displayAgentName = cleanUpAgentName(expiredTemporaryNetwork.agentNetworkName)
+            const tempNetworkItem = await screen.findByText(displayAgentName)
+
+            // Mouse over -- should get "expired" Tooltip
+            await user.hover(tempNetworkItem)
+            await screen.findByText(/Expired/u)
+
+            // Clear previous mock calls
+            chatCommonMock.mockClear()
+
+            await user.click(tempNetworkItem)
+
+            // Network expired; clicking should have no effect
+            expect(chatCommonMock).not.toHaveBeenCalled()
         })
     })
 
     describe("Agent Network Designer integration", () => {
+        type NetworkDesignerErrorScenario = {
+            readonly scenario: string
+            readonly streamChunks: string[]
+            readonly agentNetworkName: string
+            readonly expectedLog: string
+        }
+
         // Render the page, feed the default reservation chunk, and wait until the resulting temp network shows
         // up in `temporaryNetworksMock`. Returns the expected agent name for follow-up assertions.
         const seedTemporaryNetworkFromDefaultReservation = async (): Promise<string> => {
@@ -633,6 +722,25 @@ describe("MultiAgentAccelerator", () => {
             })
             return expectedAgentName
         }
+        const UPDATED_DEFINITION: AgentNetworkDefinitionEntry[] = [{origin: "copy_cat", tools: []}]
+
+        // Mock the network designer stream so onSaveAgent's chunk collector receives the given chunks.
+        const mockDesignerStream = (...chunks: string[]) => {
+            vi.mocked(sendNetworkDesignerRequest).mockImplementation(async (...args: unknown[]) => {
+                const onChunk = args[6] as (chunk: string) => void
+                chunks.forEach((chunk) => onChunk(chunk))
+            })
+        }
+
+        const renderAndWaitForSidebar = async () => {
+            renderMultiAgentAcceleratorPage()
+            await screen.findByText("Agent Networks")
+        }
+
+        const saveAgent = (agentNetworkName = RESERVATION.reservation_id) =>
+            act(async () => {
+                await onSaveAgent("copy_cat", UPDATED_DEFINITION, agentNetworkName, new AbortController().signal)
+            })
 
         it("Should detect agent registrations in the chat stream", async () => {
             renderMultiAgentAcceleratorPage()
@@ -1110,92 +1218,106 @@ describe("MultiAgentAccelerator", () => {
             // Chat history for the reaped network should also be gone.
             expect(useAgentChatHistoryStore.getState().history[expectedNetworkName]).toBeUndefined()
         })
-    })
 
-    it("Should not allow user to select an expired temporary network", async () => {
-        const expiredTemporaryNetwork: TemporaryNetwork = {
-            ...TEMPORARY_NETWORK,
-            reservation: {
-                ...TEMPORARY_NETWORK.reservation,
-                expiration_time_in_seconds: Math.floor(Date.now() / 1000) - 60,
-            },
-        }
+        it("upserts the returned network and re-selects it when a matching reservation is streamed", async () => {
+            mockDesignerStream(JSON.stringify(RESERVATION_CHAT_MESSAGE))
+            renderMultiAgentAcceleratorPage()
 
-        useTempNetworksStore.setState({tempNetworks: [expiredTemporaryNetwork]})
+            // Select a network so onSaveAgent has a selectedNetwork to copy chat history from.
+            const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
+            await user.click(header)
+            await user.click(await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY))
 
-        renderMultiAgentAcceleratorPage()
+            await saveAgent()
 
-        // Expand temporary networks section
-        const header = await screen.findByText(cleanUpAgentName(TEMPORARY_NETWORK_FOLDER))
-        await user.click(header)
-
-        const displayAgentName = cleanUpAgentName(expiredTemporaryNetwork.agentNetworkName)
-        const tempNetworkItem = await screen.findByText(displayAgentName)
-
-        // Mouse over -- should get "expired" Tooltip
-        await user.hover(tempNetworkItem)
-        await screen.findByText(/Expired/u)
-
-        // Clear previous mock calls
-        chatCommonMock.mockClear()
-
-        await user.click(tempNetworkItem)
-
-        // Network expired; clicking should have no effect
-        expect(chatCommonMock).not.toHaveBeenCalled()
-    })
-
-    it("Should pass along network icon suggestions to the sidebar", async () => {
-        const iconSuggestions = {
-            copy_cat: "Copy",
-            date_time_provider: "DateTime",
-        } satisfies NetworkIconSuggestions
-
-        vi.mocked(getNetworkIconSuggestions).mockResolvedValue(iconSuggestions)
-
-        renderMultiAgentAcceleratorPage()
-
-        await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
-
-        await waitFor(() => expect(networkIconSuggestionsMock).toHaveBeenCalledWith(iconSuggestions))
-    })
-
-    it("Should handle getNetworkIconSuggestions failure gracefully", async () => {
-        vi.mocked(getNetworkIconSuggestions).mockRejectedValue(new Error("Failed to fetch icon suggestions"))
-
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn())
-        renderMultiAgentAcceleratorPage()
-        await waitFor(() => {
-            expect(warnSpy).toHaveBeenCalledWith(
-                expect.stringContaining("Unable to get network icon suggestions"),
-                expect.any(Error)
+            const expectedAgentName = `${TEMPORARY_NETWORK_FOLDER}/${RESERVATION.reservation_id}`
+            // The returned reservation was upserted into the temp networks store...
+            expect(useTempNetworksStore.getState().tempNetworks).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        agentInfo: expect.objectContaining({agent_name: expectedAgentName}),
+                    }),
+                ])
             )
+            // ...and the newly-saved network became the selected target.
+            await waitFor(() => {
+                expect(chatCommonMock).toHaveBeenCalledWith(
+                    expect.objectContaining({selectedNetwork: expectedAgentName})
+                )
+            })
+        })
+
+        it.each<NetworkDesignerErrorScenario>([
+            {
+                scenario: "the designer returns no reservation",
+                streamChunks: [] as string[],
+                agentNetworkName: RESERVATION.reservation_id,
+                expectedLog: "did not return a reservation",
+            },
+            {
+                scenario: "the returned reservation does not match the edited network",
+                streamChunks: [JSON.stringify(RESERVATION_CHAT_MESSAGE)],
+                // agentNetworkName does not match the streamed reservation's derived name → no replacement found.
+                agentNetworkName: "some-other-network",
+                expectedLog: "did not match the current network",
+            },
+        ])(
+            "shows an error and does not upsert when $scenario",
+            async ({streamChunks, agentNetworkName, expectedLog}) => {
+                const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
+                mockDesignerStream(...streamChunks)
+                await renderAndWaitForSidebar()
+
+                await saveAgent(agentNetworkName)
+
+                expect(useTempNetworksStore.getState().tempNetworks).toHaveLength(0)
+                expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining(expectedLog))
+            }
+        )
+
+        it("notifies a save error when the network designer stream throws", async () => {
+            const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
+            const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn())
+            vi.mocked(sendNetworkDesignerRequest).mockRejectedValue(new Error("stream exploded"))
+            await renderAndWaitForSidebar()
+
+            await saveAgent()
+
+            expect(errorSpy).toHaveBeenCalled()
+            expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("stream exploded"))
+        })
+
+        it("suppresses the error notification when the save is aborted by the user", async () => {
+            vi.mocked(sendNetworkDesignerRequest).mockRejectedValue(
+                new DOMException("The operation was aborted", "AbortError")
+            )
+            await renderAndWaitForSidebar()
+
+            // No console spies: an AbortError must be swallowed silently (no console.error / notification),
+            // so any logging here would fail the test via jest-fail-on-console.
+            await saveAgent()
+
+            expect(useTempNetworksStore.getState().tempNetworks).toHaveLength(0)
         })
     })
 
-    it("Should handle receiving something that isn't a ChatMessage", async () => {
-        renderMultiAgentAcceleratorPage()
-        await act(async () => {
-            const result = onChunkReceived("I am not a ChatMessage")
-            expect(result).toEqual(true)
+    describe("Event Handling", () => {
+        it("should reset conversations onStreamingComplete is called", async () => {
+            renderMultiAgentAcceleratorPage()
+
+            await act(async () => {
+                onStreamingComplete()
+            })
+
+            // Verify conversations were cleared by checking the AgentFlow prop
+            await waitFor(() => {
+                const lastCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1]
+                expect(lastCall[0]).toBeNull()
+            })
         })
     })
 
-    it("should show reset conversations onStreamingComplete is called", async () => {
-        renderMultiAgentAcceleratorPage()
-
-        await act(async () => {
-            onStreamingComplete()
-        })
-
-        // Verify conversations were cleared by checking the AgentFlow prop
-        await waitFor(() => {
-            const lastCall = conversationMock.mock.calls[conversationMock.mock.calls.length - 1]
-            expect(lastCall[0]).toBeNull()
-        })
-    })
-
-    describe("extraSlyData", () => {
+    describe("extraSlyData Handling", () => {
         const agentNetworkDefinition = [
             {origin: "agent1", tools: [] as string[], display_as: "llm_agent", instructions: "Do stuff."},
         ]
@@ -1203,6 +1325,13 @@ describe("MultiAgentAccelerator", () => {
         const tempNetworkWithDefinition: TemporaryNetwork = {
             ...TEMPORARY_NETWORK,
             agentNetworkDefinition,
+        }
+
+        const badProvider = "not_a_known_provider"
+
+        type ByokTestCase = {
+            readonly required: ByokKeyField[]
+            readonly expectedMissing: boolean
         }
 
         it("is undefined for a permanent network", async () => {
@@ -1279,13 +1408,6 @@ describe("MultiAgentAccelerator", () => {
                 )
             })
         })
-
-        const badProvider = "not_a_known_provider"
-
-        type ByokTestCase = {
-            readonly required: ByokKeyField[]
-            readonly expectedMissing: boolean
-        }
 
         it.each<ByokTestCase>([
             {required: [LLM_PROVIDER_API_KEY_FIELD["OpenAI"]], expectedMissing: true},
@@ -1365,110 +1487,13 @@ describe("MultiAgentAccelerator", () => {
         })
     })
 
-    describe("onSaveAgent", () => {
-        const UPDATED_DEFINITION: AgentNetworkDefinitionEntry[] = [{origin: "copy_cat", tools: []}]
-
-        // Mock the network designer stream so onSaveAgent's chunk collector receives the given chunks.
-        const mockDesignerStream = (...chunks: string[]) => {
-            vi.mocked(sendNetworkDesignerRequest).mockImplementation(async (...args: unknown[]) => {
-                const onChunk = args[6] as (chunk: string) => void
-                chunks.forEach((chunk) => onChunk(chunk))
-            })
-        }
-
-        const renderAndWaitForSidebar = async () => {
-            renderMultiAgentAcceleratorPage()
-            await screen.findByText("Agent Networks")
-        }
-
-        const saveAgent = (agentNetworkName = RESERVATION.reservation_id) =>
-            act(async () => {
-                await onSaveAgent("copy_cat", UPDATED_DEFINITION, agentNetworkName, new AbortController().signal)
-            })
-
-        it("upserts the returned network and reselects it when a matching reservation is streamed", async () => {
-            mockDesignerStream(JSON.stringify(RESERVATION_CHAT_MESSAGE))
-            renderMultiAgentAcceleratorPage()
-
-            // Select a network so onSaveAgent has a selectedNetwork to copy chat history from.
-            const header = await screen.findByText(TEST_AGENTS_FOLDER_DISPLAY)
-            await user.click(header)
-            await user.click(await screen.findByText(TEST_AGENT_MATH_GUY_DISPLAY))
-
-            await saveAgent()
-
-            const expectedAgentName = `${TEMPORARY_NETWORK_FOLDER}/${RESERVATION.reservation_id}`
-            // The returned reservation was upserted into the temp networks store...
-            expect(useTempNetworksStore.getState().tempNetworks).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        agentInfo: expect.objectContaining({agent_name: expectedAgentName}),
-                    }),
-                ])
-            )
-            // ...and the newly-saved network became the selected target.
-            await waitFor(() => {
-                expect(chatCommonMock).toHaveBeenCalledWith(
-                    expect.objectContaining({selectedNetwork: expectedAgentName})
-                )
-            })
-        })
-
-        it.each([
-            {
-                scenario: "the designer returns no reservation",
-                streamChunks: [] as string[],
-                agentNetworkName: RESERVATION.reservation_id,
-                expectedLog: "did not return a reservation",
-            },
-            {
-                scenario: "the returned reservation does not match the edited network",
-                streamChunks: [JSON.stringify(RESERVATION_CHAT_MESSAGE)],
-                // agentNetworkName does not match the streamed reservation's derived name → no replacement found.
-                agentNetworkName: "some-other-network",
-                expectedLog: "did not match the current network",
-            },
-        ])(
-            "shows an error and does not upsert when $scenario",
-            async ({streamChunks, agentNetworkName, expectedLog}) => {
-                const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
-                mockDesignerStream(...streamChunks)
-                await renderAndWaitForSidebar()
-
-                await saveAgent(agentNetworkName)
-
-                expect(useTempNetworksStore.getState().tempNetworks).toHaveLength(0)
-                expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining(expectedLog))
-            }
-        )
-
-        it("notifies a save error when the network designer stream throws", async () => {
-            const debugSpy = vi.spyOn(console, "debug").mockImplementation(vi.fn())
-            const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn())
-            vi.mocked(sendNetworkDesignerRequest).mockRejectedValue(new Error("stream exploded"))
-            await renderAndWaitForSidebar()
-
-            await saveAgent()
-
-            expect(errorSpy).toHaveBeenCalled()
-            expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("stream exploded"))
-        })
-
-        it("suppresses the error notification when the save is aborted by the user", async () => {
-            vi.mocked(sendNetworkDesignerRequest).mockRejectedValue(
-                new DOMException("The operation was aborted", "AbortError")
-            )
-            await renderAndWaitForSidebar()
-
-            // No console spies: an AbortError must be swallowed silently (no console.error / notification),
-            // so any logging here would fail the test via jest-fail-on-console.
-            await saveAgent()
-
-            expect(useTempNetworksStore.getState().tempNetworks).toHaveLength(0)
-        })
-    })
-
     describe("Tour", () => {
+        type TourScenario = {
+            readonly buttonName: string
+            readonly shouldStartTour: boolean
+            readonly expectedStatus: TourPromptState
+        }
+
         it("should run the tour when requested and successfully visit each step", async () => {
             renderMultiAgentAcceleratorPage()
 
@@ -1501,7 +1526,7 @@ describe("MultiAgentAccelerator", () => {
             }
         }, 10_000)
 
-        it.each([
+        it.each<TourScenario>([
             {
                 buttonName: "Take the tour",
                 shouldStartTour: true,

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -1330,7 +1330,7 @@ describe("MultiAgentAccelerator", () => {
             renderMultiAgentAcceleratorPage()
 
             // Haven't shown announcement yet
-            expect(useAnnouncementsStore.getState().hasShown(AnnouncementId.NeuroSanStudioGithubStar)).toBe(false)
+            useAnnouncementsStore.getState().reset(AnnouncementId.NeuroSanStudioGithubStar)
 
             // Advance time to trigger the callout. Add 1000 to give Slide animation time to complete
             act(() => {

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -785,8 +785,8 @@ describe("MultiAgentAccelerator", () => {
             // When a reservation arrives alongside sly_data that contains agent_network_definition,
             // that data should be stored on the temporary network's own entry in the temp-networks
             // store — NOT in the chat history sly_data.
-            const agentNetworkDefinition = [
-                {origin: "copy_cat", tools: [] as string[], display_as: "llm_agent", instructions: "Copy everything."},
+            const agentNetworkDefinition: AgentNetworkDefinitionEntry[] = [
+                {origin: "copy_cat", tools: [], display_as: "llm_agent", instructions: "Copy everything."},
             ]
             const reservationWithDefinition: ChatResponse = {
                 response: {
@@ -816,18 +816,18 @@ describe("MultiAgentAccelerator", () => {
 
         it("Should store agent_network_definition independently for two different temporary networks", async () => {
             // Each temporary network must have its own independent agentNetworkDefinition entry.
-            const definitionA = [
+            const definitionA: AgentNetworkDefinitionEntry[] = [
                 {
                     origin: "agent_alpha",
-                    tools: [] as string[],
+                    tools: [],
                     display_as: "llm_agent",
                     instructions: "Network A instructions.",
                 },
             ]
-            const definitionB = [
+            const definitionB: AgentNetworkDefinitionEntry[] = [
                 {
                     origin: "agent_beta",
-                    tools: [] as string[],
+                    tools: [],
                     display_as: "llm_agent",
                     instructions: "Network B instructions.",
                 },
@@ -1250,7 +1250,7 @@ describe("MultiAgentAccelerator", () => {
         it.each<NetworkDesignerErrorScenario>([
             {
                 scenario: "the designer returns no reservation",
-                streamChunks: [] as string[],
+                streamChunks: [],
                 agentNetworkName: RESERVATION.reservation_id,
                 expectedLog: "did not return a reservation",
             },
@@ -1318,8 +1318,8 @@ describe("MultiAgentAccelerator", () => {
     })
 
     describe("extraSlyData Handling", () => {
-        const agentNetworkDefinition = [
-            {origin: "agent1", tools: [] as string[], display_as: "llm_agent", instructions: "Do stuff."},
+        const agentNetworkDefinition: AgentNetworkDefinitionEntry[] = [
+            {origin: "agent1", tools: [], display_as: "llm_agent", instructions: "Do stuff."},
         ]
 
         const tempNetworkWithDefinition: TemporaryNetwork = {

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -1119,6 +1119,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                         setNeuroSanCalloutOpen(false)
                         markAnnouncementShown(AnnouncementId.NeuroSanStudioGithubStar)
                     }}
+                    role="button"
                     size="small"
                     sx={{
                         bgcolor: "background.paper",

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import Close from "@mui/icons-material/Close"
 import StopCircle from "@mui/icons-material/StopCircle"
 import Box from "@mui/material/Box"
 import Grid from "@mui/material/Grid"
+import IconButton from "@mui/material/IconButton"
 import Slide from "@mui/material/Slide"
+import Snackbar from "@mui/material/Snackbar"
 import {useTheme} from "@mui/material/styles"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
@@ -37,9 +40,12 @@ import {
     AgentNetworkDefinitionEntry,
     EXPIRED_NETWORKS_CHECK_INTERVAL_MS,
     GRACE_PERIOD_MS,
+    NEURO_SAN_CALLOUT_DELAY_MS,
     SHOW_TOUR_DELAY_MS,
     TRIGGER_APP_TOUR_EVENT_NAME,
 } from "./const"
+import {NeuroSanStudioCallout} from "./NeuroSanStudioCallout"
+import {BYOK} from "./Schema/SlyData"
 import {Sidebar} from "./Sidebar/Sidebar"
 import {
     extractTemporaryNetworksFromMessage,
@@ -54,7 +60,9 @@ import {getAgentIconSuggestions, getNetworkIconSuggestions} from "../../controll
 import {AgentIconSuggestions} from "../../controller/Types/AgentIconSuggestions"
 import {NetworkIconSuggestions} from "../../controller/Types/NetworkIconSuggestions"
 import {AgentInfo, ConnectivityInfo, ConnectivityResponse} from "../../generated/neuro-san/NeuroSanClient"
+import {AnnouncementId, useAnnouncementsStore} from "../../state/Announcements"
 import {useAgentChatHistoryStore} from "../../state/ChatHistory"
+import {ByokKeyField, getApiKey, LLM_PROVIDER_API_KEY_FIELD, LLMProvider, useSettingsStore} from "../../state/Settings"
 import {TemporaryNetwork, useTempNetworksStore} from "../../state/TemporaryNetworks"
 import {TourPromptState, useTourStore} from "../../state/Tour"
 import {toDisplayName} from "../../utils/AgentName"
@@ -67,8 +75,6 @@ import {ConfirmationModal, StyledButton} from "../Common/ConfirmationModal"
 import {MUIAlert} from "../Common/MUIAlert"
 import {MUIDialog} from "../Common/MUIDialog"
 import {closeNotification, NotificationType, sendNotification} from "../Common/notification"
-import {BYOK} from "./Schema/SlyData"
-import {ByokKeyField, getApiKey, LLM_PROVIDER_API_KEY_FIELD, LLMProvider, useSettingsStore} from "../../state/Settings"
 
 export interface MultiAgentAcceleratorProps {
     readonly username: string
@@ -206,6 +212,13 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
             skip: "Exit Tour",
         },
     })
+
+    // Neuro SAN Studio callout
+    const [neuroSanCalloutOpen, setNeuroSanCalloutOpen] = useState<boolean>(false)
+    const haveShownNeuroSanCallout = useAnnouncementsStore((state) =>
+        state.hasShown(AnnouncementId.NeuroSanStudioGithubStar)
+    )
+    const markAnnouncementShown = useAnnouncementsStore((state) => state.markShown)
 
     const resetState = useCallback(() => {
         setThoughtBubbleEdges(new Map())
@@ -700,6 +713,21 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
         }
     }, [haveShownTourModal, tourRequested, tourStatus])
 
+    // Show Neuro SAN Studio callout after a delay if the user hasn't seen it yet
+    useEffect(() => {
+        // If it's already open, or we've already shown it, just return
+        if (neuroSanCalloutOpen || haveShownNeuroSanCallout) return undefined
+
+        // Show callout after a delay
+        const timer = setTimeout(() => {
+            setNeuroSanCalloutOpen(true)
+        }, NEURO_SAN_CALLOUT_DELAY_MS)
+
+        return () => {
+            clearTimeout(timer)
+        }
+    }, [haveShownNeuroSanCallout, neuroSanCalloutOpen])
+
     useEffect(() => {
         if (!tourRequested) return
 
@@ -1056,8 +1084,63 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
             </MUIAlert>
         )
 
+    const getNeuroSanStudioCallout = () => (
+        <Snackbar
+            anchorOrigin={{vertical: "bottom", horizontal: "left"}}
+            open={neuroSanCalloutOpen}
+            slotProps={{
+                clickAwayListener: {
+                    onClickAway: (event) => {
+                        ;(event as (MouseEvent | TouchEvent) & {defaultMuiPrevented: boolean}).defaultMuiPrevented =
+                            true
+                    },
+                },
+                transition: {
+                    timeout: {
+                        enter: 500,
+                        exit: 250,
+                    },
+                },
+            }}
+            slots={{transition: Slide}}
+            sx={{mb: 2}}
+        >
+            <Box
+                sx={{
+                    position: "relative",
+                    maxWidth: 340,
+                }}
+            >
+                <IconButton
+                    aria-label="Close Neuro SAN Studio callout"
+                    onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        setNeuroSanCalloutOpen(false)
+                        markAnnouncementShown(AnnouncementId.NeuroSanStudioGithubStar)
+                    }}
+                    size="small"
+                    sx={{
+                        bgcolor: "background.paper",
+                        position: "absolute",
+                        right: 4,
+                        top: 20,
+                        "&:hover": {
+                            bgcolor: "action.hover",
+                        },
+                    }}
+                >
+                    <Close fontSize="small" />
+                </IconButton>
+
+                <NeuroSanStudioCallout />
+            </Box>
+        </Snackbar>
+    )
+
     return (
         <>
+            {getNeuroSanStudioCallout()}
             {getMissingApiKeysAlert()}
             {Tour}
             {getTourModal()}

--- a/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
@@ -57,6 +57,8 @@ export const NeuroSanStudioCallout: FC = () => (
         <Box
             alt="GitHub Repo stars"
             component="img"
+            loading="lazy"
+            referrerPolicy="no-referrer"
             src="https://img.shields.io/github/stars/cognizant-ai-lab/neuro-san-studio?label=Neuro%20SAN%20Studio"
             sx={{
                 borderRadius: 1,

--- a/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
@@ -20,7 +20,7 @@ export const NeuroSanStudioCallout: FC = () => (
                     backgroundImage: `linear-gradient(135deg, ${paper}, ${alpha(primary, 0.14)})`,
                     borderColor: "primary.main",
                     boxShadow: `0 0 0 3px ${alpha(primary, 0.22)}, ${theme.shadows[6]}`,
-                    color: "primary.main",
+                    color: "secondary.main",
                 },
                 bgcolor: "background.paper",
                 backgroundImage: `linear-gradient(135deg, ${paper}, ${alpha(primary, 0.06)})`,
@@ -51,7 +51,7 @@ export const NeuroSanStudioCallout: FC = () => (
             sx={{mt: 0.5, mb: 1.25, opacity: 0.92}}
             variant="body2"
         >
-            See the latest releases, explore examples, and help grow the community on GitHub.
+            See the latest releases, explore examples, read the User Guide and help grow the community on GitHub.
         </Typography>
 
         <Box

--- a/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
@@ -6,6 +6,7 @@ import {FC} from "react"
 
 export const NeuroSanStudioCallout: FC = () => (
     <Paper
+        aria-label="neuro-san-studio GitHub repository"
         component="a"
         elevation={4}
         href="https://github.com/cognizant-ai-lab/neuro-san-studio"

--- a/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/NeuroSanStudioCallout.tsx
@@ -1,0 +1,70 @@
+import Box from "@mui/material/Box"
+import Paper from "@mui/material/Paper"
+import {alpha} from "@mui/material/styles"
+import Typography from "@mui/material/Typography"
+import {FC} from "react"
+
+export const NeuroSanStudioCallout: FC = () => (
+    <Paper
+        component="a"
+        elevation={4}
+        href="https://github.com/cognizant-ai-lab/neuro-san-studio"
+        rel="noopener noreferrer"
+        sx={(theme) => {
+            const paper = theme.palette.background.paper
+            const primary = theme.palette.primary.main
+
+            return {
+                "&:hover": {
+                    backgroundImage: `linear-gradient(135deg, ${paper}, ${alpha(primary, 0.14)})`,
+                    borderColor: "primary.main",
+                    boxShadow: `0 0 0 3px ${alpha(primary, 0.22)}, ${theme.shadows[6]}`,
+                    color: "primary.main",
+                },
+                bgcolor: "background.paper",
+                backgroundImage: `linear-gradient(135deg, ${paper}, ${alpha(primary, 0.06)})`,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 2,
+                color: "text.primary",
+                display: "block",
+                mt: 2,
+                p: 2,
+                textAlign: "center",
+                textDecoration: "none", // prevent underline on hover
+                transition: theme.transitions.create(["color", "border-color", "box-shadow"], {
+                    duration: theme.transitions.duration.shortest,
+                }),
+            }
+        }}
+        target="_blank"
+    >
+        <Typography
+            sx={{fontWeight: 700}}
+            variant="body1"
+        >
+            ⭐ Star us on GitHub!
+        </Typography>
+
+        <Typography
+            sx={{mt: 0.5, mb: 1.25, opacity: 0.92}}
+            variant="body2"
+        >
+            See the latest releases, explore examples, and help grow the community on GitHub.
+        </Typography>
+
+        <Box
+            alt="GitHub Repo stars"
+            component="img"
+            src="https://img.shields.io/github/stars/cognizant-ai-lab/neuro-san-studio?label=Neuro%20SAN%20Studio"
+            sx={{
+                borderRadius: 1,
+                border: "1px solid",
+                borderColor: "divider",
+                display: "inline-block",
+                height: 20,
+                verticalAlign: "middle",
+            }}
+        />
+    </Paper>
+)

--- a/packages/ui-common/components/MultiAgentAccelerator/Tour/MainTourSteps.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Tour/MainTourSteps.tsx
@@ -1,3 +1,5 @@
+import Box from "@mui/material/Box"
+import Typography from "@mui/material/Typography"
 import {Step} from "react-joyride"
 
 /**
@@ -18,7 +20,7 @@ export const MAIN_TOUR_STEPS: Step[] = [
         content:
             "This is the list of agent networks available on the server. Select a network to see its agents and " +
             "start interacting with it!",
-        target: () => document.querySelector("#multi-agent-accelerator-sidebar-heading"),
+        target: () => document.querySelector(".MuiRichTreeView-root"),
         placement: "bottom",
     },
     {
@@ -108,9 +110,66 @@ export const MAIN_TOUR_STEPS: Step[] = [
         placement: "top",
     },
     {
-        content:
-            "If you want to take the tour again, or if you have any questions or need help, click here to access " +
-            "the help information or to contact the Cognizant AI Labs team. We'd love to hear from you!",
+        content: (
+            <>
+                <Typography
+                    sx={{mb: 1}}
+                    variant="body2"
+                >
+                    Need help, want to retake the tour, or have feedback? Use this menu to find help resources and
+                    contact the Cognizant AI Labs team.
+                </Typography>
+
+                <Box
+                    component="a"
+                    href="https://github.com/cognizant-ai-lab/neuro-san-studio"
+                    rel="noopener noreferrer"
+                    sx={{
+                        display: "block",
+                        mt: 2,
+                        p: 2,
+                        border: "1px solid rgba(255, 255, 255, 0.35)",
+                        borderRadius: 2,
+                        textAlign: "center",
+                        textDecoration: "none",
+                        background: "linear-gradient(135deg, rgba(255,255,255,0.20), rgba(255,255,255,0.08))",
+                        boxShadow: "0 8px 24px rgba(0,0,0,0.22)",
+                        transition: "transform 120ms ease, background 120ms ease, border-color 120ms ease",
+                        "&:hover": {
+                            background: "linear-gradient(135deg, rgba(255,255,255,0.28), rgba(255,255,255,0.12))",
+                            borderColor: "rgba(255, 255, 255, 0.65)",
+                            transform: "translateY(-1px)",
+                        },
+                    }}
+                    target="_blank"
+                >
+                    <Typography
+                        sx={{fontWeight: 700}}
+                        variant="body1"
+                    >
+                        ⭐ Star us on GitHub!
+                    </Typography>
+
+                    <Typography
+                        sx={{mt: 0.5, mb: 1.25, opacity: 0.92}}
+                        variant="body2"
+                    >
+                        See the latest releases, explore examples, and help grow the Neuro SAN community.
+                    </Typography>
+
+                    <Box
+                        alt="GitHub Repo stars"
+                        component="img"
+                        src="https://img.shields.io/github/stars/cognizant-ai-lab/neuro-san-studio?style=social"
+                        sx={{
+                            display: "inline-block",
+                            height: 20,
+                            verticalAlign: "middle",
+                        }}
+                    />
+                </Box>
+            </>
+        ),
         target: () => document.querySelector("#help-dropdown"),
         placement: "top",
     },

--- a/packages/ui-common/components/MultiAgentAccelerator/Tour/MainTourSteps.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/Tour/MainTourSteps.tsx
@@ -1,6 +1,7 @@
-import Box from "@mui/material/Box"
 import Typography from "@mui/material/Typography"
 import {Step} from "react-joyride"
+
+import {NeuroSanStudioCallout} from "../NeuroSanStudioCallout"
 
 /**
  * This file defines the steps for the main tour of the Multi-Agent Accelerator application.
@@ -119,55 +120,7 @@ export const MAIN_TOUR_STEPS: Step[] = [
                     Need help, want to retake the tour, or have feedback? Use this menu to find help resources and
                     contact the Cognizant AI Labs team.
                 </Typography>
-
-                <Box
-                    component="a"
-                    href="https://github.com/cognizant-ai-lab/neuro-san-studio"
-                    rel="noopener noreferrer"
-                    sx={{
-                        display: "block",
-                        mt: 2,
-                        p: 2,
-                        border: "1px solid rgba(255, 255, 255, 0.35)",
-                        borderRadius: 2,
-                        textAlign: "center",
-                        textDecoration: "none",
-                        background: "linear-gradient(135deg, rgba(255,255,255,0.20), rgba(255,255,255,0.08))",
-                        boxShadow: "0 8px 24px rgba(0,0,0,0.22)",
-                        transition: "transform 120ms ease, background 120ms ease, border-color 120ms ease",
-                        "&:hover": {
-                            background: "linear-gradient(135deg, rgba(255,255,255,0.28), rgba(255,255,255,0.12))",
-                            borderColor: "rgba(255, 255, 255, 0.65)",
-                            transform: "translateY(-1px)",
-                        },
-                    }}
-                    target="_blank"
-                >
-                    <Typography
-                        sx={{fontWeight: 700}}
-                        variant="body1"
-                    >
-                        ⭐ Star us on GitHub!
-                    </Typography>
-
-                    <Typography
-                        sx={{mt: 0.5, mb: 1.25, opacity: 0.92}}
-                        variant="body2"
-                    >
-                        See the latest releases, explore examples, and help grow the Neuro SAN community.
-                    </Typography>
-
-                    <Box
-                        alt="GitHub Repo stars"
-                        component="img"
-                        src="https://img.shields.io/github/stars/cognizant-ai-lab/neuro-san-studio?style=social"
-                        sx={{
-                            display: "inline-block",
-                            height: 20,
-                            verticalAlign: "middle",
-                        }}
-                    />
-                </Box>
+                <NeuroSanStudioCallout />
             </>
         ),
         target: () => document.querySelector("#help-dropdown"),

--- a/packages/ui-common/components/MultiAgentAccelerator/const.ts
+++ b/packages/ui-common/components/MultiAgentAccelerator/const.ts
@@ -69,6 +69,9 @@ export const LEVEL_SPACING = 150
 // We show the tour modal after this amount of time so as not to "pounce" on the user when they first open the app
 export const SHOW_TOUR_DELAY_MS = 5000
 
+// Show the Neuro SAN Studio callout after this many MS
+export const NEURO_SAN_CALLOUT_DELAY_MS = 5000
+
 // Temporary folder name for networks created from agent reservations. These networks are not "in a folder" when
 // they come from the backend, but we need to put them somewhere in the UI, and this makes it clear that they're
 // temporary.

--- a/packages/ui-common/state/Announcements.ts
+++ b/packages/ui-common/state/Announcements.ts
@@ -1,0 +1,49 @@
+import {create} from "zustand"
+import {persist} from "zustand/middleware"
+
+export enum AnnouncementId {
+    NeuroSanStudioGithubStar = "NeuroSanStudioGithubStar",
+}
+
+interface AnnouncementsStore {
+    readonly lastShownAt: Partial<Record<AnnouncementId, number>>
+    readonly markShown: (id: AnnouncementId) => void
+    readonly hasShown: (id: AnnouncementId) => boolean
+    readonly reset: (id?: AnnouncementId) => void
+}
+
+const ANNOUNCEMENTS_STORAGE_KEY = "announcements"
+
+/**
+ * Persisted zustand store for announcements we want to show to the user once, or every some amount of time.
+ */
+export const useAnnouncementsStore = create<AnnouncementsStore>()(
+    persist(
+        (set, get) => ({
+            lastShownAt: {},
+
+            markShown: (id) =>
+                set((state) => ({
+                    lastShownAt: {
+                        ...state.lastShownAt,
+                        [id]: Date.now(),
+                    },
+                })),
+
+            hasShown: (id) => Boolean(get().lastShownAt[id]),
+
+            reset: (id) =>
+                set((state) => {
+                    if (!id) {
+                        return {lastShownAt: {}}
+                    }
+
+                    const {[id]: _removed, ...remaining} = state.lastShownAt
+                    return {lastShownAt: remaining}
+                }),
+        }),
+        {
+            name: ANNOUNCEMENTS_STORAGE_KEY,
+        }
+    )
+)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -82,
-                branches: -129,
+                statements: -80,
+                branches: -128,
                 functions: -18,
-                lines: -58,
+                lines: -56,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -91,
-                branches: -130,
-                functions: -23,
-                lines: -66,
+                statements: -82,
+                branches: -129,
+                functions: -18,
+                lines: -58,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,10 +22,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -80,
-                branches: -128,
-                functions: -18,
-                lines: -56,
+                statements: -91,
+                branches: -130,
+                functions: -23,
+                lines: -66,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests


### PR DESCRIPTION
Adds callouts to Neuro SAN Studio repository in various places in MAUI:

1) Splash screen
2) Last tour step
3) "First run" popup. Future: could consider re-showing this every (some time interval eg. 30 days). But could be annoying for users.

Note: if a user doesn't explicitly dismiss the "first run" callout, it will keep showing up until they do. Not sure if that is totally correct behavior, but it seems the right thing to do.

Splash screen:
<br />
<img width="1609" height="766" alt="image" src="https://github.com/user-attachments/assets/193cd14c-445c-4303-8c24-633e20770761" />

First run:
<br />
<img width="1618" height="761" alt="image" src="https://github.com/user-attachments/assets/1e96df04-d697-4fa0-948f-3ed8622b8170" />

Final Tour step:
<br />
<img width="1609" height="759" alt="image" src="https://github.com/user-attachments/assets/de698904-417e-4fee-b834-88b2b6789ce7" />

First run callout appears after a few seconds:
<br />

https://github.com/user-attachments/assets/4f94fcae-6eb3-4a57-a530-e3f7661396e0



