### PR TITLE
Fix Docker build/next build error (again) due to MUI versions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,7 +12,7 @@ catalogs:
         "@langchain/core": "1.1.17"
         "@mui/icons-material": "9.0.1"
         "@mui/material": "9.0.1"
-        "@mui/system": "9.1.2"
+        "@mui/system": "9.2.0"
         "@mui/x-tree-view": "9.1.0"
         "@testing-library/dom": "10.4.1"
         "@testing-library/react": "16.3.0"

--- a/packages/ui-common/components/AgentChat/Common/LlmChatButton.tsx
+++ b/packages/ui-common/components/AgentChat/Common/LlmChatButton.tsx
@@ -14,19 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Button from "@mui/material/Button"
+import Button, {ButtonProps} from "@mui/material/Button"
 import {styled} from "@mui/material/styles"
+import {ComponentType} from "react"
 
-//#region: Types
-
-type LLMChatGroupConfigBtnProps = {
-    disabled?: boolean
-}
-
-//#endregion: Types
-
-// In LlmChatButton.tsx
-export const LlmChatButton = styled(Button)<LLMChatGroupConfigBtnProps>(({disabled, theme}) => ({
+export const LlmChatButton: ComponentType<ButtonProps> = styled(Button)<ButtonProps>(({disabled, theme}) => ({
     backgroundColor: theme.palette.background.paper,
     borderRadius: "var(--bs-border-radius)",
     cursor: disabled ? "not-allowed" : "pointer",
@@ -34,7 +26,7 @@ export const LlmChatButton = styled(Button)<LLMChatGroupConfigBtnProps>(({disabl
     padding: "0.5rem",
 }))
 
-export const SmallLlmChatButton = styled(LlmChatButton)({
+export const SmallLlmChatButton: ComponentType<ButtonProps> = styled(LlmChatButton)<ButtonProps>({
     minWidth: 0,
     padding: "0.25rem",
 })

--- a/packages/ui-common/components/Common/ConfirmationModal.tsx
+++ b/packages/ui-common/components/Common/ConfirmationModal.tsx
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 import Box from "@mui/material/Box"
-import Button from "@mui/material/Button"
+import Button, {ButtonProps} from "@mui/material/Button"
 import {styled} from "@mui/material/styles"
-import {FC, JSX as ReactJSX, ReactNode, useState} from "react"
+import {ComponentType, FC, JSX as ReactJSX, ReactNode, useState} from "react"
 
 import {MUIDialog} from "./MUIDialog"
 
 // #region: Styled Components
-export const StyledButton = styled(Button)({
+export const StyledButton: ComponentType<ButtonProps> = styled(Button)({
     fontSize: "0.8em",
     padding: "0px 7px",
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,7 +1583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^9.1.1, @mui/private-theming@npm:^9.2.0":
+"@mui/private-theming@npm:^9.2.0":
   version: 9.2.0
   resolution: "@mui/private-theming@npm:9.2.0"
   dependencies:
@@ -1623,35 +1623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:9.1.2":
-  version: 9.1.2
-  resolution: "@mui/system@npm:9.1.2"
-  dependencies:
-    "@babel/runtime": "npm:^7.29.2"
-    "@mui/private-theming": "npm:^9.1.1"
-    "@mui/styled-engine": "npm:^9.1.1"
-    "@mui/types": "npm:^9.1.1"
-    "@mui/utils": "npm:^9.1.1"
-    clsx: "npm:^2.1.1"
-    csstype: "npm:^3.2.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10c0/9f274cf009e4235a9bbb9a6524aa2de6ba59a3fc01e91157004be1a4d5c6d4db5f16d91dfe95d3c3acb36fa355a8ac7d811b146a547f3b9292c2a1c981adb707
-  languageName: node
-  linkType: hard
-
-"@mui/system@npm:^9.0.1":
+"@mui/system@npm:9.2.0, @mui/system@npm:^9.0.1":
   version: 9.2.0
   resolution: "@mui/system@npm:9.2.0"
   dependencies:
@@ -1713,7 +1685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^9.0.1, @mui/utils@npm:^9.1.1, @mui/utils@npm:^9.2.0":
+"@mui/utils@npm:^9.0.1, @mui/utils@npm:^9.2.0":
   version: 9.2.0
   resolution: "@mui/utils@npm:9.2.0"
   dependencies:


### PR DESCRIPTION
Reference: https://github.com/cognizant-ai-lab/neuro-san-ui/pull/324

Somehow the error started happening again, maybe due to a previous PR regen'ing the yarn lock file.

Errors, during Docker build:

```console
Run yarn build:lib
✨ openapi-typescript 7.8.0
🚀 https://neuro-san-dev.decisionai.ml/api/v1/docs → ./generated/neuro-san/NeuroSanClient.ts [431.6ms]
Error: components/AgentChat/Common/LlmChatButton.tsx(29,14): error TS2742: The inferred type of 'LlmChatButton' cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary.
Error: components/AgentChat/Common/LlmChatButton.tsx(37,14): error TS2742: The inferred type of 'SmallLlmChatButton' cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary.
Error: components/Common/ConfirmationModal.tsx(25,14): error TS2742: The inferred type of 'StyledButton' cannot be named without a reference to '@mui/material/node_modules/@mui/system'. This is likely not portable. A type annotation is necessary.
Error: Process completed with exit code 1.
```

Copilot says, "For library/exported styled components, avoid letting TypeScript infer the public declaration type." So that is what this PR fixes, as well as cleaning up the `yarn.lock` file.