### PR TITLE
#52 add sly data input field

### DIFF
--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
@@ -1595,6 +1595,36 @@ describe("ChatCommon", () => {
             expect(sendChatQuery).toHaveBeenCalledTimes(1)
         })
 
+        it("Should not persist echoed BYOK keys into the sly_data store", async () => {
+            act(() => {
+                useAgentChatHistoryStore.getState().resetHistory(TEST_AGENT_MATH_GUY)
+            })
+
+            renderChatCommonComponent()
+
+            const chunkWithSecret: ChatResponse = {
+                response: {
+                    type: ChatMessageType.AGENT_FRAMEWORK,
+                    text: "done",
+                    sly_data: {
+                        llm_config: {openai_api_key: "sk-should-never-persist"},
+                        running_cost: 3,
+                    },
+                },
+            }
+
+            mockSendChatQuery(({callback}) => {
+                callback(JSON.stringify(chunkWithSecret))
+            })
+
+            await sendQuery(TEST_AGENT_MATH_GUY, "query that echoes a secret")
+
+            await waitFor(() => {
+                const storedSlyData = useAgentChatHistoryStore.getState().history[TEST_AGENT_MATH_GUY]?.slyData
+                expect(storedSlyData).toEqual({running_cost: 3})
+            })
+        })
+
         const openSlyDataEditor = async () => {
             await user.click(screen.getByTestId("TuneIcon"))
             await user.click(screen.getByRole("menuitem", {name: "Sly data..."}))
@@ -1626,7 +1656,7 @@ describe("ChatCommon", () => {
                 "query after seeding sly_data",
                 TEST_AGENT_MATH_GUY,
                 expect.any(Function),
-                undefined, // no chat context yet: only sly_data has been stored for this network
+                null, // no chat context yet: setSlyData initializes a fresh entry with null context
                 {login: TEST_USER, seeded_by_user: "yes"},
                 TEST_USER,
                 StreamingUnit.Line

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
@@ -1594,6 +1594,56 @@ describe("ChatCommon", () => {
             // sendChatQuery was called — the component processed the chunk without error
             expect(sendChatQuery).toHaveBeenCalledTimes(1)
         })
+
+        const openSlyDataEditor = async () => {
+            await user.click(screen.getByTestId("TuneIcon"))
+            await user.click(screen.getByRole("menuitem", {name: "Sly data..."}))
+            return screen.getByLabelText<HTMLTextAreaElement>("Sly data")
+        }
+
+        it("Should send sly_data edited in the editor with the next request", async () => {
+            act(() => {
+                useAgentChatHistoryStore.getState().resetHistory(TEST_AGENT_MATH_GUY)
+            })
+
+            renderChatCommonComponent()
+            mockSendChatQuery(({callback}) => {
+                callback(JSON.stringify({response: getResponseMessage(ChatMessageType.AGENT_FRAMEWORK, "done")}))
+            })
+
+            const editor = await openSlyDataEditor()
+            await user.clear(editor)
+            await user.click(editor)
+            await user.paste('{"seeded_by_user": "yes"}')
+            await user.click(screen.getByRole("button", {name: "Save"}))
+
+            await sendQuery(TEST_AGENT_MATH_GUY, "query after seeding sly_data")
+
+            // sly_data is the 7th argument to sendChatQuery. The user's value rides along with the entries the
+            // component always supplies.
+            expect(vi.mocked(sendChatQuery).mock.calls[0][6]).toEqual({
+                seeded_by_user: "yes",
+                login: TEST_USER,
+            })
+        })
+
+        it("Should show the sly_data currently in the store", async () => {
+            act(() => {
+                useAgentChatHistoryStore.getState().setSlyData(TEST_AGENT_MATH_GUY, {charges: 7})
+            })
+
+            renderChatCommonComponent()
+
+            expect(await openSlyDataEditor()).toHaveValue('{\n  "charges": 7\n}')
+        })
+
+        it("Should not offer the sly_data editor for legacy agents, which have no sly_data", async () => {
+            renderChatCommonComponent({selectedNetwork: LegacyAgentType.DataGenerator})
+
+            await user.click(screen.getByTestId("TuneIcon"))
+
+            expect(screen.queryByRole("menuitem", {name: "Sly data..."})).not.toBeInTheDocument()
+        })
     })
 
     describe("Chat Context Handling", () => {

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
@@ -1619,12 +1619,18 @@ describe("ChatCommon", () => {
 
             await sendQuery(TEST_AGENT_MATH_GUY, "query after seeding sly_data")
 
-            // sly_data is the 7th argument to sendChatQuery. The user's value rides along with the entries the
-            // component always supplies.
-            expect(vi.mocked(sendChatQuery).mock.calls[0][6]).toEqual({
-                seeded_by_user: "yes",
-                login: TEST_USER,
-            })
+            // The user's value rides along with the entries the component always supplies (login).
+            expect(sendChatQuery).toHaveBeenCalledExactlyOnceWith(
+                undefined, // neuroSanURL is not set in these props
+                expect.any(AbortSignal),
+                "query after seeding sly_data",
+                TEST_AGENT_MATH_GUY,
+                expect.any(Function),
+                undefined, // no chat context yet: only sly_data has been stored for this network
+                {login: TEST_USER, seeded_by_user: "yes"},
+                TEST_USER,
+                StreamingUnit.Line
+            )
         })
 
         it("Should show the sly_data currently in the store", async () => {

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -120,6 +120,9 @@ describe("SlyDataDialog", () => {
 
         expect(screen.getByRole("button", {name: "Save"})).toBeDisabled()
         expect(screen.getByRole("button", {name: "Export sly data"})).toBeDisabled()
+        // The parser's message is shown as the editor's helper text. Its exact wording is engine-dependent,
+        // but every variant mentions JSON.
+        expect(getEditor()).toHaveAccessibleDescription(/json/iu)
     })
 
     it("refuses to save a JSON array, since sly data has to be an object", async () => {

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -238,7 +238,7 @@ describe("SlyDataDialog", () => {
     it("names the keys that get merged in on send, without showing their values", () => {
         renderDialog(["llm_config", "login"])
 
-        expect(screen.getByText(/added automatically to every request/u)).toBeInTheDocument()
+        expect(screen.getByText(/Sent automatically with every request/u)).toBeInTheDocument()
         expect(screen.getByText("llm_config")).toBeInTheDocument()
         expect(screen.getByText("login")).toBeInTheDocument()
     })
@@ -246,6 +246,6 @@ describe("SlyDataDialog", () => {
     it("says nothing about merged keys when there are none", () => {
         renderDialog()
 
-        expect(screen.queryByText(/added automatically to every request/u)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Sent automatically with every request/u)).not.toBeInTheDocument()
     })
 })

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -180,7 +180,7 @@ describe("SlyDataDialog", () => {
         renderDialog()
 
         const file = new File(['{"imported": true}'], "sly.json", {type: "application/json"})
-        await user.upload(screen.getByTestId(`${DIALOG_ID}-file-input`), file, {applyAccept: false})
+        await user.upload(screen.getByTestId(`${DIALOG_ID}-file-input`), file)
 
         expect(getEditor()).toHaveValue('{"imported": true}')
         expect(screen.getByRole("button", {name: "Save"})).toBeEnabled()
@@ -190,7 +190,7 @@ describe("SlyDataDialog", () => {
         renderDialog()
 
         const file = new File(["not json at all"], "sly.json", {type: "application/json"})
-        await user.upload(screen.getByTestId(`${DIALOG_ID}-file-input`), file, {applyAccept: false})
+        await user.upload(screen.getByTestId(`${DIALOG_ID}-file-input`), file)
 
         expect(getEditor()).toHaveValue("not json at all")
         expect(screen.getByRole("button", {name: "Save"})).toBeDisabled()

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -1,0 +1,249 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {act, render, screen} from "@testing-library/react"
+import {userEvent, UserEvent} from "@testing-library/user-event"
+
+import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
+import {SlyDataDialog} from "../../../../components/AgentChat/ChatCommon/SlyDataDialog"
+import {useAgentChatHistoryStore} from "../../../../state/ChatHistory"
+import {downloadFile} from "../../../../utils/File"
+
+vi.mock("../../../../utils/File", async () => {
+    const actual = vi.importActual("../../../../utils/File")
+    return {
+        ...(await actual),
+        downloadFile: vi.fn(),
+    }
+})
+
+const NETWORK_ID = "music_nerd_pro"
+const DIALOG_ID = "test-sly-data-dialog"
+
+// A one-pixel transparent GIF, as a data URI
+const IMAGE_DATA_URI = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+
+describe("SlyDataDialog", () => {
+    withStrictMocks()
+
+    let user: UserEvent
+    const onCloseMock = vi.fn()
+
+    beforeEach(() => {
+        user = userEvent.setup({delay: null})
+
+        // Start each test from a clean store
+        const agentHistory = useAgentChatHistoryStore.getState().history
+        Object.keys(agentHistory).forEach((agentId) => {
+            useAgentChatHistoryStore.getState().resetHistory(agentId)
+        })
+    })
+
+    const renderDialog = (extraSlyDataKeys?: readonly string[]) =>
+        render(
+            <SlyDataDialog
+                extraSlyDataKeys={extraSlyDataKeys}
+                id={DIALOG_ID}
+                isOpen={true}
+                networkDisplayName="Music Nerd Pro"
+                networkId={NETWORK_ID}
+                onClose={onCloseMock}
+            />
+        )
+
+    const getEditor = () => screen.getByLabelText<HTMLTextAreaElement>("Sly data")
+
+    const getSlyData = () => useAgentChatHistoryStore.getState().history[NETWORK_ID]?.slyData
+
+    /**
+     * Replaces the whole contents of the editor. Uses paste rather than type because sly_data is JSON and
+     * userEvent's type() treats braces as syntax.
+     */
+    const replaceEditorContents = async (contents: string) => {
+        const editor = getEditor()
+        await user.clear(editor)
+        await user.click(editor)
+        await user.paste(contents)
+    }
+
+    it("shows the current sly data for the network, pretty-printed", () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2, user: "bob"}))
+
+        renderDialog()
+
+        expect(getEditor()).toHaveValue('{\n  "charges": 2,\n  "user": "bob"\n}')
+    })
+
+    it("shows an empty object when the network has no sly data yet", () => {
+        renderDialog()
+
+        expect(getEditor()).toHaveValue("{}")
+    })
+
+    it("saves edits to the store and closes", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2}))
+
+        renderDialog()
+        await replaceEditorContents('{"charges": 5}')
+        await user.click(screen.getByRole("button", {name: "Save"}))
+
+        expect(getSlyData()).toEqual({charges: 5})
+        expect(onCloseMock).toHaveBeenCalled()
+    })
+
+    it("removes keys the user deleted, rather than merging them back in", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2, user: "bob"}))
+
+        renderDialog()
+        await replaceEditorContents('{"charges": 2}')
+        await user.click(screen.getByRole("button", {name: "Save"}))
+
+        expect(getSlyData()).toEqual({charges: 2})
+    })
+
+    it("refuses to save malformed JSON and says why", async () => {
+        renderDialog()
+        await replaceEditorContents('{"charges": }')
+
+        expect(screen.getByRole("button", {name: "Save"})).toBeDisabled()
+        expect(screen.getByRole("button", {name: "Export sly data"})).toBeDisabled()
+    })
+
+    it("refuses to save a JSON array, since sly data has to be an object", async () => {
+        renderDialog()
+        await replaceEditorContents("[1, 2]")
+
+        expect(screen.getByText("Sly data must be a JSON object, not an array.")).toBeInTheDocument()
+        expect(screen.getByRole("button", {name: "Save"})).toBeDisabled()
+    })
+
+    it("recovers once the JSON is valid again", async () => {
+        renderDialog()
+        await replaceEditorContents("{oops")
+        expect(screen.getByRole("button", {name: "Save"})).toBeDisabled()
+
+        await replaceEditorContents('{"ok": true}')
+        expect(screen.getByRole("button", {name: "Save"})).toBeEnabled()
+    })
+
+    it("clears the editor without touching the store until the user saves", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2}))
+
+        renderDialog()
+        await user.click(screen.getByRole("button", {name: "Clear sly data"}))
+
+        expect(getEditor()).toHaveValue("{}")
+        expect(getSlyData()).toEqual({charges: 2})
+
+        await user.click(screen.getByRole("button", {name: "Save"}))
+        expect(getSlyData()).toEqual({})
+    })
+
+    it("discards edits when cancelled", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2}))
+
+        renderDialog()
+        await replaceEditorContents('{"charges": 99}')
+        await user.click(screen.getByRole("button", {name: "Cancel"}))
+
+        expect(getSlyData()).toEqual({charges: 2})
+        expect(onCloseMock).toHaveBeenCalled()
+    })
+
+    it("exports the sly data as a JSON file", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2}))
+
+        renderDialog()
+        await user.click(screen.getByRole("button", {name: "Export sly data"}))
+
+        expect(downloadFile).toHaveBeenCalledWith(
+            '{\n  "charges": 2\n}',
+            "music_nerd_pro_sly_data.json",
+            "application/json"
+        )
+    })
+
+    it("loads sly data from an imported file", async () => {
+        renderDialog()
+
+        const file = new File(['{"imported": true}'], "sly.json", {type: "application/json"})
+        await user.upload(screen.getByTestId(`${DIALOG_ID}-file-input`), file, {applyAccept: false})
+
+        expect(getEditor()).toHaveValue('{"imported": true}')
+        expect(screen.getByRole("button", {name: "Save"})).toBeEnabled()
+    })
+
+    it("explains why an imported file is unusable instead of silently dropping it", async () => {
+        renderDialog()
+
+        const file = new File(["not json at all"], "sly.json", {type: "application/json"})
+        await user.upload(screen.getByTestId(`${DIALOG_ID}-file-input`), file, {applyAccept: false})
+
+        expect(getEditor()).toHaveValue("not json at all")
+        expect(screen.getByRole("button", {name: "Save"})).toBeDisabled()
+    })
+
+    it("previews values that look like images", () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {avatar: IMAGE_DATA_URI}))
+
+        renderDialog()
+
+        expect(screen.getByRole("img", {name: "avatar"})).toHaveAttribute("src", IMAGE_DATA_URI)
+    })
+
+    it("shows no image preview when there is nothing to preview", () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2}))
+
+        renderDialog()
+
+        expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    })
+
+    it("follows the store while the user has not made any edits", () => {
+        renderDialog()
+
+        act(() => useAgentChatHistoryStore.getState().updateSlyData(NETWORK_ID, {charges: 3}))
+
+        expect(getEditor()).toHaveValue('{\n  "charges": 3\n}')
+    })
+
+    it("keeps the user's edits when the agents update sly data, and offers a reload", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {charges: 2}))
+
+        renderDialog()
+        await replaceEditorContents('{"charges": 99}')
+
+        // The agents echo new sly data while the user is still editing
+        act(() => useAgentChatHistoryStore.getState().updateSlyData(NETWORK_ID, {charges: 3}))
+
+        expect(getEditor()).toHaveValue('{"charges": 99}')
+
+        await user.click(screen.getByRole("button", {name: "Reload"}))
+        expect(getEditor()).toHaveValue('{\n  "charges": 3\n}')
+    })
+
+    it("names the keys that get merged in on send, without showing their values", () => {
+        renderDialog(["llm_config", "login"])
+
+        expect(screen.getByText(/llm_config, login/u)).toBeInTheDocument()
+    })
+
+    it("says nothing about merged keys when there are none", () => {
+        renderDialog()
+
+        expect(screen.queryByText(/Added automatically when you send/u)).not.toBeInTheDocument()
+    })
+})

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -238,12 +238,14 @@ describe("SlyDataDialog", () => {
     it("names the keys that get merged in on send, without showing their values", () => {
         renderDialog(["llm_config", "login"])
 
-        expect(screen.getByText(/llm_config, login/u)).toBeInTheDocument()
+        expect(screen.getByText(/added automatically to every request/u)).toBeInTheDocument()
+        expect(screen.getByText("llm_config")).toBeInTheDocument()
+        expect(screen.getByText("login")).toBeInTheDocument()
     })
 
     it("says nothing about merged keys when there are none", () => {
         renderDialog()
 
-        expect(screen.queryByText(/Added automatically when you send/u)).not.toBeInTheDocument()
+        expect(screen.queryByText(/added automatically to every request/u)).not.toBeInTheDocument()
     })
 })

--- a/packages/ui-common/__tests__/unit/State/ChatHistory.test.ts
+++ b/packages/ui-common/__tests__/unit/State/ChatHistory.test.ts
@@ -110,6 +110,15 @@ describe("ChatHistory", () => {
         expect(useAgentChatHistoryStore.getState().history["agent7"]?.slyData).toEqual({})
     })
 
+    it("should initialize defaults when setting sly_data on a fresh network", async () => {
+        useAgentChatHistoryStore.getState().setSlyData("agent10", {user: "bob"})
+
+        const entry = useAgentChatHistoryStore.getState().history["agent10"]
+        expect(entry?.chatHistory).toEqual([])
+        expect(entry?.chatContext).toBeNull()
+        expect(entry?.slyData).toEqual({user: "bob"})
+    })
+
     it("should leave other parts of the history alone when setting sly_data", async () => {
         useAgentChatHistoryStore.getState().updateChatHistory("agent8", TEST_MESSAGES)
         useAgentChatHistoryStore.getState().setSlyData("agent8", {user: "bob"})

--- a/packages/ui-common/__tests__/unit/State/ChatHistory.test.ts
+++ b/packages/ui-common/__tests__/unit/State/ChatHistory.test.ts
@@ -89,6 +89,34 @@ describe("ChatHistory", () => {
         expect(updatedHistory["agent4"]?.slyData).toEqual(slyData)
     })
 
+    it("should merge sly_data when updating, so a streamed message only has to carry what changed", async () => {
+        useAgentChatHistoryStore.getState().updateSlyData("agent5", {charges: 1, user: "bob"})
+        useAgentChatHistoryStore.getState().updateSlyData("agent5", {charges: 2})
+
+        expect(useAgentChatHistoryStore.getState().history["agent5"]?.slyData).toEqual({charges: 2, user: "bob"})
+    })
+
+    it("should replace sly_data when setting it, so the editor can delete keys", async () => {
+        useAgentChatHistoryStore.getState().updateSlyData("agent6", {charges: 1, user: "bob"})
+        useAgentChatHistoryStore.getState().setSlyData("agent6", {charges: 2})
+
+        expect(useAgentChatHistoryStore.getState().history["agent6"]?.slyData).toEqual({charges: 2})
+    })
+
+    it("should let sly_data be emptied", async () => {
+        useAgentChatHistoryStore.getState().updateSlyData("agent7", {user: "bob"})
+        useAgentChatHistoryStore.getState().setSlyData("agent7", {})
+
+        expect(useAgentChatHistoryStore.getState().history["agent7"]?.slyData).toEqual({})
+    })
+
+    it("should leave other parts of the history alone when setting sly_data", async () => {
+        useAgentChatHistoryStore.getState().updateChatHistory("agent8", TEST_MESSAGES)
+        useAgentChatHistoryStore.getState().setSlyData("agent8", {user: "bob"})
+
+        expect(useAgentChatHistoryStore.getState().history["agent8"]?.chatHistory).toEqual(TEST_MESSAGES)
+    })
+
     it("should copy history from one agent to another", async () => {
         useAgentChatHistoryStore.getState().updateChatHistory("agentA", TEST_MESSAGES)
         useAgentChatHistoryStore.getState().updateSlyData("agentA", {key: "value"})

--- a/packages/ui-common/__tests__/unit/Utils/SlyData.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/SlyData.test.ts
@@ -1,0 +1,136 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Unit tests for the sly_data view/edit helpers
+ */
+
+// eslint-disable-next-line no-shadow
+import {describe, expect, it} from "vitest"
+
+import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
+import {findImageValues, formatSlyData, parseSlyData} from "../../../utils/SlyData"
+
+// A one-pixel transparent GIF, as a data URI
+const IMAGE_DATA_URI = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+
+describe("formatSlyData", () => {
+    withStrictMocks()
+
+    it("pretty-prints sly data as indented JSON", () => {
+        expect(formatSlyData({charges: 2, user: "bob"})).toBe('{\n  "charges": 2,\n  "user": "bob"\n}')
+    })
+
+    it("renders an empty object when there is no sly data", () => {
+        expect(formatSlyData(undefined)).toBe("{}")
+        expect(formatSlyData({})).toBe("{}")
+    })
+
+    it("round-trips through the parser", () => {
+        const original = {list: [1, 2, 3], nested: {a: true}}
+        expect(parseSlyData(formatSlyData(original)).value).toStrictEqual(original)
+    })
+})
+
+describe("parseSlyData", () => {
+    withStrictMocks()
+
+    it("parses a JSON object", () => {
+        const result = parseSlyData('{"charges": 2}')
+        expect(result.error).toBeUndefined()
+        expect(result.value).toStrictEqual({charges: 2})
+    })
+
+    it.each(["", " ".repeat(3), "\n"])("treats blank text (%j) as empty sly data", (text: string) => {
+        const result = parseSlyData(text)
+        expect(result.error).toBeUndefined()
+        expect(result.value).toStrictEqual({})
+    })
+
+    it("reports malformed JSON, quoting the parser's own message", () => {
+        const result = parseSlyData('{"charges": }')
+        expect(result.error).toBeTruthy()
+        expect(result.value).toStrictEqual({})
+    })
+
+    it("rejects an array at the root", () => {
+        expect(parseSlyData("[1, 2]").error).toBe("Sly data must be a JSON object, not an array.")
+    })
+
+    it.each(["42", '"hello"', "true", "null"])("rejects the primitive %s at the root", (text: string) => {
+        expect(parseSlyData(text).error).toBe("Sly data must be a JSON object, not a primitive value.")
+    })
+
+    it("survives being handed nothing at all", () => {
+        expect(parseSlyData(undefined).value).toStrictEqual({})
+    })
+})
+
+describe("findImageValues", () => {
+    withStrictMocks()
+
+    it("finds an image supplied as a data URI", () => {
+        expect(findImageValues({avatar: IMAGE_DATA_URI})).toStrictEqual([{path: "avatar", src: IMAGE_DATA_URI}])
+    })
+
+    it.each([
+        "https://example.com/chart.png",
+        "http://example.com/chart.JPEG",
+        "https://example.com/chart.svg?width=200",
+        "https://example.com/chart.webp#top",
+    ])("finds an image supplied as the URL %s", (url: string) => {
+        expect(findImageValues({chart: url})).toStrictEqual([{path: "chart", src: url}])
+    })
+
+    it.each([
+        "just some text",
+        "https://example.com/report.pdf",
+        "data:text/plain;base64,aGVsbG8=",
+        "example.com/chart.png",
+    ])("ignores the non-image value %j", (value: string) => {
+        expect(findImageValues({field: value})).toStrictEqual([])
+    })
+
+    it("reports a readable key path for nested images", () => {
+        const slyData = {report: {charts: [{thumbnail: IMAGE_DATA_URI}]}}
+        expect(findImageValues(slyData)).toStrictEqual([{path: "report.charts[0].thumbnail", src: IMAGE_DATA_URI}])
+    })
+
+    it("finds every image, in document order", () => {
+        const slyData = {first: IMAGE_DATA_URI, notes: "no image here", second: "https://example.com/b.png"}
+        expect(findImageValues(slyData).map((image) => image.path)).toStrictEqual(["first", "second"])
+    })
+
+    it("stops descending past the maximum depth", () => {
+        // 7 levels of nesting: one deeper than the walker will follow
+        const tooDeep = {a: {b: {c: {d: {e: {f: {g: IMAGE_DATA_URI}}}}}}}
+        expect(findImageValues(tooDeep)).toStrictEqual([])
+
+        const justShallowEnough = {a: {b: {c: {d: {e: {f: IMAGE_DATA_URI}}}}}}
+        expect(findImageValues(justShallowEnough)).toHaveLength(1)
+    })
+
+    it("caps the number of images it returns", () => {
+        const many = Object.fromEntries(
+            Array.from({length: 50}, (_, index: number) => [`image${index}`, IMAGE_DATA_URI])
+        )
+        expect(findImageValues(many)).toHaveLength(20)
+    })
+
+    it.each([undefined, null, "not an object", 42])("returns nothing for the non-payload %j", (value: unknown) => {
+        expect(findImageValues(value)).toStrictEqual([])
+    })
+})

--- a/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
@@ -21,6 +21,7 @@ import {AIMessage, HumanMessage} from "@langchain/core/messages"
 import AddBoxRounded from "@mui/icons-material/AddBoxRounded"
 import ClearIcon from "@mui/icons-material/Clear"
 import CloseIcon from "@mui/icons-material/Close"
+import DataObjectIcon from "@mui/icons-material/DataObject"
 import TuneIcon from "@mui/icons-material/Tune"
 import Box from "@mui/material/Box"
 import Checkbox from "@mui/material/Checkbox"
@@ -51,12 +52,13 @@ import {
 import {v4 as uuid} from "uuid"
 
 import {ChatHistory, toTurns} from "./ChatHistory"
-import {MAX_TURNS} from "./Const"
+import {MAX_TURNS, SLY_DATA_LOGIN_KEY} from "./Const"
 import {ControlButtons} from "./ControlButtons"
 import {Conversation} from "./Conversation"
 import {ConversationTurn, MessageRole} from "./ConversationTurn"
 import {SampleQueries} from "./SampleQueries"
 import {SendButton} from "./SendButton"
+import {SlyDataDialog} from "./SlyDataDialog"
 import {Thinking} from "./Thinking"
 import {sendChatQuery} from "../../../controller/agent/Agent"
 import {sendLlmRequest, StreamingUnit} from "../../../controller/llm/LlmChat"
@@ -308,6 +310,9 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
     const [optionsMenuAnchorEl, setOptionsMenuAnchorEl] = useState<null | HTMLElement>(null)
     const [optionsMenuOpen, setOptionsMenuOpen] = useState<boolean | undefined>(false)
 
+    // Whether the sly_data editor is showing
+    const [slyDataDialogOpen, setSlyDataDialogOpen] = useState<boolean>(false)
+
     // Persistent agent chat history store, which is where we store both kinds of chat histories
     // (see store implementation for details)
     const storedChatHistory = useAgentChatHistoryStore((state) =>
@@ -558,7 +563,11 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                         // It's a Neuro-san agent.
 
                         // Some coded tools (data generator...) expect the username provided in slyData.
-                        const slyDataWithUsername = {...agentChatHistory?.slyData, ...extraSlyData, login: currentUser}
+                        const slyDataWithUsername = {
+                            ...agentChatHistory?.slyData,
+                            ...extraSlyData,
+                            [SLY_DATA_LOGIN_KEY]: currentUser,
+                        }
                         await sendChatQuery(
                             neuroSanURL,
                             controller?.current.signal,
@@ -967,6 +976,18 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
         setShouldWrapOutput((prev) => !prev)
     }
 
+    const handleShowSlyData = () => {
+        handleOptionsMenuClose()
+        setSlyDataDialogOpen(true)
+    }
+
+    /**
+     * The sly_data keys that this component merges in on every request, on top of whatever is in the store. The
+     * sly_data editor lists them so that the user isn't surprised by keys arriving at the server that they never
+     * typed -- and, for the API keys among them, so that we never have to display their values.
+     */
+    const getMergedSlyDataKeys = (): readonly string[] => [...Object.keys(extraSlyData ?? {}), SLY_DATA_LOGIN_KEY]
+
     const getOptionsMenu = () => (
         <Menu
             id={`${id}-options-menu`}
@@ -1005,6 +1026,18 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                 </ListItemIcon>
                 <ListItemText primary="Wrap output" />
             </MenuItem>
+            {/* Legacy agents talk straight to an LLM and have no sly_data, so there is nothing to show for them */}
+            {!isLegacyAgentType(selectedNetwork) && (
+                <MenuItem
+                    id={`${id}-sly-data-menu-item`}
+                    onClick={handleShowSlyData}
+                >
+                    <ListItemIcon>
+                        <DataObjectIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Sly data..." />
+                </MenuItem>
+            )}
         </Menu>
     )
 
@@ -1140,6 +1173,16 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                     }}
                     okBtnLabel="Yes, clear chat"
                     title={`Clear all chat including history for ${networkDisplayName}?`}
+                />
+            ) : null}
+            {slyDataDialogOpen ? (
+                <SlyDataDialog
+                    extraSlyDataKeys={getMergedSlyDataKeys()}
+                    id={`${id}-sly-data-dialog`}
+                    isOpen={slyDataDialogOpen}
+                    networkDisplayName={networkDisplayName}
+                    networkId={selectedNetwork}
+                    onClose={() => setSlyDataDialogOpen(false)}
                 />
             ) : null}
             <Box

--- a/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
@@ -451,9 +451,12 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                 return
             }
 
-            // Shallow merge existing slyData with incoming chatMessage.sly_data
+            // Shallow merge existing slyData with incoming chatMessage.sly_data.
+            // Defense in depth: never let BYOK API keys enter the persistent store, even if a network echoes
+            // them back -- the store is displayed and exportable via the sly_data editor.
             if (chatMessage.sly_data) {
-                updateSlyData(selectedNetwork, chatMessage.sly_data)
+                const {llm_config: _, ...echoedSlyData} = chatMessage.sly_data
+                updateSlyData(selectedNetwork, echoedSlyData)
             }
 
             // It's a ChatMessage. Does it have chat context? Only AGENT_FRAMEWORK messages can have chat context.

--- a/packages/ui-common/components/AgentChat/ChatCommon/Const.ts
+++ b/packages/ui-common/components/AgentChat/ChatCommon/Const.ts
@@ -1,2 +1,5 @@
 // Maximum number of turns to save
 export const MAX_TURNS = 50
+
+// The sly_data key under which we supply the current username. Some coded tools (data generator...) expect it.
+export const SLY_DATA_LOGIN_KEY = "login"

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -24,7 +24,7 @@ import IconButton from "@mui/material/IconButton"
 import TextField from "@mui/material/TextField"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
-import {ChangeEvent, FC, useEffect, useMemo, useRef, useState} from "react"
+import {ChangeEvent, FC, Fragment, useEffect, useMemo, useRef, useState} from "react"
 
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
 import {downloadFile, toSafeFilename} from "../../../utils/File"
@@ -317,8 +317,24 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                 severity="info"
                 sx={{mt: 0.5, py: 0, "& .MuiAlert-message": {fontSize: "0.75rem"}}}
             >
-                Added automatically when you send: {[...extraSlyDataKeys].sort().join(", ")}. These come from your
-                settings and the selected network, not from this editor.
+                These keys are added automatically to every request:{" "}
+                {[...extraSlyDataKeys].sort().map((key, index) => (
+                    <Fragment key={key}>
+                        {index > 0 && ", "}
+                        <Box
+                            component="code"
+                            sx={{
+                                backgroundColor: "action.hover",
+                                borderRadius: 0.5,
+                                fontFamily: "monospace",
+                                px: 0.5,
+                            }}
+                        >
+                            {key}
+                        </Box>
+                    </Fragment>
+                ))}
+                . They come from your settings and the selected network, not from this editor.
             </Alert>
         )
 

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -1,0 +1,379 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import DataObjectIcon from "@mui/icons-material/DataObject"
+import DeleteOutlined from "@mui/icons-material/DeleteOutlined"
+import FileDownloadOutlined from "@mui/icons-material/FileDownloadOutlined"
+import FileUploadOutlined from "@mui/icons-material/FileUploadOutlined"
+import Alert from "@mui/material/Alert"
+import Box from "@mui/material/Box"
+import IconButton from "@mui/material/IconButton"
+import TextField from "@mui/material/TextField"
+import Tooltip from "@mui/material/Tooltip"
+import Typography from "@mui/material/Typography"
+import {ChangeEvent, FC, useEffect, useMemo, useRef, useState} from "react"
+
+import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
+import {downloadFile, toSafeFilename} from "../../../utils/File"
+import {findImageValues, formatSlyData, parseSlyData} from "../../../utils/SlyData"
+import {StyledButton} from "../../Common/ConfirmationModal"
+import {MUIDialog} from "../../Common/MUIDialog"
+import InfoTip from "../../Settings/InfoTip"
+
+//#region: Types
+export interface SlyDataDialogProps {
+    /**
+     * Names of the sly_data keys that the UI itself merges into each request (API keys, agent network definition,
+     * login...). Shown to the user as names only -- never values, since some of them are secrets.
+     */
+    readonly extraSlyDataKeys?: readonly string[]
+
+    /** HTML id to use for the outer component */
+    readonly id: string
+
+    readonly isOpen: boolean
+
+    /** The network whose sly_data is being edited. Sly data is stored per network. */
+    readonly networkId: string
+
+    /** Human-readable name of the network, for display only */
+    readonly networkDisplayName: string
+
+    readonly onClose: () => void
+}
+//#endregion: Types
+
+//#region: Constants
+
+// Avoids a new array literal as a default prop value on every render
+const NO_EXTRA_KEYS: readonly string[] = []
+
+// Height of the JSON editor, in rows. Big enough to see a realistic payload without dominating the screen.
+const EDITOR_ROWS = 14
+
+// Edge length of the image previews, in pixels
+const IMAGE_PREVIEW_SIZE = 96
+
+const SECURITY_WARNING =
+    "We strongly recommend against putting secrets in sly data, here or in any source file. Sly data tends to end " +
+    "up in source control and in logs."
+
+//#endregion: Constants
+
+/**
+ * Dialog for viewing and editing the sly_data of the selected agent network.
+ * <br>
+ * sly_data is the side-channel payload that rides along with every request: the server echoes it back as the
+ * conversation progresses, and the UI bounces it to the server on the next request. Until now it was invisible.
+ * This dialog exposes it as editable JSON, so a user can inspect what the agents are passing around and seed values
+ * of their own before the first turn.
+ * <br>
+ * Edits are written straight into the per-network chat history store, which is the same place the streaming code
+ * writes server-echoed sly_data and the same place the send path reads from. There is therefore no separate plumbing
+ * to the server: whatever is saved here goes out with the next request.
+ */
+export const SlyDataDialog: FC<SlyDataDialogProps> = ({
+    extraSlyDataKeys = NO_EXTRA_KEYS,
+    id,
+    isOpen,
+    networkId,
+    networkDisplayName,
+    onClose,
+}) => {
+    const storedSlyData = useAgentChatHistoryStore((state) =>
+        networkId ? state.history[networkId]?.slyData : undefined
+    )
+    const setSlyData = useAgentChatHistoryStore((state) => state.setSlyData)
+
+    const storedText = useMemo(() => formatSlyData(storedSlyData), [storedSlyData])
+
+    const [text, setText] = useState<string>(storedText)
+
+    // Whether the user has made changes that have not been saved yet
+    const [isDirty, setIsDirty] = useState<boolean>(false)
+
+    // The text the editor was last seeded with, so we can tell "the server changed sly_data" apart from
+    // "the user changed sly_data"
+    const [seededText, setSeededText] = useState<string>(storedText)
+
+    const fileInputRef = useRef<HTMLInputElement>(null)
+
+    // Seed the editor when the dialog opens, and keep following the store for as long as the user has not typed
+    // anything. Once there are unsaved edits we leave their text alone and offer a reload instead (see below).
+    useEffect(() => {
+        if (!isOpen) {
+            setIsDirty(false)
+            return
+        }
+
+        if (!isDirty) {
+            setText(storedText)
+            setSeededText(storedText)
+        }
+    }, [isOpen, isDirty, storedText])
+
+    const parseResult = useMemo(() => parseSlyData(text), [text])
+
+    const images = useMemo(() => findImageValues(parseResult.value), [parseResult])
+
+    // The server echoed new sly_data while the user had unsaved edits. Saying so beats silently discarding
+    // either side's version.
+    const wasUpdatedByServer = isDirty && storedText !== seededText
+
+    const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+        setText(event.target.value)
+        setIsDirty(true)
+    }
+
+    const handleReload = () => {
+        setText(storedText)
+        setSeededText(storedText)
+        setIsDirty(false)
+    }
+
+    const handleClear = () => {
+        setText("{}")
+        setIsDirty(true)
+    }
+
+    const handleExport = () => {
+        if (parseResult.error) {
+            return
+        }
+        const filename = `${toSafeFilename(`${networkId}-sly-data`)}.json`
+        downloadFile(formatSlyData(parseResult.value), filename, "application/json")
+    }
+
+    const handleFileSelected = async (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+
+        // Reset the input so that picking the same file again still fires a change event
+        event.target.value = ""
+
+        if (!file) {
+            return
+        }
+
+        // Whatever the file contains goes into the editor as-is. If it isn't usable sly_data, the same validation
+        // that guards typing will explain why.
+        setText(await file.text())
+        setIsDirty(true)
+    }
+
+    const handleSave = () => {
+        if (parseResult.error) {
+            return
+        }
+        setSlyData(networkId, parseResult.value)
+        setIsDirty(false)
+        onClose()
+    }
+
+    const getTitle = () => (
+        <Box sx={{alignItems: "center", display: "flex", gap: 0.75}}>
+            <DataObjectIcon
+                fontSize="small"
+                id={`${id}-title-icon`}
+            />
+            <span>Sly data for {networkDisplayName}</span>
+            <InfoTip title={SECURITY_WARNING} />
+        </Box>
+    )
+
+    const getToolbar = () => (
+        <Box sx={{display: "flex", gap: 0.5, justifyContent: "flex-end"}}>
+            <Tooltip title="Import from a JSON file">
+                <span>
+                    <IconButton
+                        aria-label="Import sly data"
+                        id={`${id}-import-button`}
+                        onClick={() => fileInputRef.current?.click()}
+                        size="small"
+                    >
+                        <FileUploadOutlined fontSize="small" />
+                    </IconButton>
+                </span>
+            </Tooltip>
+            <Tooltip title="Export to a JSON file">
+                <span>
+                    <IconButton
+                        aria-label="Export sly data"
+                        disabled={Boolean(parseResult.error)}
+                        id={`${id}-export-button`}
+                        onClick={handleExport}
+                        size="small"
+                    >
+                        <FileDownloadOutlined fontSize="small" />
+                    </IconButton>
+                </span>
+            </Tooltip>
+            <Tooltip title="Clear all sly data (takes effect when you save)">
+                <span>
+                    <IconButton
+                        aria-label="Clear sly data"
+                        id={`${id}-clear-button`}
+                        onClick={handleClear}
+                        size="small"
+                        sx={{"&:hover": {color: "error.main"}}}
+                    >
+                        <DeleteOutlined fontSize="small" />
+                    </IconButton>
+                </span>
+            </Tooltip>
+            <input
+                accept="application/json, .json"
+                aria-label="Sly data file"
+                data-testid={`${id}-file-input`}
+                id={`${id}-file-input`}
+                onChange={handleFileSelected}
+                ref={fileInputRef}
+                style={{display: "none"}}
+                type="file"
+            />
+        </Box>
+    )
+
+    const getServerUpdateAlert = () =>
+        wasUpdatedByServer && (
+            <Alert
+                action={
+                    <StyledButton
+                        id={`${id}-reload-button`}
+                        onClick={handleReload}
+                        variant="outlined"
+                    >
+                        Reload
+                    </StyledButton>
+                }
+                id={`${id}-server-update-alert`}
+                severity="info"
+                sx={{my: 1}}
+            >
+                The agents updated sly data while you were editing. Reloading discards your changes.
+            </Alert>
+        )
+
+    /**
+     * Preview strip for any values that look like images. Read-only: the underlying value stays editable as text.
+     * Agent networks do not have a settled convention for passing images over sly_data yet, so this displays what
+     * it can recognize rather than assuming a shape.
+     */
+    const getImagePreviews = () =>
+        images.length > 0 && (
+            <Box id={`${id}-images`}>
+                <Typography
+                    sx={{fontSize: "0.75rem", mt: 1}}
+                    variant="caption"
+                >
+                    Images in sly data
+                </Typography>
+                <Box sx={{display: "flex", flexWrap: "wrap", gap: 1, mt: 0.5}}>
+                    {images.map((image) => (
+                        <Box
+                            key={image.path}
+                            sx={{maxWidth: IMAGE_PREVIEW_SIZE, textAlign: "center"}}
+                        >
+                            <img
+                                alt={image.path}
+                                src={image.src}
+                                style={{
+                                    height: IMAGE_PREVIEW_SIZE,
+                                    objectFit: "contain",
+                                    width: IMAGE_PREVIEW_SIZE,
+                                }}
+                            />
+                            <Typography
+                                sx={{display: "block", fontSize: "0.7rem", overflowWrap: "anywhere"}}
+                                variant="caption"
+                            >
+                                {image.path}
+                            </Typography>
+                        </Box>
+                    ))}
+                </Box>
+            </Box>
+        )
+
+    /**
+     * Explains the keys that this dialog deliberately does not show, so that their absence doesn't look like a bug.
+     */
+    const getMergedKeysNote = () =>
+        extraSlyDataKeys.length > 0 && (
+            <Typography
+                id={`${id}-merged-keys`}
+                sx={{display: "block", mt: 1}}
+                variant="caption"
+            >
+                Added automatically when you send: {[...extraSlyDataKeys].sort().join(", ")}. These come from your
+                settings and the selected network, not from this editor.
+            </Typography>
+        )
+
+    const getFooter = () => (
+        <>
+            <StyledButton
+                id={`${id}-cancel-button`}
+                onClick={onClose}
+                variant="outlined"
+            >
+                Cancel
+            </StyledButton>
+            <StyledButton
+                disabled={Boolean(parseResult.error)}
+                id={`${id}-save-button`}
+                onClick={handleSave}
+                variant="contained"
+            >
+                Save
+            </StyledButton>
+        </>
+    )
+
+    return (
+        <MUIDialog
+            contentSx={{minWidth: "550px", paddingTop: "0"}}
+            footer={getFooter()}
+            id={id}
+            isOpen={isOpen}
+            onClose={onClose}
+            paperProps={{maxWidth: "800px", width: "80vw"}}
+            title={getTitle()}
+        >
+            {getToolbar()}
+            {getServerUpdateAlert()}
+            <TextField
+                error={Boolean(parseResult.error)}
+                fullWidth
+                helperText={parseResult.error ?? " "}
+                id={`${id}-editor`}
+                maxRows={EDITOR_ROWS}
+                minRows={EDITOR_ROWS}
+                multiline
+                onChange={handleTextChange}
+                slotProps={{
+                    htmlInput: {
+                        "aria-label": "Sly data",
+                        spellCheck: false,
+                        style: {fontFamily: "monospace", fontSize: "0.8rem"},
+                    },
+                }}
+                value={text}
+            />
+            {getImagePreviews()}
+            {getMergedKeysNote()}
+        </MUIDialog>
+    )
+}

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -67,9 +67,10 @@ const EDITOR_ROWS = 14
 // Edge length of the image previews, in pixels
 const IMAGE_PREVIEW_SIZE = 96
 
-const SECURITY_WARNING =
-    "We strongly recommend against putting secrets in sly data, here or in any source file. Sly data tends to end " +
-    "up in source control and in logs."
+// Tooltip explaining what sly data is, in end-user terms: it exists to carry values (credentials included) that
+// belong with the request but must stay out of the LLM conversation.
+const SLY_DATA_EXPLAINER =
+    "Data is sent to the agent network in a private channel with each request but kept out of the LLM."
 
 //#endregion: Constants
 
@@ -183,7 +184,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                 id={`${id}-title-icon`}
             />
             <span>Sly data for {networkDisplayName}</span>
-            <InfoTip title={SECURITY_WARNING} />
+            <InfoTip title={SLY_DATA_EXPLAINER} />
         </Box>
     )
 

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -283,6 +283,8 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                         >
                             <img
                                 alt={image.path}
+                                loading="lazy"
+                                referrerPolicy="no-referrer"
                                 src={image.src}
                                 style={{
                                     height: IMAGE_PREVIEW_SIZE,

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -317,7 +317,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                 severity="info"
                 sx={{mt: 0.5, py: 0, "& .MuiAlert-message": {fontSize: "0.75rem"}}}
             >
-                These keys are added automatically to every request:{" "}
+                Sent automatically with every request:{" "}
                 {[...extraSlyDataKeys].sort().map((key, index) => (
                     <Fragment key={key}>
                         {index > 0 && ", "}
@@ -334,7 +334,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                         </Box>
                     </Fragment>
                 ))}
-                . They come from your settings and the selected network, not from this editor.
+                . Supplied by the app, not from this editor.
             </Alert>
         )
 

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -312,14 +312,14 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
      */
     const getMergedKeysNote = () =>
         extraSlyDataKeys.length > 0 && (
-            <Typography
+            <Alert
                 id={`${id}-merged-keys`}
-                sx={{display: "block", mt: 1}}
-                variant="caption"
+                severity="info"
+                sx={{mt: 0.5, py: 0, "& .MuiAlert-message": {fontSize: "0.75rem"}}}
             >
                 Added automatically when you send: {[...extraSlyDataKeys].sort().join(", ")}. These come from your
                 settings and the selected network, not from this editor.
-            </Typography>
+            </Alert>
         )
 
     const getFooter = () => (

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -24,7 +24,7 @@ import IconButton from "@mui/material/IconButton"
 import TextField from "@mui/material/TextField"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
-import {ChangeEvent, FC, Fragment, useEffect, useMemo, useRef, useState} from "react"
+import {ChangeEvent, FC, Fragment, useMemo, useRef, useState} from "react"
 
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
 import {downloadFile, toSafeFilename} from "../../../utils/File"
@@ -100,30 +100,21 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
     const storedText = useMemo(() => formatSlyData(storedSlyData), [storedSlyData])
 
-    const [text, setText] = useState<string>(storedText)
+    // The user's unsaved edit, or null while they have none. While null, the editor simply renders the store,
+    // so server-echoed updates show up without any syncing code. Once the user edits, their draft is what
+    // renders, and we offer a reload instead of overwriting it (see below).
+    const [draft, setDraft] = useState<string | null>(null)
 
-    // Whether the user has made changes that have not been saved yet
-    const [isDirty, setIsDirty] = useState<boolean>(false)
-
-    // The text the editor was last seeded with, so we can tell "the server changed sly_data" apart from
-    // "the user changed sly_data"
-    const [seededText, setSeededText] = useState<string>(storedText)
+    // What the store held when the user started editing, so we can tell "the server changed sly_data" apart
+    // from "the user changed sly_data"
+    const [draftBaseline, setDraftBaseline] = useState<string | null>(null)
 
     const fileInputRef = useRef<HTMLInputElement>(null)
 
-    // Seed the editor when the dialog opens, and keep following the store for as long as the user has not typed
-    // anything. Once there are unsaved edits we leave their text alone and offer a reload instead (see below).
-    useEffect(() => {
-        if (!isOpen) {
-            setIsDirty(false)
-            return
-        }
+    // Derived rather than stored: dirtiness is simply "a draft exists"
+    const isDirty = draft !== null
 
-        if (!isDirty) {
-            setText(storedText)
-            setSeededText(storedText)
-        }
-    }, [isOpen, isDirty, storedText])
+    const text = draft ?? storedText
 
     const parseResult = useMemo(() => parseSlyData(text), [text])
 
@@ -131,22 +122,27 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
     // The server echoed new sly_data while the user had unsaved edits. Saying so beats silently discarding
     // either side's version.
-    const wasUpdatedByServer = isDirty && storedText !== seededText
+    const wasUpdatedByServer = isDirty && storedText !== draftBaseline
+
+    /** Records a user edit, snapshotting what the store held when editing began. */
+    const startOrUpdateDraft = (newText: string) => {
+        if (draft === null) {
+            setDraftBaseline(storedText)
+        }
+        setDraft(newText)
+    }
 
     const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-        setText(event.target.value)
-        setIsDirty(true)
+        startOrUpdateDraft(event.target.value)
     }
 
     const handleReload = () => {
-        setText(storedText)
-        setSeededText(storedText)
-        setIsDirty(false)
+        setDraft(null)
+        setDraftBaseline(null)
     }
 
     const handleClear = () => {
-        setText("{}")
-        setIsDirty(true)
+        startOrUpdateDraft("{}")
     }
 
     const handleExport = () => {
@@ -169,8 +165,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
         // Whatever the file contains goes into the editor as-is. If it isn't usable sly_data, the same validation
         // that guards typing will explain why.
-        setText(await file.text())
-        setIsDirty(true)
+        startOrUpdateDraft(await file.text())
     }
 
     const handleSave = () => {
@@ -178,7 +173,6 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
             return
         }
         setSlyData(networkId, parseResult.value)
-        setIsDirty(false)
         onClose()
     }
 

--- a/packages/ui-common/state/ChatHistory.ts
+++ b/packages/ui-common/state/ChatHistory.ts
@@ -8,9 +8,7 @@ import {persist, PersistStorage, StorageValue} from "zustand/middleware"
 
 import {indexedDBStorage} from "./IndexedDBStorage"
 import {ChatContext} from "../generated/neuro-san/NeuroSanClient"
-
-// Define a type to represent sly_data, which is super loose and can be almost anything depending on the agent.
-type SlyData = Record<string, unknown>
+import {SlyData} from "../utils/SlyData"
 
 // Maximum number of messages to keep in the chat history for each agent. Once we reach this limit, we will start
 // dropping old messages.
@@ -141,7 +139,10 @@ export const useAgentChatHistoryStore = create<ChatHistoryStore>()(
                 }),
             setSlyData: (agentId: string, slyData: SlyData) =>
                 set((state) => {
-                    const existing = state.history[agentId]
+                    // The editor can save sly_data before any conversation exists, so initialize the rest of the
+                    // entry with the same defaults readers expect instead of leaving the fields undefined.
+                    const fallback: AgentChatHistory<BaseMessage[]> = {chatHistory: [], chatContext: null, slyData}
+                    const existing = state.history[agentId] ?? fallback
                     const newHistory = {...state.history, [agentId]: {...existing, slyData}}
                     return {history: newHistory}
                 }),

--- a/packages/ui-common/state/ChatHistory.ts
+++ b/packages/ui-common/state/ChatHistory.ts
@@ -38,8 +38,17 @@ interface AgentChatHistory<T = BaseMessage[] | ReturnType<typeof mapChatMessages
 interface ChatHistoryStore {
     readonly history: Record<string, AgentChatHistory<BaseMessage[]>>
     resetHistory: (agentId: string) => void
+    /**
+     * Replaces the sly_data for an agent outright, so that keys the caller left out are removed. Used by the
+     * sly_data editor, where the user has to be able to delete keys. Contrast with `updateSlyData`, which merges.
+     */
+    setSlyData: (agentId: string, slyData: SlyData) => void
     updateChatContext: (agentId: string, chatContext: ChatContext) => void
     updateChatHistory: (agentId: string, messages: BaseMessage[]) => void
+    /**
+     * Merges incoming sly_data into whatever the agent already has. Used for sly_data echoed by the server during
+     * streaming, where each message carries only the keys that changed.
+     */
     updateSlyData: (agentId: string, slyData: SlyData) => void
     /**
      * Copies the full history entry from `fromId` to `toId`. Used when a temporary network is replaced
@@ -128,6 +137,12 @@ export const useAgentChatHistoryStore = create<ChatHistoryStore>()(
                     const existing = state.history[agentId]
                     const mergedSlyData = {...existing?.slyData, ...slyData}
                     const newHistory = {...state.history, [agentId]: {...existing, slyData: mergedSlyData}}
+                    return {history: newHistory}
+                }),
+            setSlyData: (agentId: string, slyData: SlyData) =>
+                set((state) => {
+                    const existing = state.history[agentId]
+                    const newHistory = {...state.history, [agentId]: {...existing, slyData}}
                     return {history: newHistory}
                 }),
             resetHistory: (agentId: string) =>

--- a/packages/ui-common/utils/SlyData.ts
+++ b/packages/ui-common/utils/SlyData.ts
@@ -21,6 +21,12 @@ limitations under the License.
  * but coded tools read from and write to it. It is "super loose": any JSON object the agent network cares to define.
  */
 
+/**
+ * A sly_data payload. Deliberately loose: the shape is defined by each agent network, so the UI can only assume
+ * "a JSON object".
+ */
+export type SlyData = Record<string, unknown>
+
 // How many levels deep to look for image values. Deep enough for realistic payloads, shallow enough that a
 // pathological structure can't lock up the browser.
 const MAX_IMAGE_SEARCH_DEPTH = 6
@@ -55,7 +61,7 @@ export interface SlyDataParseResult {
     readonly error?: string
 
     /** The parsed sly_data. Empty when `error` is set. */
-    readonly value: Record<string, unknown>
+    readonly value: SlyData
 }
 
 /**
@@ -63,7 +69,7 @@ export interface SlyDataParseResult {
  * @param data The sly_data to render. May be undefined, in which case an empty object is rendered.
  * @returns The sly_data as indented JSON text.
  */
-export const formatSlyData = (data?: Record<string, unknown>): string => JSON.stringify(data ?? {}, null, 2)
+export const formatSlyData = (data?: SlyData): string => JSON.stringify(data ?? {}, null, 2)
 
 /**
  * Parses sly_data text supplied by the user, rejecting anything that is not a JSON object.
@@ -95,7 +101,7 @@ export const parseSlyData = (text: string): SlyDataParseResult => {
         return {error: "Sly data must be a JSON object, not a primitive value.", value: {}}
     }
 
-    return {value: parsed as Record<string, unknown>}
+    return {value: parsed as SlyData}
 }
 
 /**

--- a/packages/ui-common/utils/SlyData.ts
+++ b/packages/ui-common/utils/SlyData.ts
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Helpers for viewing and editing sly_data as JSON.
+ *
+ * sly_data is the side-channel payload that travels with each request to an agent network. It never reaches the LLM,
+ * but coded tools read from and write to it. It is "super loose": any JSON object the agent network cares to define.
+ */
+
+// How many levels deep to look for image values. Deep enough for realistic payloads, shallow enough that a
+// pathological structure can't lock up the browser.
+const MAX_IMAGE_SEARCH_DEPTH = 6
+
+// Upper bound on how many images we will display, to keep the dialog usable.
+const MAX_IMAGE_RESULTS = 20
+
+// Prefix of a base64-encoded image supplied as a data URI, eg. "data:image/png;base64,iVBORw0KG..."
+const IMAGE_DATA_URI_PREFIX = "data:image/"
+
+// File extensions we recognize as images when a value is an http(s) URL
+const IMAGE_FILE_EXTENSIONS = [".apng", ".avif", ".bmp", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"]
+
+/**
+ * An image found somewhere inside a sly_data payload.
+ */
+export interface SlyDataImage {
+    /** Where the image was found, as a readable key path, eg. `"report.charts[0]"` */
+    readonly path: string
+
+    /** The value itself, suitable for use as the `src` of an `img` element */
+    readonly src: string
+}
+
+/**
+ * The outcome of parsing user-supplied sly_data text.
+ * @note Deliberately not a discriminated union: this repo compiles with `strictNullChecks` off, where narrowing on
+ * a boolean discriminant is unreliable.
+ */
+export interface SlyDataParseResult {
+    /** Why the text cannot be used as sly_data, or undefined if it parsed fine */
+    readonly error?: string
+
+    /** The parsed sly_data. Empty when `error` is set. */
+    readonly value: Record<string, unknown>
+}
+
+/**
+ * Renders sly_data as pretty-printed JSON for display in an editor.
+ * @param data The sly_data to render. May be undefined, in which case an empty object is rendered.
+ * @returns The sly_data as indented JSON text.
+ */
+export const formatSlyData = (data?: Record<string, unknown>): string => JSON.stringify(data ?? {}, null, 2)
+
+/**
+ * Parses sly_data text supplied by the user, rejecting anything that is not a JSON object.
+ * <br>
+ * The root has to be an object because that is what the server expects: sly_data is a map of keys to values, and
+ * an array or a primitive at the root cannot be merged with the entries the UI itself supplies (API keys, login...).
+ * @param text The text to parse. Empty or whitespace-only text is treated as an empty object.
+ * @returns The parsed object, or a message describing why the text is not usable as sly_data.
+ */
+export const parseSlyData = (text: string): SlyDataParseResult => {
+    const trimmed = text?.trim() ?? ""
+
+    if (trimmed.length === 0) {
+        return {value: {}}
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(trimmed)
+    } catch (error: unknown) {
+        return {error: error instanceof Error ? error.message : "Invalid JSON.", value: {}}
+    }
+
+    if (Array.isArray(parsed)) {
+        return {error: "Sly data must be a JSON object, not an array.", value: {}}
+    }
+
+    if (parsed === null || typeof parsed !== "object") {
+        return {error: "Sly data must be a JSON object, not a primitive value.", value: {}}
+    }
+
+    return {value: parsed as Record<string, unknown>}
+}
+
+/**
+ * Determines whether a string value looks like something we can display as an image.
+ * @param value The string to test.
+ * @returns True if the value is an image data URI or an http(s) URL with an image file extension.
+ */
+const isImageValue = (value: string): boolean => {
+    if (value.startsWith(IMAGE_DATA_URI_PREFIX)) {
+        return true
+    }
+
+    if (!value.startsWith("http://") && !value.startsWith("https://")) {
+        return false
+    }
+
+    // Ignore any query string or fragment so that eg. "https://example.com/a.png?size=large" still matches
+    const withoutQuery = value.split("?", 1)[0].split("#", 1)[0].toLowerCase()
+    return IMAGE_FILE_EXTENSIONS.some((extension) => withoutQuery.endsWith(extension))
+}
+
+/**
+ * Finds every value inside a sly_data payload that can be displayed as an image.
+ * <br>
+ * This is the extension point for image support: agent networks do not yet have an agreed convention for passing
+ * images over sly_data, so we recognize the two encodings that are unambiguous today (data URIs and image URLs).
+ * Supporting a new encoding means teaching {@link isImageValue} about it -- nothing else needs to change.
+ * @param data Any part of a sly_data payload. Objects and arrays are searched recursively.
+ * @returns The images found, in document order, capped at a sane maximum.
+ */
+export const findImageValues = (data: unknown): readonly SlyDataImage[] => {
+    const found: SlyDataImage[] = []
+
+    const walk = (value: unknown, path: string, depth: number): void => {
+        if (depth > MAX_IMAGE_SEARCH_DEPTH || found.length >= MAX_IMAGE_RESULTS) {
+            return
+        }
+
+        if (typeof value === "string") {
+            if (isImageValue(value)) {
+                found.push({path, src: value})
+            }
+            return
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach((item: unknown, index: number) => walk(item, `${path}[${index}]`, depth + 1))
+            return
+        }
+
+        if (value !== null && typeof value === "object") {
+            Object.entries(value).forEach(([key, item]: [string, unknown]) =>
+                walk(item, path.length > 0 ? `${path}.${key}` : key, depth + 1)
+            )
+        }
+    }
+
+    walk(data, "", 0)
+
+    return found
+}


### PR DESCRIPTION
Addresses #52 

### Overview

* Adds a sly data editor to the chat: ⚙ options menu → "Sly data…" opens a dialog showing the selected network's `sly_data` as editable JSON, with import/export/clear and validation.

* Why: the server echoes `sly_data` every turn and the UI bounces it back, but users could never see or seed it. This makes the existing loop visible - no changes to the wire format, controller, or send path; the editor writes to the same per-network store the send path already reads.

* Implementation: `utils/SlyData.ts` (format/parse/image-detection helpers) · `setSlyData` store action (replace semantics, so keys can be deleted; streaming keeps merging via `updateSlyData`) · `SlyDataDialog` + menu wiring in `ChatCommon`. Values that look like images render as thumbnails .

* Verified: e2e vs a local neuro-san on `music_nerd_pro_sly` - typed `running_cost: 100`, Accountant returned `103` (its deliberate +3.0), echo shown back in the dialog. Screenshots below. 


<img width="1525" height="784" alt="screenshot-1785598855497-7" src="https://github.com/user-attachments/assets/5c52179d-a8c4-40b2-81c4-6b6934c70f75" />

<img width="1525" height="784" alt="screenshot-1785598951963-8" src="https://github.com/user-attachments/assets/f39f1379-7638-4d06-9a66-8f7bfb4d4e1e" />



- No new dependencies, endpoints, env vars, or API routes.
- Behaviour ported from nsflow's `EditorSlyDataPanel`, not the code - it uses
  `json-edit-react` and a localStorage cache, neither of which fits here. 

I am way out of my depth here, so expecting alot of push back. Bring those comments :)


