### PR TITLE
Enable fork pull request CI runs

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -20,6 +20,7 @@
 # Trigger Scenarios:
 # - Push to any branch: Runs tests only (for development feedback)
 # - Push to main branch: Runs test → build → deploy to dev
+# - Pull request to main: Runs tests only; supports fork PRs via workflow approval
 # - GitHub release: Runs test → build → deploy to staging → bump package.json
 # ================================================================================
 
@@ -32,9 +33,18 @@ on:
     # Trigger on pushes to any branch
     push:
         branches: ["**"]
+    # Trigger on pull requests targeting main, including updates from forks
+    pull_request:
+        types: [opened, synchronize, reopened]
+        branches:
+            - main
     # Trigger on GitHub release events
     release:
         types: [published]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
+    cancel-in-progress: true
 
 permissions:
     id-token: write
@@ -64,8 +74,12 @@ jobs:
                     "${{ github.event.release.tag_name }}" \
                     "${{ github.sha }}"
 
-    # Step 1: Always run tests
+    # Step 1: Always run tests on pushes, releases, and pull requests targeting main
     test:
+        if: >
+            github.event_name == 'push' ||
+            github.event_name == 'release' ||
+            (github.event_name == 'pull_request' && github.base_ref == 'main')
         uses: ./.github/workflows/test.yml
         needs: setup
         with:

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -46,8 +46,8 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
     cancel-in-progress: true
 
+# Minimal default permissions; jobs that need extra permissions override below.
 permissions:
-    id-token: write
     contents: read
 
 jobs:
@@ -87,6 +87,9 @@ jobs:
 
     # Step 2: Build Docker image (only for main/release)
     build:
+        permissions:
+            id-token: write
+            contents: read
         uses: ./.github/workflows/build.yml
         needs: [setup, test]
         if: needs.test.result == 'success' && needs.setup.outputs.should_build == 'true'

--- a/build_scripts/determine_version.sh
+++ b/build_scripts/determine_version.sh
@@ -23,8 +23,8 @@
 # Usage: determine_version.sh <event_name> <ref> [tag_name] [sha]
 #
 # Arguments:
-#   event_name: The GitHub event name (e.g., "release", "push")
-#   ref: The GitHub ref (e.g., "refs/heads/main", "refs/heads/feature-branch")
+#   event_name: The GitHub event name (e.g., "release", "push", "pull_request")
+#   ref: The GitHub ref (e.g., "refs/heads/main", "refs/heads/feature-branch", "refs/pull/123/merge")
 #   tag_name: (Optional) The release tag name (required if event_name is "release")
 #   sha: (Optional) The Git SHA (required for non-release events)
 #
@@ -71,7 +71,7 @@ if [[ "$EVENT_NAME" == "release" ]]; then
 elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
     # Push to main: Deploy to dev with short SHA
     if [[ -z "$SHA" ]]; then
-        echo "Error: sha is required for push events" >&2
+        echo "Error: sha is required for non-release events" >&2
         exit 1
     fi
     
@@ -80,10 +80,22 @@ elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
     SHOULD_BUILD="true"
     SHOULD_DEPLOY="true"
     
-else
-    # Any other branch push: Only test, no build or deploy
+elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+    # Pull request to main: Only test, no build or deploy
     if [[ -z "$SHA" ]]; then
-        echo "Error: sha is required for push events" >&2
+        echo "Error: sha is required for non-release events" >&2
+        exit 1
+    fi
+    
+    VERSION="${SHA:0:7}"
+    DEPLOY_ENV="dev"
+    SHOULD_BUILD="false"
+    SHOULD_DEPLOY="false"
+    
+else
+    # Any other branch/ref event: Only test, no build or deploy
+    if [[ -z "$SHA" ]]; then
+        echo "Error: sha is required for non-release events" >&2
         exit 1
     fi
     


### PR DESCRIPTION
## Summary

Adds a `pull_request` trigger with `synchronize` to the Orchestrator workflow and a concurrency group so fork PRs queue workflow runs that maintainers can approve, while internal branch `push` and `pull_request` events for the same commit cancel instead of duplicating. 

Note: back in the old days, before public repos and forked repos, we removed the `sychronize` trigger to avoid duplicated action triggers for push/pull requests. Now we need the `synchronize` trigger to support forks (as they don't emit `push`) . So now that we've re-added a `synchronize` trigger with a concurrency group it means we will get two action _triggers_ but only one of those will _run_. The other will show up in the Actions list as cancelled. That's the best behavior we could come up with.  neuro-san repo adopts this behavior as well.

Updates `determine_version.sh` to handle `pull_request` events as test-only, matching the recent neuro-san fix.

Link to Devin session: https://app.devin.ai/sessions/de18e5fdd36d451b849904545ca02ab7
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->