### PR TITLE
#502 Persist user preferences for graph display

### DIFF
--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow/AgentFlow.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/AgentFlow/AgentFlow.test.tsx
@@ -33,6 +33,7 @@ import {AgentNetworkDefinitionEntry} from "../../../../components/MultiAgentAcce
 import {ThoughtBubbleEdgeShape} from "../../../../components/MultiAgentAccelerator/ThoughtBubbles/ThoughtBubbleEdge"
 import {sendChatQuery} from "../../../../controller/agent/Agent"
 import {ChatMessageType, ChatResponse, ConnectivityInfo} from "../../../../generated/neuro-san/NeuroSanClient"
+import {useSettingsStore} from "../../../../state/Settings"
 import {useTempNetworksStore} from "../../../../state/TemporaryNetworks"
 import {PALETTES} from "../../../../Theme/Palettes"
 import {cleanUpAgentName} from "../../../../utils/AgentName"
@@ -186,6 +187,9 @@ describe("AgentFlow", () => {
             mode: "light",
         })
         useTempNetworksStore.getState().setTempNetworks([])
+
+        useSettingsStore.getState().resetSettings()
+        useSettingsStore.persist.clearStorage()
     })
 
     // Helper to create a minimal TemporaryNetwork for seeding the store in tests.
@@ -479,7 +483,7 @@ describe("AgentFlow", () => {
             verifyAgentNodes(container)
         })
 
-        it("Should show radial guides only in radial layout with more than one depth", () => {
+        it("Should show radial guides only in radial layout with more than one depth", async () => {
             const {container, rerender} = renderAgentFlowComponent()
 
             // Should show radial guides SVG with more than one node (which is used for the default test network)
@@ -507,7 +511,9 @@ describe("AgentFlow", () => {
             )
 
             // Should not show radial guides SVG with only one node
-            expect(container.querySelector("#test-flow-id-radial-guides")).not.toBeInTheDocument()
+            await waitFor(() => {
+                expect(container.querySelector("#test-flow-id-radial-guides")).not.toBeInTheDocument()
+            })
         })
 
         it("Should handle radial guides toggle when layout is linear", async () => {
@@ -541,7 +547,9 @@ describe("AgentFlow", () => {
             await user.click(radialGuidesButton)
 
             // Radial guides should be visible again
-            expect(container.querySelector("#test-flow-id-radial-guides")).toBeInTheDocument()
+            await waitFor(() => {
+                expect(container.querySelector("#test-flow-id-radial-guides")).toBeInTheDocument()
+            })
         })
     })
 

--- a/packages/ui-common/__tests__/unit/MultiAgentAccelerator/AgentFlow/GraphLayouts.test.ts
+++ b/packages/ui-common/__tests__/unit/MultiAgentAccelerator/AgentFlow/GraphLayouts.test.ts
@@ -87,6 +87,8 @@ describe("GraphLayouts", () => {
         {origin: "agent3", tools: []},
     ]
 
+    const graphWithoutFrontMan: ConnectivityInfo[] = [{origin: undefined, tools: ["agent2"]}]
+
     it("Should generate a linear layout", () => {
         const {nodes, edges} = layoutLinear({
             ...defaultLayoutParams,
@@ -401,6 +403,20 @@ describe("GraphLayouts", () => {
 
         expect(nodes.length).toBeGreaterThanOrEqual(0) // undefined behavior with bad input
         expect(edges.length).toBeGreaterThanOrEqual(0) // undefined behavior with bad input
+    })
+
+    it.each([
+        {layoutFunction: layoutRadial, name: "radial", expectedNodes: 0, expectedEdges: 0},
+        {layoutFunction: layoutLinear, name: "linear", expectedNodes: 1, expectedEdges: 0},
+    ])("Should handle a graph with no frontman in $name layout", ({expectedEdges, expectedNodes, layoutFunction}) => {
+        // This is an invalid case. Every network should have a frontman. But let's at least make sure we don't crash.
+        const {nodes, edges} = layoutFunction({
+            ...defaultLayoutParams,
+            agentsInNetwork: graphWithoutFrontMan,
+        })
+
+        expect(nodes.length).toEqual(expectedNodes)
+        expect(edges.length).toEqual(expectedEdges)
     })
 
     describe("Thought Bubble Edge Management", () => {

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow/AgentFlow.tsx
@@ -79,7 +79,7 @@ import {StreamingUnit} from "../../../controller/llm/LlmChat"
 import {AgentIconSuggestions} from "../../../controller/Types/AgentIconSuggestions"
 import {ConnectivityInfo} from "../../../generated/neuro-san/NeuroSanClient"
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
-import {usePalette, useSettingsStore} from "../../../state/Settings"
+import {GraphColoringOption, Layout, usePalette, useSettingsStore} from "../../../state/Settings"
 import {TemporaryNetwork, useTempNetworksStore} from "../../../state/TemporaryNetworks"
 import {getZIndex} from "../../../utils/zIndexLayers"
 import {chatMessageFromChunk} from "../../AgentChat/Common/Utils"
@@ -95,6 +95,7 @@ import {
 } from "../TemporaryNetworks"
 import {ThoughtBubbleEdge, ThoughtBubbleEdgeShape} from "../ThoughtBubbles/ThoughtBubbleEdge"
 import {ThoughtBubbleOverlay} from "../ThoughtBubbles/ThoughtBubbleOverlay"
+
 //#region: Types
 export interface AgentFlowProps {
     readonly agentCounts?: Map<string, number>
@@ -132,8 +133,6 @@ export interface AgentFlowProps {
         SetStateAction<Map<string, {edge: ThoughtBubbleEdgeShape; timestamp: number}>>
     >
 }
-
-type Layout = "radial" | "linear"
 
 //#endregion: Types
 
@@ -265,13 +264,43 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         return () => window.removeEventListener("resize", handleResize)
     }, [handleResize])
 
-    const [layout, setLayout] = useState<Layout>("radial")
+    const updateSettings = useSettingsStore((state) => state.updateSettings)
 
-    const [coloringOption, setColoringOption] = useState<"depth" | "heatmap">("depth")
+    const layout = useSettingsStore((state) => state.settings.appearance.layout)
+    const setLayout = (newLayout: Layout) => {
+        updateSettings({
+            appearance: {
+                layout: newLayout,
+            },
+        })
+    }
 
-    const [enableRadialGuides, setEnableRadialGuides] = useState<boolean>(true)
+    const graphColoringOption = useSettingsStore((state) => state.settings.appearance.graphColoringOption)
+    const setGraphColoringOption = (newValue: GraphColoringOption) => {
+        updateSettings({
+            appearance: {
+                graphColoringOption: newValue,
+            },
+        })
+    }
 
-    const [showThoughtBubbles, setShowThoughtBubbles] = useState<boolean>(true)
+    const showRadialGuides = useSettingsStore((state) => state.settings.appearance.showRadialGuides)
+    const setShowRadialGuides = (newValue: boolean) => {
+        updateSettings({
+            appearance: {
+                showRadialGuides: newValue,
+            },
+        })
+    }
+
+    const showThoughtBubbles = useSettingsStore((state) => state.settings.appearance.showThoughtBubbles)
+    const setShowThoughtBubbles = (newValue: boolean) => {
+        updateSettings({
+            appearance: {
+                showThoughtBubbles: newValue,
+            },
+        })
+    }
 
     // Read temporary networks to find agent_network_definition for the currently selected network.
     const tempNetworks = useTempNetworksStore((state) => state.tempNetworks)
@@ -377,7 +406,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
         return () => clearInterval(cleanupInterval)
     }, [setThoughtBubbleEdges]) // mount/unmount only
 
-    const isHeatmap = coloringOption === "heatmap"
+    const isHeatmap = graphColoringOption === "heatmap"
 
     const palette = usePalette()
 
@@ -406,9 +435,9 @@ export const AgentFlow: FC<AgentFlowProps> = ({
 
     // Create the flow layout depending on user preference
     // Memoize layoutResult so it only recalculates when relevant data changes
-    const layoutResult: LayoutResult = useMemo(
-        () =>
-            layout === "linear"
+    const layoutResult: LayoutResult = useMemo(() => {
+        if (mergedAgentsInNetwork.length > 0) {
+            return layout === "linear"
                 ? layoutLinear({
                       agentCounts: isHeatmap ? agentCounts : undefined,
                       agentIconSuggestions,
@@ -430,21 +459,23 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                       isTemporaryNetwork,
                       thoughtBubbleEdges,
                       useNativeNames,
-                  }),
-        [
-            agentCounts,
-            agentIconSuggestions,
-            currentConversations,
-            isAgentNetworkDesignerMode,
-            isAwaitingLlm,
-            isHeatmap,
-            isTemporaryNetwork,
-            layout,
-            mergedAgentsInNetwork,
-            thoughtBubbleEdges,
-            useNativeNames,
-        ]
-    )
+                  })
+        } else {
+            return {nodes: [], edges: []}
+        }
+    }, [
+        agentCounts,
+        agentIconSuggestions,
+        currentConversations,
+        isAgentNetworkDesignerMode,
+        isAwaitingLlm,
+        isHeatmap,
+        isTemporaryNetwork,
+        layout,
+        mergedAgentsInNetwork,
+        thoughtBubbleEdges,
+        useNativeNames,
+    ])
 
     const [nodes, setNodes] = useState<RFNode<AgentNodeProps>[]>(layoutResult.nodes)
 
@@ -876,11 +907,11 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                 ))}
                 <ToggleButtonGroup
                     id={`${id}-coloring-toggle`}
-                    value={coloringOption}
+                    value={graphColoringOption}
                     exclusive={true}
                     onChange={(_, newValue) => {
                         if (newValue !== null) {
-                            setColoringOption(newValue)
+                            setGraphColoringOption(newValue)
                         }
                     }}
                     size="small"
@@ -936,7 +967,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
     }
 
     // Only show radial guides if radial layout is selected, radial guides are enabled, and it's not just Frontman
-    const shouldShowRadialGuides = enableRadialGuides && layout === "radial" && maxDepth > 1
+    const shouldShowRadialGuides = showRadialGuides && layout === "radial" && maxDepth > 1
 
     // Generate the control bar for the flow, including layout and radial guides toggles
     const getControls = () => {
@@ -996,9 +1027,9 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                     <span id="radial-guides-span">
                         <ControlButton
                             id="radial-guides-button"
-                            onClick={() => setEnableRadialGuides(!enableRadialGuides)}
+                            onClick={() => setShowRadialGuides(!showRadialGuides)}
                             style={{
-                                backgroundColor: getControlButtonBackgroundColor(enableRadialGuides),
+                                backgroundColor: getControlButtonBackgroundColor(showRadialGuides),
                             }}
                             disabled={layout !== "radial"}
                         >
@@ -1030,8 +1061,10 @@ export const AgentFlow: FC<AgentFlowProps> = ({
     const titleBackgroundColor = alpha(theme.palette.background.paper, 0.75)
 
     const getTitle = () => {
+        if (!networkDisplayName) return null
+
         return (
-            networkDisplayName && (
+            <Box sx={{marginBottom: "1rem"}}>
                 <Box
                     id={`${id}-network-title-bar`}
                     sx={{
@@ -1039,6 +1072,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                         display: "flex",
                         gap: 1,
                         left: "50%",
+
                         pointerEvents: "none",
                         position: "absolute",
                         top: 0,
@@ -1050,31 +1084,30 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                         title={networkDisplayName}
                         placement="top"
                     >
-                        <Box sx={{pointerEvents: "auto"}}>
-                            <Typography
-                                id={`${id}-network-title`}
-                                variant="subtitle1"
-                                sx={{
-                                    backdropFilter: "blur(6px)",
-                                    backgroundColor: titleBackgroundColor,
-                                    border: `1px solid ${alpha(theme.palette.divider, 0.75)}`,
-                                    borderRadius: 2,
-                                    boxShadow: theme.shadows[6],
-                                    color: theme.palette.text.primary,
-                                    fontWeight: 600,
-                                    letterSpacing: "0.01em",
-                                    lineHeight: 1.35,
-                                    maxWidth: 400,
-                                    overflow: "hidden",
-                                    px: 2,
-                                    py: 0.45,
-                                    textOverflow: "ellipsis",
-                                    whiteSpace: "nowrap",
-                                }}
-                            >
-                                {networkDisplayName}
-                            </Typography>
-                        </Box>
+                        <Typography
+                            id={`${id}-network-title`}
+                            variant="subtitle1"
+                            sx={{
+                                backdropFilter: "blur(6px)",
+                                backgroundColor: titleBackgroundColor,
+                                border: `1px solid ${alpha(theme.palette.divider, 0.75)}`,
+                                borderRadius: 2,
+                                boxShadow: theme.shadows[6],
+                                color: theme.palette.text.primary,
+                                fontWeight: 600,
+                                letterSpacing: "0.01em",
+                                lineHeight: 1.35,
+                                maxWidth: 400,
+                                overflow: "hidden",
+                                pointerEvents: "auto",
+                                px: 2,
+                                py: 0.45,
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                            }}
+                        >
+                            {networkDisplayName}
+                        </Typography>
                     </Tooltip>
                     {isTemporaryNetwork && !isEditMode && !isAwaitingLlm && onEnterEditMode && (
                         <Button
@@ -1092,7 +1125,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                         </Button>
                     )}
                 </Box>
-            )
+            </Box>
         )
     }
 
@@ -1130,7 +1163,7 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                 id={`${id}-react-flow-wrapper`}
                 sx={{position: "relative", flex: 1, minHeight: 0}}
             >
-                {networkDisplayName ? <Box sx={{marginBottom: "1rem"}}>{getTitle()}</Box> : null}
+                {getTitle()}
                 <ReactFlow
                     connectionMode={ConnectionMode.Loose}
                     edgeTypes={edgeTypes}

--- a/packages/ui-common/components/MultiAgentAccelerator/AgentFlow/AgentFlow.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/AgentFlow/AgentFlow.tsx
@@ -1072,7 +1072,6 @@ export const AgentFlow: FC<AgentFlowProps> = ({
                         display: "flex",
                         gap: 1,
                         left: "50%",
-
                         pointerEvents: "none",
                         position: "absolute",
                         top: 0,

--- a/packages/ui-common/state/Settings.ts
+++ b/packages/ui-common/state/Settings.ts
@@ -49,6 +49,10 @@ type ApiKeys = Partial<Record<LLMProvider, ApiKeyEntry>>
 
 export type PaletteKey = keyof typeof PALETTES | "brand"
 
+export type Layout = "radial" | "linear"
+
+export type GraphColoringOption = "depth" | "heatmap"
+
 /**
  * User preference settings
  */
@@ -57,8 +61,12 @@ interface Settings {
         readonly agentIconColor: string
         readonly agentNodeColor: string
         readonly autoAgentIconColor: boolean
+        readonly graphColoringOption: GraphColoringOption
+        readonly layout: Layout
         readonly plasmaColor: string
         readonly rangePalette: PaletteKey
+        readonly showRadialGuides: boolean
+        readonly showThoughtBubbles: boolean
         readonly useNativeNames: boolean
     }
     readonly branding: {
@@ -104,11 +112,15 @@ export const LLM_PROVIDER_API_KEY_FIELD = {
 export const DEFAULT_SETTINGS: Settings = {
     appearance: {
         // CSS variables like --bs-green don't work here. TBD why.
-        agentNodeColor: "#2db81f",
         agentIconColor: "black",
+        agentNodeColor: "#2db81f",
         autoAgentIconColor: true,
-        rangePalette: "blue",
+        graphColoringOption: "depth",
+        layout: "radial",
         plasmaColor: "#2db81f",
+        rangePalette: "blue",
+        showRadialGuides: true,
+        showThoughtBubbles: true,
         useNativeNames: false,
     },
     branding: {


### PR DESCRIPTION
[Copilot overview.](https://github.com/cognizant-ai-lab/neuro-san-ui/pull/504#pullrequestreview-4868198617)

Internal/technical/quality of life PR. No visible changes.

Makes it so user options for graph display (thought bubbles, radial vs linear, radial guides, heatmap/depth color option) persist in local storage between sessions. 

Values are stored under existing `appSettings` key, just like items from the Settings dialog, but for now, keep the buttons to control these settings in the graph itself. We could consider consolidating them into the Settings dialog later, but that's a non-obvious UX change.