### PR TITLE
Update build-common action pins to 1.0.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,16 +96,16 @@ jobs:
               run: yarn generate
 
             - name: Authenticate to AWS and login to ECR
-              # build-common 1.0.8
-              uses: cognizant-ai-lab/build-common/actions/aws-ecr-auth@30321843331e00848309b34e08b839e1f6490ba2
+              # build-common 1.0.9
+              uses: cognizant-ai-lab/build-common/actions/aws-ecr-auth@b14b3de23cb9aca02b2165e57542335e0c8f5304
               with:
                   aws-account-id: ${{ vars.AWS_ACCOUNT_ID }}
                   aws-role-name: ${{ vars.AWS_ROLE_NAME }}
                   aws-region: ${{ env.AWS_REGION }}
 
             - name: Build and push Docker image to ECR
-              # build-common 1.0.8
-              uses: cognizant-ai-lab/build-common/actions/docker-buildx-push@30321843331e00848309b34e08b839e1f6490ba2
+              # build-common 1.0.9
+              uses: cognizant-ai-lab/build-common/actions/docker-buildx-push@b14b3de23cb9aca02b2165e57542335e0c8f5304
               with:
                   context: .
                   dockerfile: apps/main/Dockerfile

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
     checkmarx:
-        # build-common 1.0.8
-        uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@30321843331e00848309b34e08b839e1f6490ba2
+        # build-common 1.0.9
+        uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
         with:
             base-uri: ${{ vars.CX_BASE_URI }}
             cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,8 @@ jobs:
             - name: Lint Dockerfiles (hadolint)
               id: hadolint
               if: success() || failure()
-              # build-common 1.0.8
-              uses: cognizant-ai-lab/build-common/actions/run-hadolint@30321843331e00848309b34e08b839e1f6490ba2
+              # build-common 1.0.9
+              uses: cognizant-ai-lab/build-common/actions/run-hadolint@b14b3de23cb9aca02b2165e57542335e0c8f5304
               with:
                   recursive: "true"
                   failure-threshold: info


### PR DESCRIPTION
## Summary
Update the remaining build-common workflow dependencies to the immutable 1.0.9 release. This keeps the build, test, Docker, and Checkmarx workflows aligned with the setup-node and publish workflows, which already use the 1.0.9 pin.

Link to Devin session: https://app.devin.ai/sessions/710948056388411cb5653a3d793867d0
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->