### PR TITLE
Fix coverage check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,4 +131,4 @@ jobs:
               run: |
                   node --version
                   yarn vitest --version
-                  yarn test
+                  yarn test --coverage

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,8 +17,7 @@ export default defineConfig({
                 "apps/main/app/api/auth/[[]...nextauth[]]/route.ts",
             ],
             include: ["**/*.{js,jsx,ts,tsx}"],
-            // For now use instanbul provider as we're merging with jest results.
-            // Once we are fully migrated to vitest, consider switching to v8.
+            // Consider migrating to v8 coverage provider. Pros: faster. Cons: can be less accurate for some cases.
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,10 +21,10 @@ export default defineConfig({
             provider: "istanbul",
             reporter: ["text-summary"],
             thresholds: {
-                statements: -74,
-                branches: -125,
-                functions: -14,
-                lines: -50,
+                statements: -78,
+                branches: -130,
+                functions: -15,
+                lines: -54,
             },
         },
         // TODO: potential small optimization: consider using `node` environment for non-UI tests


### PR DESCRIPTION
Turns out we weren't enforcing coverage thresholds at any point in CI or the release process. This probably fell out during the migration to Vitest -- see #396 and subsequent PRs.

With this PR, we:

1) Adjust the thresholds to match reality (unfortunately lower) and
2) Reinstate the coverage check in the `yarn test` goal, which is used both by CI checks in pull requests and by the release process.