### PR TITLE
#513 - Add sly_data schema 

### DIFF
--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
@@ -1684,8 +1684,9 @@ describe("ChatCommon", () => {
 
             await openSlyDataEditor()
 
-            expect(screen.getByText(/This network expects/u)).toBeInTheDocument()
-            expect(screen.getByText(/\(float, required\)/u)).toBeInTheDocument()
+            // getByText throws when the element is missing, so these are the assertions
+            screen.getByText(/This network expects/u)
+            screen.getByText(/\(float, required\)/u)
         })
 
         it("Should not offer the sly_data editor for legacy agents, which have no sly_data", async () => {

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/ChatCommon.test.tsx
@@ -1673,6 +1673,21 @@ describe("ChatCommon", () => {
             expect(await openSlyDataEditor()).toHaveValue('{\n  "charges": 7\n}')
         })
 
+        it("Should show the network's schema hints in the sly_data editor", async () => {
+            renderChatCommonComponent({
+                slyDataSchema: {
+                    properties: {x: {description: "The first operand", type: "float"}},
+                    required: ["x"],
+                    type: "object",
+                },
+            })
+
+            await openSlyDataEditor()
+
+            expect(screen.getByText(/This network expects/u)).toBeInTheDocument()
+            expect(screen.getByText(/\(float, required\)/u)).toBeInTheDocument()
+        })
+
         it("Should not offer the sly_data editor for legacy agents, which have no sly_data", async () => {
             renderChatCommonComponent({selectedNetwork: LegacyAgentType.DataGenerator})
 

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {act, render, screen} from "@testing-library/react"
+import {act, render, screen, within} from "@testing-library/react"
 import {userEvent, UserEvent} from "@testing-library/user-event"
 
 import {withStrictMocks} from "../../../../../../__tests__/common/strictMocks"
@@ -36,6 +36,29 @@ const DIALOG_ID = "test-sly-data-dialog"
 // A one-pixel transparent GIF, as a data URI
 const IMAGE_DATA_URI = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
 
+// The shape of neuro-san's math_guy example schema: two required scalars
+const MATH_GUY_SCHEMA = {
+    properties: {
+        x: {description: "The first operand", type: "float"},
+        y: {description: "The second operand", type: "float"},
+    },
+    required: ["x", "y"],
+    type: "object",
+}
+
+// The shape of a BYOK network's schema: one scalar plus the app-managed llm_config block
+const BYOK_SCHEMA = {
+    properties: {
+        llm_config: {
+            properties: {openai_api_key: {type: "string"}},
+            type: "object",
+        },
+        running_cost: {description: "Fake billing so far", type: "float"},
+    },
+    required: ["llm_config"],
+    type: "object",
+}
+
 describe("SlyDataDialog", () => {
     withStrictMocks()
 
@@ -52,7 +75,7 @@ describe("SlyDataDialog", () => {
         })
     })
 
-    const renderDialog = (extraSlyDataKeys?: readonly string[]) =>
+    const renderDialog = (extraSlyDataKeys?: readonly string[], slyDataSchema?: Record<string, unknown>) =>
         render(
             <SlyDataDialog
                 extraSlyDataKeys={extraSlyDataKeys}
@@ -61,6 +84,7 @@ describe("SlyDataDialog", () => {
                 networkDisplayName="Music Nerd Pro"
                 networkId={NETWORK_ID}
                 onClose={onCloseMock}
+                slyDataSchema={slyDataSchema}
             />
         )
 
@@ -250,5 +274,75 @@ describe("SlyDataDialog", () => {
         renderDialog()
 
         expect(screen.queryByText(/Sent automatically with every request/u)).not.toBeInTheDocument()
+    })
+
+    it("shows no schema hints and no template button when the network declares no schema", () => {
+        renderDialog()
+
+        expect(screen.queryByText(/This network expects/u)).not.toBeInTheDocument()
+        expect(screen.queryByRole("button", {name: "Fill sly data template"})).not.toBeInTheDocument()
+    })
+
+    it("ignores an unusable schema rather than breaking the dialog", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+        renderDialog(undefined, {type: "object"})
+
+        expect(screen.queryByText(/This network expects/u)).not.toBeInTheDocument()
+        expect(getEditor()).toHaveValue("{}")
+    })
+
+    it("lists the keys the network expects, with type, requiredness and description", () => {
+        renderDialog(undefined, MATH_GUY_SCHEMA)
+
+        const hints = within(screen.getByText(/This network expects/u).parentElement)
+        expect(hints.getByText("x")).toBeInTheDocument()
+        expect(hints.getByText("y")).toBeInTheDocument()
+        expect(hints.getAllByText(/\(float, required\)/u)).toHaveLength(2)
+        expect(hints.getByText(/The first operand/u)).toBeInTheDocument()
+    })
+
+    it("leaves the app-supplied keys out of the schema hints", () => {
+        renderDialog(["llm_config"], BYOK_SCHEMA)
+
+        const hints = within(screen.getByText(/This network expects/u).parentElement)
+        expect(hints.getByText("running_cost")).toBeInTheDocument()
+        expect(hints.queryByText("llm_config")).not.toBeInTheDocument()
+    })
+
+    it("renders a bare key when the schema gives no type, requiredness or description", () => {
+        renderDialog(undefined, {properties: {plain: {}}, type: "object"})
+
+        const hints = within(screen.getByText(/This network expects/u).parentElement)
+        expect(hints.getByText("plain")).toBeInTheDocument()
+        expect(hints.queryByText(/\(/u)).not.toBeInTheDocument()
+    })
+
+    it("seeds the expected keys as a template, keeping existing values", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {x: 3}))
+
+        renderDialog(undefined, MATH_GUY_SCHEMA)
+        await user.click(screen.getByRole("button", {name: "Fill sly data template"}))
+
+        expect(getEditor()).toHaveValue('{\n  "x": 3,\n  "y": 0\n}')
+
+        // The template is only a draft until the user saves it
+        expect(getSlyData()).toEqual({x: 3})
+        await user.click(screen.getByRole("button", {name: "Save"}))
+        expect(getSlyData()).toEqual({x: 3, y: 0})
+    })
+
+    it("never seeds the app-supplied keys into the template", async () => {
+        renderDialog(["llm_config"], BYOK_SCHEMA)
+        await user.click(screen.getByRole("button", {name: "Fill sly data template"}))
+
+        expect(getEditor()).toHaveValue('{\n  "running_cost": 0\n}')
+    })
+
+    it("disables the template button while the JSON does not parse", async () => {
+        renderDialog(undefined, MATH_GUY_SCHEMA)
+        await replaceEditorContents("{oops")
+
+        expect(screen.getByRole("button", {name: "Fill sly data template"})).toBeDisabled()
     })
 })

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -295,7 +295,7 @@ describe("SlyDataDialog", () => {
     it("lists the keys the network expects, with type, requiredness and description", () => {
         renderDialog(undefined, MATH_GUY_SCHEMA)
 
-        const hints = within(screen.getByText(/This network expects/u).parentElement)
+        const hints = within(screen.getByTestId(`${DIALOG_ID}-schema-hints`))
         expect(hints.getByText("x")).toBeInTheDocument()
         expect(hints.getByText("y")).toBeInTheDocument()
         expect(hints.getAllByText(/\(float, required\)/u)).toHaveLength(2)
@@ -305,7 +305,7 @@ describe("SlyDataDialog", () => {
     it("leaves the app-supplied keys out of the schema hints", () => {
         renderDialog(["llm_config"], BYOK_SCHEMA)
 
-        const hints = within(screen.getByText(/This network expects/u).parentElement)
+        const hints = within(screen.getByTestId(`${DIALOG_ID}-schema-hints`))
         expect(hints.getByText("running_cost")).toBeInTheDocument()
         expect(hints.queryByText("llm_config")).not.toBeInTheDocument()
     })
@@ -313,7 +313,7 @@ describe("SlyDataDialog", () => {
     it("renders a bare key when the schema gives no type, requiredness or description", () => {
         renderDialog(undefined, {properties: {plain: {}}, type: "object"})
 
-        const hints = within(screen.getByText(/This network expects/u).parentElement)
+        const hints = within(screen.getByTestId(`${DIALOG_ID}-schema-hints`))
         expect(hints.getByText("plain")).toBeInTheDocument()
         expect(hints.queryByText(/\(/u)).not.toBeInTheDocument()
     })

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -320,7 +320,7 @@ describe("SlyDataDialog", () => {
     })
 
     it("seeds the expected keys as a template, keeping existing values", async () => {
-        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {x: 3}))
+        useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {x: 3})
 
         renderDialog(undefined, MATH_GUY_SCHEMA)
         await user.click(screen.getByRole("button", {name: "Fill sly data template"}))
@@ -358,7 +358,7 @@ describe("SlyDataDialog", () => {
     })
 
     it("shows stored values instead of the template when the network already has sly data", () => {
-        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {x: 3}))
+        useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {x: 3})
 
         renderDialog(undefined, MATH_GUY_SCHEMA)
 
@@ -366,7 +366,7 @@ describe("SlyDataDialog", () => {
     })
 
     it("resets to the template, not to nothing, when clearing on a network with a schema", async () => {
-        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {extra: 9, x: 3}))
+        useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {extra: 9, x: 3})
 
         renderDialog(undefined, MATH_GUY_SCHEMA)
         await user.click(screen.getByRole("button", {name: "Clear sly data"}))

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -284,12 +284,13 @@ describe("SlyDataDialog", () => {
     })
 
     it("ignores an unusable schema rather than breaking the dialog", () => {
-        vi.spyOn(console, "warn").mockImplementation(() => undefined)
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
 
         renderDialog(undefined, {type: "object"})
 
         expect(screen.queryByText(/This network expects/u)).not.toBeInTheDocument()
         expect(getEditor()).toHaveValue("{}")
+        expect(warn).toHaveBeenCalledExactlyOnceWith(expect.stringContaining("sly_data_schema"), expect.anything())
     })
 
     it("lists the keys the network expects, with type, requiredness and description", () => {

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -296,17 +296,17 @@ describe("SlyDataDialog", () => {
         renderDialog(undefined, MATH_GUY_SCHEMA)
 
         const hints = within(screen.getByTestId(`${DIALOG_ID}-schema-hints`))
-        expect(hints.getByText("x")).toBeInTheDocument()
-        expect(hints.getByText("y")).toBeInTheDocument()
+        hints.getByText("x")
+        hints.getByText("y")
+        hints.getByText(/The first operand/u)
         expect(hints.getAllByText(/\(float, required\)/u)).toHaveLength(2)
-        expect(hints.getByText(/The first operand/u)).toBeInTheDocument()
     })
 
     it("leaves the app-supplied keys out of the schema hints", () => {
         renderDialog(["llm_config"], BYOK_SCHEMA)
 
         const hints = within(screen.getByTestId(`${DIALOG_ID}-schema-hints`))
-        expect(hints.getByText("running_cost")).toBeInTheDocument()
+        hints.getByText("running_cost")
         expect(hints.queryByText("llm_config")).not.toBeInTheDocument()
     })
 
@@ -314,7 +314,7 @@ describe("SlyDataDialog", () => {
         renderDialog(undefined, {properties: {plain: {}}, type: "object"})
 
         const hints = within(screen.getByTestId(`${DIALOG_ID}-schema-hints`))
-        expect(hints.getByText("plain")).toBeInTheDocument()
+        hints.getByText("plain")
         expect(hints.queryByText(/\(/u)).not.toBeInTheDocument()
     })
 

--- a/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
+++ b/packages/ui-common/__tests__/components/AgentChat/ChatCommon/SlyDataDialog.test.tsx
@@ -345,4 +345,31 @@ describe("SlyDataDialog", () => {
 
         expect(screen.getByRole("button", {name: "Fill sly data template"})).toBeDisabled()
     })
+
+    it("pre-populates an empty editor with the network's template", () => {
+        renderDialog(undefined, MATH_GUY_SCHEMA)
+
+        expect(getEditor()).toHaveValue('{\n  "x": 0,\n  "y": 0\n}')
+
+        // It is an ordinary unsaved draft: no reload alert, and nothing in the store until the user saves
+        expect(screen.queryByRole("button", {name: "Reload"})).not.toBeInTheDocument()
+        expect(getSlyData()).toBeUndefined()
+    })
+
+    it("shows stored values instead of the template when the network already has sly data", () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {x: 3}))
+
+        renderDialog(undefined, MATH_GUY_SCHEMA)
+
+        expect(getEditor()).toHaveValue('{\n  "x": 3\n}')
+    })
+
+    it("resets to the template, not to nothing, when clearing on a network with a schema", async () => {
+        act(() => useAgentChatHistoryStore.getState().setSlyData(NETWORK_ID, {extra: 9, x: 3}))
+
+        renderDialog(undefined, MATH_GUY_SCHEMA)
+        await user.click(screen.getByRole("button", {name: "Clear sly data"}))
+
+        expect(getEditor()).toHaveValue('{\n  "x": 0,\n  "y": 0\n}')
+    })
 })

--- a/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
+++ b/packages/ui-common/__tests__/components/MultiAgentAccelerator/MultiAgentAccelerator.test.tsx
@@ -1592,6 +1592,32 @@ describe("MultiAgentAccelerator", () => {
             )
         })
 
+        it("passes the network's sly_data_schema through to the chat", async () => {
+            const schema = {
+                properties: {x: {description: "The first operand", type: "float"}},
+                required: ["x"],
+                type: "object",
+            }
+            vi.mocked(getAgentFunction).mockResolvedValue({
+                function: {sly_data_schema: schema},
+            } satisfies FunctionResponse)
+
+            renderMultiAgentAccelerator()
+
+            await act(async () => {
+                setSelectedNetwork(`${TEST_AGENTS_FOLDER}/${TEST_AGENT_MATH_GUY}`)
+            })
+
+            await screen.findByText(`${TEST_AGENTS_FOLDER}/${TEST_AGENT_MATH_GUY}`)
+
+            expect(chatCommonMock).toHaveBeenCalledWith(
+                expect.objectContaining<Partial<ChatCommonProps>>({
+                    selectedNetwork: `${TEST_AGENTS_FOLDER}/${TEST_AGENT_MATH_GUY}`,
+                    slyDataSchema: schema,
+                })
+            )
+        })
+
         it("handles missing agent name in current temp network", async () => {
             useTempNetworksStore.setState({
                 tempNetworks: [

--- a/packages/ui-common/__tests__/unit/Utils/SlyDataSchema.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/SlyDataSchema.test.ts
@@ -132,7 +132,7 @@ describe("describeSlyDataSchema", () => {
     ])("warns and returns nothing for %s", (_label: string, schema: unknown) => {
         const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
         expect(describeSlyDataSchema(schema)).toStrictEqual([])
-        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn).toHaveBeenCalledExactlyOnceWith(expect.stringContaining("sly_data_schema"), expect.anything())
     })
 })
 
@@ -206,7 +206,7 @@ describe("buildSlyDataTemplate", () => {
         const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
         const existing = {kept: true}
         expect(buildSlyDataTemplate({type: "object"}, existing)).toBe(existing)
-        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn).toHaveBeenCalledExactlyOnceWith(expect.stringContaining("sly_data_schema"), expect.anything())
     })
 
     it("stops materializing objects beyond the depth cap", () => {

--- a/packages/ui-common/__tests__/unit/Utils/SlyDataSchema.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/SlyDataSchema.test.ts
@@ -183,6 +183,11 @@ describe("buildSlyDataTemplate", () => {
         })
     })
 
+    it("seeds an empty object for an object node that declares no properties", () => {
+        const schema = {properties: {config: {type: "object"}}, type: "object"}
+        expect(buildSlyDataTemplate(schema, {})).toStrictEqual({config: {}})
+    })
+
     it("never seeds excluded keys", () => {
         expect(buildSlyDataTemplate(BYOK_SCHEMA, {}, ["llm_config"])).toStrictEqual({running_cost: 0})
     })

--- a/packages/ui-common/__tests__/unit/Utils/SlyDataSchema.test.ts
+++ b/packages/ui-common/__tests__/unit/Utils/SlyDataSchema.test.ts
@@ -1,0 +1,224 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Unit tests for the sly_data_schema helpers
+ */
+
+// eslint-disable-next-line no-shadow
+import {describe, expect, it, vi} from "vitest"
+
+import {withStrictMocks} from "../../../../../__tests__/common/strictMocks"
+import {buildSlyDataTemplate, describeSlyDataSchema} from "../../../utils/SlyDataSchema"
+
+// The schema of neuro-san's math_guy example network: two required scalars
+const MATH_GUY_SCHEMA = {
+    properties: {
+        x: {description: "The first operand for the arithmetic operation", type: "float"},
+        y: {description: "The second operand for the arithmetic operation", type: "float"},
+    },
+    required: ["x", "y"],
+    type: "object",
+}
+
+// The schema of neuro-san's music_nerd_pro_sly_api_key example network: a scalar plus the BYOK llm_config block
+const BYOK_SCHEMA = {
+    properties: {
+        llm_config: {
+            properties: {
+                openai_api_key: {description: "The User's OpenAI API key", type: "string"},
+            },
+            required: ["openai_api_key"],
+            type: "object",
+        },
+        running_cost: {description: "The running cost of the operation", type: "float"},
+    },
+    required: ["llm_config"],
+    type: "object",
+}
+
+// The schema of neuro-san's mcp_github example network: objects nested three deep, with a URL as a property key
+const MCP_URL = "https://api.githubcopilot.com/mcp"
+const MCP_SCHEMA = {
+    properties: {
+        http_headers: {
+            description: "HTTP headers to be sent with MCP tool requests.",
+            properties: {
+                [MCP_URL]: {
+                    properties: {
+                        Authorization: {description: "Authorization header for GitHub API access", type: "string"},
+                    },
+                    required: ["Authorization"],
+                    type: "object",
+                },
+            },
+            required: [MCP_URL],
+            type: "object",
+        },
+    },
+    required: ["http_headers"],
+    type: "object",
+}
+
+describe("describeSlyDataSchema", () => {
+    withStrictMocks()
+
+    it("lists scalar keys with type, required flag and description", () => {
+        expect(describeSlyDataSchema(MATH_GUY_SCHEMA)).toStrictEqual([
+            {description: "The first operand for the arithmetic operation", isRequired: true, key: "x", type: "float"},
+            {description: "The second operand for the arithmetic operation", isRequired: true, key: "y", type: "float"},
+        ])
+    })
+
+    it("marks keys absent from the required list as optional", () => {
+        const entries = describeSlyDataSchema(BYOK_SCHEMA)
+        expect(entries.find((entry) => entry.key === "running_cost")?.isRequired).toBe(false)
+        expect(entries.find((entry) => entry.key === "llm_config")?.isRequired).toBe(true)
+    })
+
+    it("skips excluded keys", () => {
+        expect(describeSlyDataSchema(BYOK_SCHEMA, ["llm_config"])).toStrictEqual([
+            {description: "The running cost of the operation", isRequired: false, key: "running_cost", type: "float"},
+        ])
+    })
+
+    it("keeps unusual property keys such as URLs verbatim", () => {
+        expect(describeSlyDataSchema(MCP_SCHEMA)).toStrictEqual([
+            {
+                description: "HTTP headers to be sent with MCP tool requests.",
+                isRequired: true,
+                key: "http_headers",
+                type: "object",
+            },
+        ])
+    })
+
+    it("infers object for an untyped node that declares properties", () => {
+        const schema = {
+            properties: {settings: {properties: {volume: {type: "int"}}}},
+            type: "object",
+        }
+        expect(describeSlyDataSchema(schema)[0].type).toBe("object")
+    })
+
+    it("leaves the type undefined when the schema does not say", () => {
+        const schema = {properties: {mystery: {description: "who knows"}}, type: "object"}
+        expect(describeSlyDataSchema(schema)[0].type).toBeUndefined()
+    })
+
+    it("returns nothing when there is no schema", () => {
+        expect(describeSlyDataSchema(undefined)).toStrictEqual([])
+        expect(describeSlyDataSchema(null)).toStrictEqual([])
+    })
+
+    it.each([
+        ["a primitive", 42],
+        ["a non-object root", {properties: {x: {type: "float"}}, type: "array"}],
+        ["a root without properties", {type: "object"}],
+        ["a root with empty properties", {properties: {}, type: "object"}],
+    ])("warns and returns nothing for %s", (_label: string, schema: unknown) => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+        expect(describeSlyDataSchema(schema)).toStrictEqual([])
+        expect(warn).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe("buildSlyDataTemplate", () => {
+    withStrictMocks()
+
+    it("seeds a default value per declared type", () => {
+        const schema = {
+            properties: {
+                count: {type: "int"},
+                enabled: {type: "bool"},
+                name: {type: "string"},
+                rate: {type: "float"},
+                stuff: {type: "list"},
+            },
+            type: "object",
+        }
+        expect(buildSlyDataTemplate(schema, {})).toStrictEqual({
+            count: 0,
+            enabled: false,
+            name: "",
+            rate: 0,
+            stuff: null,
+        })
+    })
+
+    it("accepts the JSON Schema spellings of the scalar types", () => {
+        const schema = {
+            properties: {a: {type: "integer"}, b: {type: "number"}, c: {type: "boolean"}, d: {type: "double"}},
+            type: "object",
+        }
+        expect(buildSlyDataTemplate(schema, {})).toStrictEqual({a: 0, b: 0, c: false, d: 0})
+    })
+
+    it("keeps every existing value, even one that contradicts the schema", () => {
+        const existing = {x: "not a number", y: 4.5}
+        expect(buildSlyDataTemplate(MATH_GUY_SCHEMA, existing)).toStrictEqual({x: "not a number", y: 4.5})
+    })
+
+    it("adds only the missing keys", () => {
+        expect(buildSlyDataTemplate(MATH_GUY_SCHEMA, {x: 3})).toStrictEqual({x: 3, y: 0})
+    })
+
+    it("builds nested objects and fills gaps inside a partial one", () => {
+        const existing = {http_headers: {[MCP_URL]: {}}}
+        expect(buildSlyDataTemplate(MCP_SCHEMA, existing)).toStrictEqual({
+            http_headers: {[MCP_URL]: {Authorization: ""}},
+        })
+    })
+
+    it("never seeds excluded keys", () => {
+        expect(buildSlyDataTemplate(BYOK_SCHEMA, {}, ["llm_config"])).toStrictEqual({running_cost: 0})
+    })
+
+    it("leaves an existing non-object value alone where the schema declares an object", () => {
+        expect(buildSlyDataTemplate(MCP_SCHEMA, {http_headers: "oops"})).toStrictEqual({http_headers: "oops"})
+    })
+
+    it("does not mutate the existing sly data", () => {
+        const existing = {x: 3}
+        buildSlyDataTemplate(MATH_GUY_SCHEMA, existing)
+        expect(existing).toStrictEqual({x: 3})
+    })
+
+    it("returns the existing sly data untouched when the schema is unusable", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+        const existing = {kept: true}
+        expect(buildSlyDataTemplate({type: "object"}, existing)).toBe(existing)
+        expect(warn).toHaveBeenCalledTimes(1)
+    })
+
+    it("stops materializing objects beyond the depth cap", () => {
+        // Each level nests one object deeper than the last; the cap must cut this off, not recurse forever
+        let node: Record<string, unknown> = {type: "string"}
+        for (let index = 0; index < 10; index += 1) {
+            node = {properties: {deeper: node}, type: "object"}
+        }
+        const result = buildSlyDataTemplate(node, {})
+
+        let depth = 0
+        let cursor: unknown = result
+        while (cursor !== null && typeof cursor === "object" && "deeper" in cursor) {
+            cursor = (cursor as Record<string, unknown>)["deeper"]
+            depth += 1
+        }
+        expect(depth).toBeLessThan(10)
+        expect(depth).toBeGreaterThan(0)
+    })
+})

--- a/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/ChatCommon.tsx
@@ -197,6 +197,12 @@ export interface ChatCommonProps {
      * If true, indicates that the user is missing API keys for one or more LLM providers.
      */
     readonly hasMissingApiKeys?: boolean
+
+    /**
+     * The sly_data_schema the selected network's front man advertises, if any. Enables schema hints in the
+     * sly_data dialog.
+     */
+    readonly slyDataSchema?: Record<string, unknown>
 }
 
 // Type for forward ref to expose the handleStop and handleClearChat functions
@@ -273,6 +279,7 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
         setIsAwaitingLlm,
         setPreviousResponse,
         setSelectedNetwork,
+        slyDataSchema,
         title,
     } = props
     // MUI theme
@@ -1186,6 +1193,7 @@ export const ChatCommon = ({ref, ...props}: ChatCommonProps & {ref?: Ref<ChatCom
                     networkDisplayName={networkDisplayName}
                     networkId={selectedNetwork}
                     onClose={() => setSlyDataDialogOpen(false)}
+                    slyDataSchema={slyDataSchema}
                 />
             ) : null}
             <Box

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -18,6 +18,7 @@ import DataObjectIcon from "@mui/icons-material/DataObject"
 import DeleteOutlined from "@mui/icons-material/DeleteOutlined"
 import FileDownloadOutlined from "@mui/icons-material/FileDownloadOutlined"
 import FileUploadOutlined from "@mui/icons-material/FileUploadOutlined"
+import PlaylistAddOutlined from "@mui/icons-material/PlaylistAddOutlined"
 import Alert from "@mui/material/Alert"
 import Box from "@mui/material/Box"
 import IconButton from "@mui/material/IconButton"
@@ -29,6 +30,7 @@ import {ChangeEvent, FC, Fragment, useMemo, useRef, useState} from "react"
 import {useAgentChatHistoryStore} from "../../../state/ChatHistory"
 import {downloadFile, toSafeFilename} from "../../../utils/File"
 import {findImageValues, formatSlyData, parseSlyData} from "../../../utils/SlyData"
+import {buildSlyDataTemplate, describeSlyDataSchema, SlyDataSchemaEntry} from "../../../utils/SlyDataSchema"
 import {StyledButton} from "../../Common/ConfirmationModal"
 import {MUIDialog} from "../../Common/MUIDialog"
 import InfoTip from "../../Settings/InfoTip"
@@ -53,6 +55,12 @@ export interface SlyDataDialogProps {
     readonly networkDisplayName: string
 
     readonly onClose: () => void
+
+    /**
+     * The sly_data_schema the network's front man advertises, if any. When present and usable, the dialog lists
+     * the expected keys and offers to seed them as a template.
+     */
+    readonly slyDataSchema?: Record<string, unknown>
 }
 //#endregion: Types
 
@@ -72,7 +80,24 @@ const IMAGE_PREVIEW_SIZE = 96
 const SLY_DATA_EXPLAINER =
     "Data is sent to the agent network in a private channel with each request but kept out of the LLM."
 
+// Styling for a sly_data key name rendered as an inline code chip
+const KEY_CHIP_SX = {
+    backgroundColor: "action.hover",
+    borderRadius: 0.5,
+    fontFamily: "monospace",
+    px: 0.5,
+} as const
+
 //#endregion: Constants
+
+/**
+ * Renders the parenthetical qualifiers after a schema key name, eg. " (float, required)".
+ * Empty when the schema declares neither a type nor requiredness.
+ */
+const describeEntryQualifiers = (entry: SlyDataSchemaEntry): string => {
+    const qualifiers = [entry.type, entry.isRequired ? "required" : undefined].filter(Boolean)
+    return qualifiers.length > 0 ? ` (${qualifiers.join(", ")})` : ""
+}
 
 /**
  * Dialog for viewing and editing the sly_data of the selected agent network.
@@ -93,6 +118,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
     networkId,
     networkDisplayName,
     onClose,
+    slyDataSchema,
 }) => {
     const storedSlyData = useAgentChatHistoryStore((state) =>
         networkId ? state.history[networkId]?.slyData : undefined
@@ -121,6 +147,13 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
     const images = useMemo(() => findImageValues(parseResult.value), [parseResult])
 
+    // The keys the network says it expects, minus the ones the app supplies on its own. Empty for the many
+    // networks that do not advertise a schema, in which case the dialog looks exactly as it always has.
+    const schemaEntries = useMemo(
+        () => describeSlyDataSchema(slyDataSchema, extraSlyDataKeys),
+        [slyDataSchema, extraSlyDataKeys]
+    )
+
     // The server echoed new sly_data while the user had unsaved edits. Saying so beats silently discarding
     // either side's version.
     const wasUpdatedByServer = isDirty && storedText !== draftBaseline
@@ -144,6 +177,10 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
     const handleClear = () => {
         startOrUpdateDraft("{}")
+    }
+
+    const handleFillTemplate = () => {
+        startOrUpdateDraft(formatSlyData(buildSlyDataTemplate(slyDataSchema, parseResult.value, extraSlyDataKeys)))
     }
 
     const handleExport = () => {
@@ -190,6 +227,21 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
     const getToolbar = () => (
         <Box sx={{display: "flex", gap: 0.5, justifyContent: "flex-end"}}>
+            {schemaEntries.length > 0 && (
+                <Tooltip title="Insert the keys this network expects (keeps your values)">
+                    <span>
+                        <IconButton
+                            aria-label="Fill sly data template"
+                            disabled={Boolean(parseResult.error)}
+                            id={`${id}-template-button`}
+                            onClick={handleFillTemplate}
+                            size="small"
+                        >
+                            <PlaylistAddOutlined fontSize="small" />
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            )}
             <Tooltip title="Import from a JSON file">
                 <span>
                     <IconButton
@@ -240,6 +292,47 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
             />
         </Box>
     )
+
+    /**
+     * Lists the keys the network says it expects, so the user knows what to fill in without reading the
+     * network's source. Renders nothing when the network advertises no usable schema.
+     */
+    const getSchemaHints = () =>
+        schemaEntries.length > 0 && (
+            <Box
+                id={`${id}-schema-hints`}
+                sx={{mb: 0.5}}
+            >
+                <Typography
+                    sx={{fontSize: "0.75rem"}}
+                    variant="caption"
+                >
+                    This network expects:
+                </Typography>
+                <Box
+                    component="ul"
+                    sx={{listStyle: "none", m: 0, pl: 1.5}}
+                >
+                    {schemaEntries.map((entry) => (
+                        <Typography
+                            component="li"
+                            key={entry.key}
+                            sx={{display: "block", fontSize: "0.75rem"}}
+                            variant="caption"
+                        >
+                            <Box
+                                component="code"
+                                sx={KEY_CHIP_SX}
+                            >
+                                {entry.key}
+                            </Box>
+                            {describeEntryQualifiers(entry)}
+                            {entry.description ? `: ${entry.description}` : ""}
+                        </Typography>
+                    ))}
+                </Box>
+            </Box>
+        )
 
     const getServerUpdateAlert = () =>
         wasUpdatedByServer && (
@@ -320,12 +413,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                         {index > 0 && ", "}
                         <Box
                             component="code"
-                            sx={{
-                                backgroundColor: "action.hover",
-                                borderRadius: 0.5,
-                                fontFamily: "monospace",
-                                px: 0.5,
-                            }}
+                            sx={KEY_CHIP_SX}
                         >
                             {key}
                         </Box>
@@ -366,6 +454,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
             title={getTitle()}
         >
             {getToolbar()}
+            {getSchemaHints()}
             {getServerUpdateAlert()}
             <TextField
                 error={Boolean(parseResult.error)}

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -300,6 +300,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
     const getSchemaHints = () =>
         schemaEntries.length > 0 && (
             <Box
+                data-testid={`${id}-schema-hints`}
                 id={`${id}-schema-hints`}
                 sx={{mb: 0.5}}
             >

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -127,14 +127,33 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
 
     const storedText = useMemo(() => formatSlyData(storedSlyData), [storedSlyData])
 
+    // The keys the network says it expects, minus the ones the app supplies on its own. Empty for the many
+    // networks that do not advertise a schema, in which case the dialog looks exactly as it always has.
+    const schemaEntries = useMemo(
+        () => describeSlyDataSchema(slyDataSchema, extraSlyDataKeys),
+        [slyDataSchema, extraSlyDataKeys]
+    )
+
+    // The network's sly_data skeleton, pretty-printed, or null when it advertises no usable schema
+    const templateText = useMemo(
+        () =>
+            schemaEntries.length > 0 ? formatSlyData(buildSlyDataTemplate(slyDataSchema, {}, extraSlyDataKeys)) : null,
+        [schemaEntries, slyDataSchema, extraSlyDataKeys]
+    )
+
+    // When the dialog opens onto an empty store and the network declares a schema, start from the template so
+    // the user fills in blanks instead of typing structure. It is an ordinary unsaved draft: nothing touches
+    // the store unless they save. The dialog is mounted fresh on every open, so this is per-open behavior.
+    const prefillText = storedText === "{}" ? templateText : null
+
     // The user's unsaved edit, or null while they have none. While null, the editor simply renders the store,
     // so server-echoed updates show up without any syncing code. Once the user edits, their draft is what
     // renders, and we offer a reload instead of overwriting it (see below).
-    const [draft, setDraft] = useState<string | null>(null)
+    const [draft, setDraft] = useState<string | null>(prefillText)
 
     // What the store held when the user started editing, so we can tell "the server changed sly_data" apart
     // from "the user changed sly_data"
-    const [draftBaseline, setDraftBaseline] = useState<string | null>(null)
+    const [draftBaseline, setDraftBaseline] = useState<string | null>(prefillText === null ? null : storedText)
 
     const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -146,13 +165,6 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
     const parseResult = useMemo(() => parseSlyData(text), [text])
 
     const images = useMemo(() => findImageValues(parseResult.value), [parseResult])
-
-    // The keys the network says it expects, minus the ones the app supplies on its own. Empty for the many
-    // networks that do not advertise a schema, in which case the dialog looks exactly as it always has.
-    const schemaEntries = useMemo(
-        () => describeSlyDataSchema(slyDataSchema, extraSlyDataKeys),
-        [slyDataSchema, extraSlyDataKeys]
-    )
 
     // The server echoed new sly_data while the user had unsaved edits. Saying so beats silently discarding
     // either side's version.
@@ -175,8 +187,10 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
         setDraftBaseline(null)
     }
 
+    // On a network with a schema, "clear" means back to the blank template rather than to nothing:
+    // stranding the user on {} would force them to rebuild the structure the network just told us about.
     const handleClear = () => {
-        startOrUpdateDraft("{}")
+        startOrUpdateDraft(templateText ?? "{}")
     }
 
     const handleFillTemplate = () => {
@@ -267,7 +281,13 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                     </IconButton>
                 </span>
             </Tooltip>
-            <Tooltip title="Clear all sly data (takes effect when you save)">
+            <Tooltip
+                title={
+                    templateText === null
+                        ? "Clear all sly data (takes effect when you save)"
+                        : "Reset to the network's expected keys (takes effect when you save)"
+                }
+            >
                 <span>
                     <IconButton
                         aria-label="Clear sly data"

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -95,6 +95,8 @@ const KeyChip = styled("code")(({theme}) => ({
 /**
  * Renders the parenthetical qualifiers after a schema key name, eg. " (float, required)".
  * Empty when the schema declares neither a type nor requiredness.
+ * @param entry The schema entry to describe.
+ * @returns The qualifier text, with a leading space, or an empty string.
  */
 const describeEntryQualifiers = (entry: SlyDataSchemaEntry): string => {
     const qualifiers = [entry.type, entry.isRequired ? "required" : undefined].filter(Boolean)

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -22,6 +22,7 @@ import PlaylistAddOutlined from "@mui/icons-material/PlaylistAddOutlined"
 import Alert from "@mui/material/Alert"
 import Box from "@mui/material/Box"
 import IconButton from "@mui/material/IconButton"
+import {styled} from "@mui/material/styles"
 import TextField from "@mui/material/TextField"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
@@ -80,15 +81,16 @@ const IMAGE_PREVIEW_SIZE = 96
 const SLY_DATA_EXPLAINER =
     "Data is sent to the agent network in a private channel with each request but kept out of the LLM."
 
-// Styling for a sly_data key name rendered as an inline code chip
-const KEY_CHIP_SX = {
-    backgroundColor: "action.hover",
-    borderRadius: 0.5,
-    fontFamily: "monospace",
-    px: 0.5,
-} as const
-
 //#endregion: Constants
+
+// A sly_data key name rendered as an inline code chip
+const KeyChip = styled(Box)(({theme}) => ({
+    backgroundColor: theme.palette.action.hover,
+    borderRadius: theme.shape.borderRadius * 0.5,
+    fontFamily: "monospace",
+    paddingLeft: theme.spacing(0.5),
+    paddingRight: theme.spacing(0.5),
+}))
 
 /**
  * Renders the parenthetical qualifiers after a schema key name, eg. " (float, required)".
@@ -341,12 +343,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                             sx={{display: "block", fontSize: "0.75rem"}}
                             variant="caption"
                         >
-                            <Box
-                                component="code"
-                                sx={KEY_CHIP_SX}
-                            >
-                                {entry.key}
-                            </Box>
+                            <KeyChip component="code">{entry.key}</KeyChip>
                             {describeEntryQualifiers(entry)}
                             {entry.description ? `: ${entry.description}` : ""}
                         </Typography>
@@ -432,12 +429,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                 {[...extraSlyDataKeys].sort().map((key, index) => (
                     <Fragment key={key}>
                         {index > 0 && ", "}
-                        <Box
-                            component="code"
-                            sx={KEY_CHIP_SX}
-                        >
-                            {key}
-                        </Box>
+                        <KeyChip component="code">{key}</KeyChip>
                     </Fragment>
                 ))}
                 . Supplied by the app, not from this editor.

--- a/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
+++ b/packages/ui-common/components/AgentChat/ChatCommon/SlyDataDialog.tsx
@@ -84,9 +84,9 @@ const SLY_DATA_EXPLAINER =
 //#endregion: Constants
 
 // A sly_data key name rendered as an inline code chip
-const KeyChip = styled(Box)(({theme}) => ({
+const KeyChip = styled("code")(({theme}) => ({
     backgroundColor: theme.palette.action.hover,
-    borderRadius: theme.shape.borderRadius * 0.5,
+    borderRadius: `calc(${theme.shape.borderRadius}px * 0.5)`,
     fontFamily: "monospace",
     paddingLeft: theme.spacing(0.5),
     paddingRight: theme.spacing(0.5),
@@ -343,7 +343,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                             sx={{display: "block", fontSize: "0.75rem"}}
                             variant="caption"
                         >
-                            <KeyChip component="code">{entry.key}</KeyChip>
+                            <KeyChip>{entry.key}</KeyChip>
                             {describeEntryQualifiers(entry)}
                             {entry.description ? `: ${entry.description}` : ""}
                         </Typography>
@@ -429,7 +429,7 @@ export const SlyDataDialog: FC<SlyDataDialogProps> = ({
                 {[...extraSlyDataKeys].sort().map((key, index) => (
                     <Fragment key={key}>
                         {index > 0 && ", "}
-                        <KeyChip component="code">{key}</KeyChip>
+                        <KeyChip>{key}</KeyChip>
                     </Fragment>
                 ))}
                 . Supplied by the app, not from this editor.

--- a/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
+++ b/packages/ui-common/components/MultiAgentAccelerator/MultiAgentAccelerator.tsx
@@ -144,6 +144,9 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
     // LLM providers for which BYOK keys are supported by the current network
     const [supportedByokProviders, setSupportedByokProviders] = useState<ReadonlySet<LLMProvider>>(new Set())
 
+    // The sly_data_schema advertised by the current network, if any. Drives schema hints in the sly_data dialog.
+    const [slyDataSchema, setSlyDataSchema] = useState<Record<string, unknown> | undefined>(undefined)
+
     const neuroSanURL = useSettingsStore((state) => state.settings.externalServices.neuroSanUrl) ?? defaultNeuroSanUrl
 
     // Tracks how many times each agent has been involved in the conversation
@@ -390,6 +393,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                 // Reset before fetching
                 setNetworkDescription("")
                 setSupportedByokProviders(new Set())
+                setSlyDataSchema(undefined)
 
                 // Get agent function from server
                 const agentFunction = await getAgentFunction(neuroSanURL, selectedNetwork, username)
@@ -397,6 +401,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
 
                 const schema = agentFunction?.function?.sly_data_schema
                 setSupportedByokProviders(getSupportedLlmProviders(schema))
+                setSlyDataSchema(schema)
             } catch (e) {
                 console.warn(`Unable to get agent details for network ${selectedNetwork}:`, e)
             }
@@ -861,6 +866,7 @@ export const MultiAgentAccelerator: FC<MultiAgentAcceleratorProps> = ({
                 setIsAwaitingLlm={setIsAwaitingLlm}
                 selectedNetwork={selectedNetwork}
                 setSelectedNetwork={changeSelectedNetwork}
+                slyDataSchema={slyDataSchema}
             />
         </Panel>
     )

--- a/packages/ui-common/utils/SlyDataSchema.ts
+++ b/packages/ui-common/utils/SlyDataSchema.ts
@@ -1,0 +1,193 @@
+/*
+Copyright 2025 Cognizant Technology Solutions Corp, www.cognizant.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as z from "zod"
+
+import {SlyData} from "./SlyData"
+
+/**
+ * Helpers for reading an agent network's `sly_data_schema`.
+ *
+ * A network's front man may advertise the sly_data it expects via `sly_data_schema` (see the neuro-san agent hocon
+ * reference). The document is OpenAI-tool-style JSON Schema -- `type`/`properties`/`required`/`description` -- with
+ * one quirk: scalar types use neuro-san's names `"int"`, `"float"`, `"string"`, `"bool"` rather than the JSON Schema
+ * names. Everything here is defensive: the schema is server-supplied data, and a malformed one must degrade to
+ * "no schema" rather than break the sly_data editor.
+ */
+
+// How many levels of nested objects a template will materialize. Deep enough for every published schema
+// (mcp-style http_headers nest three levels), shallow enough that a pathological schema cannot recurse away.
+const MAX_TEMPLATE_DEPTH = 5
+
+// Scalar type names accepted for each kind of template value. Neuro-san's names first, but the JSON Schema
+// spellings cost nothing to accept and schema authors do write them.
+const INT_TYPES: ReadonlySet<string> = new Set(["int", "integer"])
+const FLOAT_TYPES: ReadonlySet<string> = new Set(["double", "float", "number"])
+const BOOL_TYPES: ReadonlySet<string> = new Set(["bool", "boolean"])
+
+/**
+ * One node of a sly_data_schema document. Loose on purpose: extra keys are the schema author's business.
+ * The recursion mirrors JSON Schema's -- an object node describes its keys under `properties`.
+ */
+const SchemaNode = z.looseObject({
+    description: z.string().optional(),
+    get properties() {
+        return z.record(z.string(), SchemaNode).optional()
+    },
+    required: z.array(z.string()).optional(),
+    type: z.string().optional(),
+})
+
+type SchemaNodeType = z.infer<typeof SchemaNode>
+
+/**
+ * A top-level sly_data key advertised by the network, in a shape ready for display.
+ */
+export interface SlyDataSchemaEntry {
+    /** What the key is for, verbatim from the schema */
+    readonly description?: string
+
+    /** True if the key appears in the schema's root `required` list */
+    readonly isRequired: boolean
+
+    /** The property name, verbatim. Any string is legal here -- some networks use URLs as keys. */
+    readonly key: string
+
+    /** The declared type name (neuro-san writes "int"/"float"/"string"/"bool"), or "object" when only inferable */
+    readonly type?: string
+}
+
+/**
+ * Whether a schema node describes an object. An explicit `type: "object"` counts, and so does an untyped node
+ * that declares `properties` -- schema authors routinely omit the redundant `type`.
+ */
+const isObjectNode = (node: SchemaNodeType): boolean =>
+    node.type === "object" || (node.type === undefined && node.properties !== undefined)
+
+/**
+ * Validates a server-supplied sly_data_schema and returns its root node, or null if there is nothing usable.
+ * A root is usable when it is object-shaped and declares at least one property.
+ */
+const parseSchemaRoot = (schema: unknown): SchemaNodeType | null => {
+    if (schema === undefined || schema === null) {
+        return null
+    }
+
+    const parsed = SchemaNode.safeParse(schema)
+    if (!parsed.success || !isObjectNode(parsed.data) || Object.keys(parsed.data.properties ?? {}).length === 0) {
+        // A bad schema is the network author's bug, not the user's: degrade to the schema-less experience.
+        console.warn("Ignoring unusable sly_data_schema:", schema)
+        return null
+    }
+
+    return parsed.data
+}
+
+/**
+ * Lists the top-level sly_data keys a network advertises, for display to the user.
+ * @param schema The network's sly_data_schema, as returned by the function endpoint. May be anything.
+ * @param excludeKeys Keys to leave out: the ones the UI itself supplies at send time (API keys, login...), which
+ * the user should not be prompted for.
+ * @returns One entry per declared key in declaration order, or an empty array when the schema is unusable.
+ */
+export const describeSlyDataSchema = (
+    schema: unknown,
+    excludeKeys: readonly string[] = []
+): readonly SlyDataSchemaEntry[] => {
+    const root = parseSchemaRoot(schema)
+    if (root === null) {
+        return []
+    }
+
+    const required = new Set(root.required)
+
+    return Object.entries(root.properties)
+        .filter(([key]: [string, SchemaNodeType]) => !excludeKeys.includes(key))
+        .map(([key, node]: [string, SchemaNodeType]) => ({
+            description: node.description,
+            isRequired: required.has(key),
+            key,
+            type: node.type ?? (isObjectNode(node) ? "object" : undefined),
+        }))
+}
+
+/**
+ * Produces the template value for one schema node, folding in whatever the user already has.
+ * An existing value always wins -- even one that contradicts the schema -- because a template must never
+ * destroy user input. Objects are merged recursively so a partially-filled nested value gains its missing keys.
+ */
+const templateValue = (node: SchemaNodeType, existing: unknown, depth: number): unknown => {
+    if (isObjectNode(node)) {
+        if (existing !== undefined && (existing === null || typeof existing !== "object" || Array.isArray(existing))) {
+            return existing
+        }
+
+        if (depth >= MAX_TEMPLATE_DEPTH) {
+            return existing ?? {}
+        }
+
+        const merged: SlyData = {...(existing as SlyData)}
+        Object.entries(node.properties ?? {}).forEach(([key, child]: [string, SchemaNodeType]) => {
+            merged[key] = templateValue(child, merged[key], depth + 1)
+        })
+        return merged
+    }
+
+    if (existing !== undefined) {
+        return existing
+    }
+
+    if (node.type === "string") {
+        return ""
+    }
+    if (INT_TYPES.has(node.type) || FLOAT_TYPES.has(node.type)) {
+        return 0
+    }
+    if (BOOL_TYPES.has(node.type)) {
+        return false
+    }
+
+    // A type we do not understand: null marks "fill me in" without guessing a shape
+    return null
+}
+
+/**
+ * Builds a sly_data skeleton from the network's schema, layered under the user's existing values.
+ * @param schema The network's sly_data_schema. May be anything; an unusable schema returns `existing` untouched.
+ * @param existing The current sly_data. Every existing key survives verbatim; the template only adds what is missing.
+ * @param excludeKeys Top-level keys never to seed: the ones the UI supplies at send time. Keeping these out matters
+ * for more than tidiness -- `llm_config` holds API keys, which must never be led into the persistent store.
+ * @returns A new object; the input is not mutated.
+ */
+export const buildSlyDataTemplate = (
+    schema: unknown,
+    existing: SlyData,
+    excludeKeys: readonly string[] = []
+): SlyData => {
+    const root = parseSchemaRoot(schema)
+    if (root === null) {
+        return existing
+    }
+
+    const merged: SlyData = {...existing}
+    Object.entries(root.properties)
+        .filter(([key]: [string, SchemaNodeType]) => !excludeKeys.includes(key))
+        .forEach(([key, node]: [string, SchemaNodeType]) => {
+            merged[key] = templateValue(node, merged[key], 1)
+        })
+
+    return merged
+}

--- a/packages/ui-common/utils/SlyDataSchema.ts
+++ b/packages/ui-common/utils/SlyDataSchema.ts
@@ -32,11 +32,18 @@ import {SlyData} from "./SlyData"
 // (mcp-style http_headers nest three levels), shallow enough that a pathological schema cannot recurse away.
 const MAX_TEMPLATE_DEPTH = 5
 
-// Scalar type names accepted for each kind of template value. Neuro-san's names first, but the JSON Schema
-// spellings cost nothing to accept and schema authors do write them.
-const INT_TYPES: ReadonlySet<string> = new Set(["int", "integer"])
-const FLOAT_TYPES: ReadonlySet<string> = new Set(["double", "float", "number"])
-const BOOL_TYPES: ReadonlySet<string> = new Set(["bool", "boolean"])
+// Default template value for each recognized scalar type name. Neuro-san's names are canonical, but the
+// JSON Schema spellings cost nothing to accept and schema authors do write them.
+const SCALAR_TYPE_DEFAULTS: Record<string, unknown> = {
+    bool: false,
+    boolean: false,
+    double: 0,
+    float: 0,
+    int: 0,
+    integer: 0,
+    number: 0,
+    string: "",
+}
 
 /**
  * One node of a sly_data_schema document. Loose on purpose: extra keys are the schema author's business.
@@ -158,18 +165,8 @@ const templateValue = (node: SchemaNodeType, existing: unknown, depth: number): 
         return existing
     }
 
-    if (node.type === "string") {
-        return ""
-    }
-    if (INT_TYPES.has(node.type) || FLOAT_TYPES.has(node.type)) {
-        return 0
-    }
-    if (BOOL_TYPES.has(node.type)) {
-        return false
-    }
-
-    // A type we do not understand: null marks "fill me in" without guessing a shape
-    return null
+    // A type we do not understand maps to null: "fill me in" without guessing a shape
+    return SCALAR_TYPE_DEFAULTS[node.type] ?? null
 }
 
 /**

--- a/packages/ui-common/utils/SlyDataSchema.ts
+++ b/packages/ui-common/utils/SlyDataSchema.ts
@@ -73,6 +73,8 @@ export interface SlyDataSchemaEntry {
 /**
  * Whether a schema node describes an object. An explicit `type: "object"` counts, and so does an untyped node
  * that declares `properties` -- schema authors routinely omit the redundant `type`.
+ * @param node The schema node to examine.
+ * @returns True if the node describes an object value.
  */
 const isObjectNode = (node: SchemaNodeType): boolean =>
     node.type === "object" || (node.type === undefined && node.properties !== undefined)
@@ -80,6 +82,8 @@ const isObjectNode = (node: SchemaNodeType): boolean =>
 /**
  * Validates a server-supplied sly_data_schema and returns its root node, or null if there is nothing usable.
  * A root is usable when it is object-shaped and declares at least one property.
+ * @param schema The sly_data_schema as received from the server. May be anything.
+ * @returns The validated root node, or null when the schema is absent or unusable.
  */
 const parseSchemaRoot = (schema: unknown): SchemaNodeType | null => {
     if (schema === undefined || schema === null) {
@@ -128,6 +132,10 @@ export const describeSlyDataSchema = (
  * Produces the template value for one schema node, folding in whatever the user already has.
  * An existing value always wins -- even one that contradicts the schema -- because a template must never
  * destroy user input. Objects are merged recursively so a partially-filled nested value gains its missing keys.
+ * @param node The schema node describing this value.
+ * @param existing The value currently at this position, or undefined if there is none.
+ * @param depth How many object levels deep this node is, for the recursion cap.
+ * @returns The existing value, or a default appropriate for the declared type when there is none.
  */
 const templateValue = (node: SchemaNodeType, existing: unknown, depth: number): unknown => {
     if (isObjectNode(node)) {


### PR DESCRIPTION
Addresses #513 which builds off #498 where we are grabbing the schema from the server and rendering it in the `sly-data` editor; pre-populated schema is done and an explanation of each variable as well.

Tested E2E - `scheme` is populated and updated in each request as per expected behavior of the `up_stream`


<img width="992" height="627" alt="image" src="https://github.com/user-attachments/assets/c278bf54-16b0-484d-afea-669bd86fdc34" />
