### PR TITLE
Bump build-common pins to 1.0.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,8 @@ jobs:
 
             - name: Setup Node.js and install dependencies
               id: setup-node
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/setup-node-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   clean-install: "true"
 
@@ -96,16 +96,16 @@ jobs:
               run: yarn generate
 
             - name: Authenticate to AWS and login to ECR
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/aws-ecr-auth@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/aws-ecr-auth@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   aws-account-id: ${{ vars.AWS_ACCOUNT_ID }}
                   aws-role-name: ${{ vars.AWS_ROLE_NAME }}
                   aws-region: ${{ env.AWS_REGION }}
 
             - name: Build and push Docker image to ECR
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/docker-buildx-push@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/docker-buildx-push@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   context: .
                   dockerfile: apps/main/Dockerfile

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
     checkmarx:
-        # build-common 1.0.9
-        uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # build-common 1.0.11
+        uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@a70df67b0d623e56f34159de26c38989cd315d26
         with:
             base-uri: ${{ vars.CX_BASE_URI }}
             cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,8 +77,8 @@ jobs:
 
             - name: Setup Node.js environment
               id: setup-node
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/setup-node-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   clean-install: "true"
                   registry-url: https://registry.npmjs.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
 
             - name: Setup Node.js environment
               id: setup-node
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/setup-node-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/setup-node-env@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   clean-install: "true"
 
@@ -105,8 +105,8 @@ jobs:
             - name: Lint Dockerfiles (hadolint)
               id: hadolint
               if: success() || failure()
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/run-hadolint@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/run-hadolint@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   recursive: "true"
                   failure-threshold: info


### PR DESCRIPTION
## Summary

Refreshes this repo's build-common pins from 1.0.9 (`b14b3de`) to the current 1.0.11 release (`a70df67`) so all repos share one build-common version. Between the two releases build-common only dropped the broken PyPI publish paths (a composite action wrapping a Docker action, and a reusable workflow that cannot satisfy PyPI Trusted Publishing) and added a build-only action. None of the actions used here (`setup-node-env`, `aws-ecr-auth`, `docker-buildx-push`, `run-hadolint`, `_checkmarx.yml`) changed, so there is no behavior change.


Link to Devin session: https://app.devin.ai/sessions/cf4d3ef8da8e4832adc46de3309a54d2
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-ui/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->